### PR TITLE
2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Notice
 
-Please use group id `com.github.aasmart` and version `dbce817`, this is the context-menu branch of JDA
+Please use group id `com.github.freya022` and version `7f6dadee2f`, this is the context-menu branch of JDA
 
 # BotCommands
 This framework simplifies the creation of Discord bots with the [JDA](https://github.com/DV8FromTheWorld/JDA) library.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -42,9 +42,9 @@
     </repositories>
     <dependencies>
         <dependency> <!-- The Java Discord API-->
-            <groupId>com.github.aasmart</groupId>
+            <groupId>com.github.freya022</groupId>
             <artifactId>JDA</artifactId>
-            <version>dbce817</version>
+            <version>7f6dadee2f</version>
             <exclusions>
                 <exclusion>
                     <groupId>club.minnced</groupId>
@@ -55,18 +55,18 @@
         <dependency> <!-- Needed for JDA and BotCommands logging -->
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.5</version>
+            <version>1.2.7</version>
         </dependency>
         <dependency> <!-- This library,
         I am using a local build, you can change the group id and version to use the jitpack one -->
             <groupId>com.freya02</groupId> <!-- TODO change here -->
             <artifactId>BotCommands</artifactId>
-            <version>2.0.0-SNAPSHOT</version> <!-- TODO change here -->
+            <version>2.2.0-SNAPSHOT</version> <!-- TODO change here -->
         </dependency>
         <dependency> <!-- Needed for components, otherwise optional - I use PGSQL but you can use any SQL database -->
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.23.jre7</version>
+            <version>42.3.1</version>
         </dependency>
         <dependency> <!-- Needed to pool SQL connections, optional if you don't use components -->
             <groupId>com.zaxxer</groupId>

--- a/examples/src/main/java/com/freya02/bot/paginationbot/commands/ChoiceMenuCommand.java
+++ b/examples/src/main/java/com/freya02/bot/paginationbot/commands/ChoiceMenuCommand.java
@@ -4,7 +4,7 @@ import com.freya02.botcommands.api.annotations.CommandMarker;
 import com.freya02.botcommands.api.application.ApplicationCommand;
 import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
 import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
-import com.freya02.botcommands.api.pagination.Paginator;
+import com.freya02.botcommands.api.pagination.menu.ChoiceMenu;
 import com.freya02.botcommands.api.pagination.menu.ChoiceMenuBuilder;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Guild;
@@ -18,11 +18,13 @@ public class ChoiceMenuCommand extends ApplicationCommand {
 	public void run(GuildSlashEvent event) {
 		final List<Guild> entries = new ArrayList<>(event.getJDA().getGuilds());
 
-		//Only the caller can use the choice menu
-		// There must be no delete button as the message is ephemeral
 		// The choice menu is like a menu except the user has buttons to choose an entry, 
 		//      and you can wait or use a callback to use the user choice
-		final Paginator paginator = new ChoiceMenuBuilder<>(event.getUser().getIdLong(), false, entries)
+		final ChoiceMenu<Guild> paginator = new ChoiceMenuBuilder<>(entries)
+				//Only the caller can use the choice menu
+				.setOwnerId(event.getUser().getIdLong())
+				// There must be no delete button as the message is ephemeral
+				.useDeleteButton(false)
 				//Transforms each entry (a Guild) into this text
 				.setTransformer(guild -> String.format("%s (%s)", guild.getName(), guild.getId()))
 				//Show only 1 entry per page
@@ -30,9 +32,9 @@ public class ChoiceMenuCommand extends ApplicationCommand {
 				//Set the entry (row) prefix
 				// This will then display as
 				// - GuildName (GuildId)
-				.setRowPrefix((entry, maxEntry) -> " - ")
+				.setRowPrefixSupplier((entry, maxEntry) -> " - ")
 				//This gets called when the user chooses an entry via the buttons
-				// First callback parameter is the button event and the second is the choosed entry (the Guild)
+				// First callback parameter is the button event and the second is the chosen entry (the Guild)
 				.setCallback((btnEvt, guild) -> {
 					//Edit the message with a Message so everything is replaced, instead of just the content
 					btnEvt.editMessage(new MessageBuilder("You chose the guild '" + guild.getName() + "' !").build()).queue();

--- a/examples/src/main/java/com/freya02/bot/paginationbot/commands/MenuCommand.java
+++ b/examples/src/main/java/com/freya02/bot/paginationbot/commands/MenuCommand.java
@@ -1,11 +1,11 @@
 package com.freya02.bot.paginationbot.commands;
 
 import com.freya02.botcommands.api.annotations.CommandMarker;
-import com.freya02.botcommands.api.pagination.Paginator;
-import com.freya02.botcommands.api.pagination.menu.MenuBuilder;
-import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
 import com.freya02.botcommands.api.application.ApplicationCommand;
+import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
 import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
+import com.freya02.botcommands.api.pagination.menu.Menu;
+import com.freya02.botcommands.api.pagination.menu.MenuBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 
 import java.util.ArrayList;
@@ -19,7 +19,11 @@ public class MenuCommand extends ApplicationCommand {
 
 		//Only the caller can use the menu
 		// There must be no delete button as the message is ephemeral
-		final Paginator paginator = new MenuBuilder<>(event.getUser().getIdLong(), false, entries)
+		final Menu<Guild> paginator = new MenuBuilder<>(entries)
+				//Only the caller can use the choice menu
+				.setOwnerId(event.getUser().getIdLong())
+				// There must be no delete button as the message is ephemeral
+				.useDeleteButton(false)
 				//Transforms each entry (a Guild) into this text
 				.setTransformer(guild -> String.format("%s (%s)", guild.getName(), guild.getId()))
 				//Show only 1 entry per page
@@ -27,7 +31,7 @@ public class MenuCommand extends ApplicationCommand {
 				//Set the entry (row) prefix
 				// This will then display as
 				// - GuildName (GuildId)
-				.setRowPrefix((entry, maxEntry) -> " - ")
+				.setRowPrefixSupplier((entry, maxEntry) -> " - ")
 				.build();
 
 		//You must send the menu as a message

--- a/examples/src/main/java/com/freya02/bot/paginationbot/commands/PaginatorCommand.java
+++ b/examples/src/main/java/com/freya02/bot/paginationbot/commands/PaginatorCommand.java
@@ -1,10 +1,11 @@
 package com.freya02.bot.paginationbot.commands;
 
 import com.freya02.botcommands.api.annotations.CommandMarker;
-import com.freya02.botcommands.api.pagination.Paginator;
-import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
 import com.freya02.botcommands.api.application.ApplicationCommand;
+import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
 import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
+import com.freya02.botcommands.api.pagination.paginator.Paginator;
+import com.freya02.botcommands.api.pagination.paginator.PaginatorBuilder;
 import net.dv8tion.jda.api.EmbedBuilder;
 
 import java.util.ArrayList;
@@ -20,17 +21,16 @@ public class PaginatorCommand extends ApplicationCommand {
 		for (int i = 0; i < 5; i++) {
 			embedBuilders.add(new EmbedBuilder().setTitle("Page #" + (i + 1)));
 		}
-		
-		//Only the caller can use the paginator
-		// There is 5 pages for the paginator
-		// There must be no delete button as the message is ephemeral
-		final Paginator paginator = new Paginator(event.getUser().getIdLong(), 5, false, (builder, components, page) -> {
-			//Page is from 0 included to 4 included (5 pages)
-			final EmbedBuilder embedBuilder = embedBuilders.get(page);
 
-			//set the builder to be embedBuilder
-			builder.copyFrom(embedBuilder);
-		});
+		final Paginator paginator = new PaginatorBuilder()
+				//Only the caller can use the choice menu
+				.setOwnerId(event.getUser().getIdLong())
+				// There must be no delete button as the message is ephemeral
+				.useDeleteButton(false)
+				// There is 5 pages for the paginator
+				.setMaxPages(5)
+				.setPaginatorSupplier((messageBuilder, components, page) -> embedBuilders.get(page).build())
+				.build();
 
 		//You must send the paginator as a message
 		event.reply(paginator.get())

--- a/examples/src/main/java/com/freya02/bot/wiki/condinst/CondInstMain.java
+++ b/examples/src/main/java/com/freya02/bot/wiki/condinst/CondInstMain.java
@@ -1,0 +1,23 @@
+package com.freya02.bot.wiki.condinst;
+
+import com.freya02.bot.Config;
+import com.freya02.botcommands.api.CommandsBuilder;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+
+public class CondInstMain {
+	public static void main(String[] args) {
+		try {
+			final Config config = Config.readConfig();
+
+			final JDA jda = JDABuilder.createLight(config.getToken()).build().awaitReady();
+
+			CommandsBuilder.newBuilder()
+					.build(jda, "com.freya02.bot.wiki.condinst.commands");
+		} catch (Exception e) {
+			e.printStackTrace();
+
+			System.exit(-1);
+		}
+	}
+}

--- a/examples/src/main/java/com/freya02/bot/wiki/condinst/commands/LinuxCommand.java
+++ b/examples/src/main/java/com/freya02/bot/wiki/condinst/commands/LinuxCommand.java
@@ -1,0 +1,20 @@
+package com.freya02.bot.wiki.condinst.commands;
+
+import com.freya02.botcommands.api.annotations.ConditionalUse;
+import com.freya02.botcommands.api.application.ApplicationCommand;
+import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
+import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
+
+public class LinuxCommand extends ApplicationCommand {
+	@ConditionalUse //Called when the class is about to get constructed
+	public static boolean canUse() { //Return false if it's not Linux
+		final String osName = System.getProperty("os.name").toLowerCase();
+
+		return osName.contains("linux") || osName.contains("nix"); //Not accurate but should do it, not tested
+	}
+
+	@JDASlashCommand(name = "linux")
+	public void execute(GuildSlashEvent event) {
+		event.reply("The bot runs on Linux").setEphemeral(true).queue();
+	}
+}

--- a/examples/src/main/java/com/freya02/bot/wiki/condinst/commands/WindowsCommand.java
+++ b/examples/src/main/java/com/freya02/bot/wiki/condinst/commands/WindowsCommand.java
@@ -1,0 +1,18 @@
+package com.freya02.bot.wiki.condinst.commands;
+
+import com.freya02.botcommands.api.annotations.ConditionalUse;
+import com.freya02.botcommands.api.application.ApplicationCommand;
+import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
+import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
+
+public class WindowsCommand extends ApplicationCommand {
+	@ConditionalUse //Called when the class is about to get constructed
+	public static boolean canUse() { //Return false if it's not Windows
+		return System.getProperty("os.name").toLowerCase().contains("windows");
+	}
+
+	@JDASlashCommand(name = "windows")
+	public void execute(GuildSlashEvent event) {
+		event.reply("The bot runs on Windows").setEphemeral(true).queue();
+	}
+}

--- a/examples/src/main/java/com/freya02/bot/wiki/slash/BasicSettingsProvider.java
+++ b/examples/src/main/java/com/freya02/bot/wiki/slash/BasicSettingsProvider.java
@@ -46,7 +46,7 @@ public class BasicSettingsProvider implements SettingsProvider {
 		getBlacklist(guild).remove(commandName); //Removes the command from the blacklist
 
 		try {
-			context.tryUpdateGuildCommands(Collections.singleton(guild));
+			context.scheduleApplicationCommandsUpdate(Collections.singleton(guild));
 		} catch (IOException e) { //Should not happen unless it can't write the cached commands on the disk
 			LOGGER.error("An error occurred while updating guild commands manually", e);
 		}

--- a/examples/src/main/java/com/freya02/bot/wiki/slash/commands/SlashChoices.java
+++ b/examples/src/main/java/com/freya02/bot/wiki/slash/commands/SlashChoices.java
@@ -48,7 +48,7 @@ public class SlashChoices extends ApplicationCommand {
 		valueList.add(new SlashCommand.Choice(name, value));
 
 		try {
-			event.getContext().tryUpdateGuildCommands(List.of(event.getGuild()));
+			event.getContext().scheduleApplicationCommandsUpdate(List.of(event.getGuild()));
 
 			event.getHook().sendMessage("Choice added successfully").queue();
 		} catch (IOException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,10 @@
                     <additionalJOptions>
                         <additionalJOption>-Xdoclint:-html</additionalJOption>
                     </additionalJOptions>
+                    <links>
+                        <link>https://ci.dv8tion.net/job/JDA/javadoc</link>
+                        <link>https://javadoc.io/doc/org.jetbrains/annotations/latest</link>
+                    </links>
                 </configuration>
                 <executions>
                     <execution>
@@ -159,13 +163,13 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>22.0.0</version>
-            <scope>compile</scope>
+            <version>23.0.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
-            <version>4.8.132</version>
+            <version>4.8.137</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.freya02</groupId>
     <artifactId>BotCommands</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -110,9 +110,9 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>com.github.aasmart</groupId>
+            <groupId>com.github.freya022</groupId>
             <artifactId>JDA</artifactId>
-            <version>dbce817</version>
+            <version>7f6dadee2f</version>
             <exclusions>
                 <exclusion>
                     <groupId>club.minnced</groupId>
@@ -121,6 +121,19 @@
             </exclusions>
             <scope>provided</scope>
         </dependency>
+        <!-- Local testing -->
+<!--        <dependency>-->
+<!--            <groupId>net.dv8tion</groupId>-->
+<!--            <artifactId>JDA</artifactId>-->
+<!--            <version>4.3.0_DEV</version>-->
+<!--            <exclusions>-->
+<!--                <exclusion>-->
+<!--                    <groupId>club.minnced</groupId>-->
+<!--                    <artifactId>opus-java</artifactId>-->
+<!--                </exclusion>-->
+<!--            </exclusions>-->
+<!--            <scope>provided</scope>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>com.vdurmont</groupId>
             <artifactId>emoji-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.8</version>
+            <version>2.8.9</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
@@ -165,13 +165,13 @@
         <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
-            <version>4.8.131</version>
+            <version>4.8.132</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.6</version>
+            <version>1.2.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -165,19 +165,19 @@
         <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
-            <version>4.8.114</version>
+            <version>4.8.131</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.5</version>
+            <version>1.2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.23.jre7</version>
+            <version>42.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
                     </additionalJOptions>
                     <links>
                         <link>https://ci.dv8tion.net/job/JDA/javadoc</link>
-                        <link>https://javadoc.io/doc/org.jetbrains/annotations/latest</link>
+                        <link>https://javadoc.io/doc/org.jetbrains/annotations/23.0.0</link>
                     </links>
                     <excludePackageNames>
                         com.freya02.botcommands.internal.*:com.freya02.botcommands.internal

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,9 @@
                         <link>https://ci.dv8tion.net/job/JDA/javadoc</link>
                         <link>https://javadoc.io/doc/org.jetbrains/annotations/latest</link>
                     </links>
+                    <excludePackageNames>
+                        com.freya02.botcommands.internal.*:com.freya02.botcommands.internal
+                    </excludePackageNames>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/com/freya02/botcommands/api/BContext.java
+++ b/src/main/java/com/freya02/botcommands/api/BContext.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.api;
 
 import com.freya02.botcommands.api.application.CommandPath;
+import com.freya02.botcommands.api.application.CommandUpdateResult;
 import com.freya02.botcommands.api.components.ComponentManager;
 import com.freya02.botcommands.api.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.prefixed.MessageInfo;
@@ -21,6 +22,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -272,7 +275,8 @@ public interface BContext {
 	 * @return <code>true</code> if one or more command / permission were changed, <code>false</code> if none changed
 	 * @throws IOException If unable to write the cache data
 	 */
-	boolean tryUpdateGuildCommands(Iterable<Guild> guilds) throws IOException;
+	@NotNull
+	Map<Guild, CompletableFuture<CommandUpdateResult>> scheduleApplicationCommandsUpdate(Iterable<Guild> guilds) throws IOException;
 
 	/**
 	 * Register a custom resolver for interaction commands (components / app commands)

--- a/src/main/java/com/freya02/botcommands/api/BContext.java
+++ b/src/main/java/com/freya02/botcommands/api/BContext.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Locale;
@@ -314,11 +313,11 @@ public interface BContext {
 	 * <i>This method is called by the application commands builder on startup</i>
 	 *
 	 * @param guilds Iterable collection of the guilds to update
+	 * @param force  Whether or not commands and permissions should be updated no matter what
 	 * @return <code>true</code> if one or more command / permission were changed, <code>false</code> if none changed
-	 * @throws IOException If unable to write the cache data
 	 */
 	@NotNull
-	Map<Guild, CompletableFuture<CommandUpdateResult>> scheduleApplicationCommandsUpdate(Iterable<Guild> guilds) throws IOException;
+	Map<Guild, CompletableFuture<CommandUpdateResult>> scheduleApplicationCommandsUpdate(Iterable<Guild> guilds, boolean force);
 
 	/**
 	 * Register a custom resolver for interaction commands (components / app commands)

--- a/src/main/java/com/freya02/botcommands/api/BContext.java
+++ b/src/main/java/com/freya02/botcommands/api/BContext.java
@@ -6,6 +6,8 @@ import com.freya02.botcommands.api.components.ComponentManager;
 import com.freya02.botcommands.api.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.prefixed.MessageInfo;
 import com.freya02.botcommands.internal.DefaultMessages;
+import com.freya02.botcommands.internal.application.ApplicationCommandInfoMapView;
+import com.freya02.botcommands.internal.application.CommandInfoMap;
 import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
 import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
@@ -17,6 +19,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -146,6 +149,46 @@ public interface BContext {
 	 */
 	@Nullable
 	MessageCommandInfo findMessageCommand(@NotNull String name);
+
+	/**
+	 * Returns a view for all the registered application commands
+	 * <br>This doesn't filter commands on a per-guild basis
+	 *
+	 * @return A view of all the application commands
+	 */
+	@NotNull
+	@UnmodifiableView
+	ApplicationCommandInfoMapView getApplicationCommandInfoMapView();
+
+	/**
+	 * Returns a view for all the registered slash commands
+	 * <br>This doesn't filter commands on a per-guild basis
+	 *
+	 * @return A view of all the slash commands
+	 */
+	@NotNull
+	@UnmodifiableView
+	CommandInfoMap<SlashCommandInfo> getSlashCommandsMapView();
+
+	/**
+	 * Returns a view for all the registered user context commands
+	 * <br>This doesn't filter commands on a per-guild basis
+	 *
+	 * @return A view of all the user context commands
+	 */
+	@NotNull
+	@UnmodifiableView
+	CommandInfoMap<UserCommandInfo> getUserCommandsMapView();
+
+	/**
+	 * Returns a view for all the registered message context commands
+	 * <br>This doesn't filter commands on a per-guild basis
+	 *
+	 * @return A view of all the message context commands
+	 */
+	@NotNull
+	@UnmodifiableView
+	CommandInfoMap<MessageCommandInfo> getMessageCommandsMapView();
 
 	/**
 	 * Returns a list of the application commands paths, names such as <code>ban/user/perm</code>

--- a/src/main/java/com/freya02/botcommands/api/BContext.java
+++ b/src/main/java/com/freya02/botcommands/api/BContext.java
@@ -6,7 +6,6 @@ import com.freya02.botcommands.api.application.CommandUpdateResult;
 import com.freya02.botcommands.api.components.ComponentManager;
 import com.freya02.botcommands.api.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.prefixed.MessageInfo;
-import com.freya02.botcommands.internal.DefaultMessages;
 import com.freya02.botcommands.internal.application.CommandInfoMap;
 import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
 import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;

--- a/src/main/java/com/freya02/botcommands/api/BContext.java
+++ b/src/main/java/com/freya02/botcommands/api/BContext.java
@@ -1,12 +1,12 @@
 package com.freya02.botcommands.api;
 
+import com.freya02.botcommands.api.application.ApplicationCommandInfoMapView;
 import com.freya02.botcommands.api.application.CommandPath;
 import com.freya02.botcommands.api.application.CommandUpdateResult;
 import com.freya02.botcommands.api.components.ComponentManager;
 import com.freya02.botcommands.api.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.prefixed.MessageInfo;
 import com.freya02.botcommands.internal.DefaultMessages;
-import com.freya02.botcommands.internal.application.ApplicationCommandInfoMapView;
 import com.freya02.botcommands.internal.application.CommandInfoMap;
 import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
 import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;

--- a/src/main/java/com/freya02/botcommands/api/CommandsBuilder.java
+++ b/src/main/java/com/freya02/botcommands/api/CommandsBuilder.java
@@ -11,6 +11,7 @@ import com.freya02.botcommands.api.prefixed.TextCommand;
 import com.freya02.botcommands.internal.BContextImpl;
 import com.freya02.botcommands.internal.CommandsBuilderImpl;
 import com.freya02.botcommands.internal.Logging;
+import com.freya02.botcommands.internal.utils.ReflectionUtils;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
@@ -221,7 +222,7 @@ public final class CommandsBuilder {
 	public CommandsBuilder addSearchPath(String commandPackageName) throws IOException {
 		Utils.requireNonBlank(commandPackageName, "Command package");
 
-		classes.addAll(Utils.getPackageClasses(commandPackageName, 3));
+		classes.addAll(ReflectionUtils.getPackageClasses(commandPackageName, 3));
 
 		return this;
 	}

--- a/src/main/java/com/freya02/botcommands/api/CommandsBuilder.java
+++ b/src/main/java/com/freya02/botcommands/api/CommandsBuilder.java
@@ -2,6 +2,7 @@ package com.freya02.botcommands.api;
 
 import com.freya02.botcommands.api.annotations.RequireOwner;
 import com.freya02.botcommands.api.application.ApplicationCommand;
+import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionTransformer;
 import com.freya02.botcommands.api.builder.ExtensionsBuilder;
 import com.freya02.botcommands.api.builder.TextCommandsBuilder;
 import com.freya02.botcommands.api.components.ComponentManager;
@@ -26,6 +27,8 @@ import java.io.InputStream;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import static net.dv8tion.jda.api.interactions.commands.SlashCommand.Choice;
 
 public final class CommandsBuilder {
 	private static final Logger LOGGER = Logging.getLogger();
@@ -129,6 +132,21 @@ public final class CommandsBuilder {
 	public CommandsBuilder updateCommandsOnGuildIds(List<Long> slashGuildIds) {
 		this.slashGuildIds.clear();
 		this.slashGuildIds.addAll(slashGuildIds);
+
+		return this;
+	}
+
+	/**
+	 * Registers an autocompletion transformer
+	 * <br>If your autocompletion handler return a {@code List<YourObject>}, you will have to register an {@code AutocompletionTransformer<YourObject>}
+	 *
+	 * @param type                      Type of the List generic element type
+	 * @param autocompletionTransformer The transformer which transforms a {@link List} element into a {@link Choice choice}
+	 * @param <T>                       Type of the List generic element type
+	 * @return This builder for chaining convenience
+	 */
+	public <T> CommandsBuilder registerAutocompletionTransformer(Class<T> type, AutocompletionTransformer<T> autocompletionTransformer) {
+		context.registerAutocompletionTransformer(type, autocompletionTransformer);
 
 		return this;
 	}

--- a/src/main/java/com/freya02/botcommands/api/CommandsBuilder.java
+++ b/src/main/java/com/freya02/botcommands/api/CommandsBuilder.java
@@ -10,7 +10,6 @@ import com.freya02.botcommands.api.components.DefaultComponentManager;
 import com.freya02.botcommands.api.prefixed.TextCommand;
 import com.freya02.botcommands.internal.BContextImpl;
 import com.freya02.botcommands.internal.CommandsBuilderImpl;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.utils.ReflectionUtils;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;

--- a/src/main/java/com/freya02/botcommands/api/CommandsBuilder.java
+++ b/src/main/java/com/freya02/botcommands/api/CommandsBuilder.java
@@ -263,7 +263,7 @@ public final class CommandsBuilder {
 	public void build(JDA jda, @NotNull String commandPackageName) throws IOException {
 		addSearchPath(commandPackageName);
 
-		new CommandsBuilderImpl(context, slashGuildIds, classes).build(jda);
+		build(jda);
 	}
 
 	/**
@@ -273,7 +273,17 @@ public final class CommandsBuilder {
 	 */
 	@Blocking
 	public void build(JDA jda) throws IOException {
-		new CommandsBuilderImpl(context, slashGuildIds, classes).build(jda);
+		try {
+			new CommandsBuilderImpl(context, slashGuildIds, classes).build(jda);
+		} catch (RuntimeException e) {
+			LOGGER.error("An error occurred while creating the framework, aborted");
+
+			throw e;
+		} catch (Throwable e) {
+			LOGGER.error("An error occurred while creating the framework, aborted");
+
+			throw new RuntimeException(e);
+		}
 	}
 
 	public BContext getContext() {

--- a/src/main/java/com/freya02/botcommands/api/DefaultMessages.java
+++ b/src/main/java/com/freya02/botcommands/api/DefaultMessages.java
@@ -1,11 +1,11 @@
-package com.freya02.botcommands.internal;
+package com.freya02.botcommands.api;
 
-import com.freya02.botcommands.api.SettingsProvider;
 import com.freya02.botcommands.api.annotations.NSFW;
 import com.freya02.botcommands.internal.utils.BResourceBundle;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -93,6 +93,10 @@ public final class DefaultMessages {
 	private final String nsfwOnlyErrorMsg;
 	private final String nsfwDMDeniedErrorMsg;
 
+	/**
+	 * <b>THIS IS NOT A PUBLIC CONSTRUCTOR</b>
+	 */
+	@ApiStatus.Internal
 	public DefaultMessages(@NotNull Locale locale) {
 		final BResourceBundle bundle = BResourceBundle.getBundle("DefaultMessages", locale);
 

--- a/src/main/java/com/freya02/botcommands/api/Logging.java
+++ b/src/main/java/com/freya02/botcommands/api/Logging.java
@@ -3,13 +3,28 @@ package com.freya02.botcommands.api;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import org.slf4j.Logger;
 
+/**
+ * Static methods which returns a {@link Logger} for the current class (the class which calls these methods)
+ * <br>The logger is implemented by the implementation you provide, such as logback-classic, or fallback to the default JDA logger
+ */
 public class Logging {
 	private static final StackWalker WALKER = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
 
+	/**
+	 * Returns the {@link Logger} for the class which calls this method
+	 *
+	 * @return The {@link Logger} for the class which calls this method
+	 */
 	public static Logger getLogger() {
 		return JDALogger.getLog(WALKER.getCallerClass());
 	}
 
+	/**
+	 * Returns the {@link Logger} for the class of this object
+	 * <br>This might be useful to get a logger which targets an implementation class instead of a superclass
+	 *
+	 * @return The {@link Logger} for the class of this object
+	 */
 	public static Logger getLogger(Object obj) {
 		return JDALogger.getLog(obj.getClass());
 	}

--- a/src/main/java/com/freya02/botcommands/api/Logging.java
+++ b/src/main/java/com/freya02/botcommands/api/Logging.java
@@ -1,4 +1,4 @@
-package com.freya02.botcommands.internal;
+package com.freya02.botcommands.api;
 
 import net.dv8tion.jda.internal.utils.JDALogger;
 import org.slf4j.Logger;

--- a/src/main/java/com/freya02/botcommands/api/SettingsProvider.java
+++ b/src/main/java/com/freya02/botcommands/api/SettingsProvider.java
@@ -1,7 +1,6 @@
 package com.freya02.botcommands.api;
 
 import com.freya02.botcommands.api.application.GuildApplicationSettings;
-import com.freya02.botcommands.internal.DefaultMessages;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/freya02/botcommands/api/application/ApplicationCommandInfoMapView.java
+++ b/src/main/java/com/freya02/botcommands/api/application/ApplicationCommandInfoMapView.java
@@ -1,8 +1,9 @@
-package com.freya02.botcommands.internal.application;
+package com.freya02.botcommands.api.application;
 
 import com.freya02.botcommands.api.BContext;
 import com.freya02.botcommands.api.SettingsProvider;
-import com.freya02.botcommands.api.application.CommandPath;
+import com.freya02.botcommands.internal.application.ApplicationCommandInfo;
+import com.freya02.botcommands.internal.application.CommandInfoMap;
 import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
 import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;

--- a/src/main/java/com/freya02/botcommands/api/application/CommandPath.java
+++ b/src/main/java/com/freya02/botcommands/api/application/CommandPath.java
@@ -41,25 +41,79 @@ public interface CommandPath {
 		}
 	}
 
+	/**
+	 * Returns the top level name of this command path
+	 * <br>For a slash command such as "<code>/show me something</code>", this would be "<code>show</code>"
+	 *
+	 * @return Top level name of this command path
+	 */
 	@NotNull
 	String getName();
 
+	/**
+	 * Returns the subcommand group name of this command path
+	 * <br>For a slash command such as "<code>/show me something</code>", this would be "<code>me</code>"
+	 *
+	 * @return Subcommand group name of this command path
+	 */
 	@Nullable
 	String getGroup();
 
+	/**
+	 * Returns the subcommand name of this command path
+	 * <br>For a slash command such as "<code>/show me something</code>", this would be "<code>something</code>"
+	 * <br>For a slash command such as "<code>/tag info</code>", this would be "<code>info</code>"
+	 *
+	 * @return Subcommand name of this command path
+	 */
 	@Nullable
 	String getSubname();
 
+	/**
+	 * Returns the number of path components of this command path
+	 * <br>For a slash command such as "<code>/show me something</code>", this would be <code>3</code>
+	 * <br>For a slash command such as "<code>/tag info</code>", this would be <code>2</code>
+	 * <br>For a slash command such as "<code>/say</code>", this would be <code>1</code>
+	 *
+	 * @return The number of path components of this command path
+	 */
 	int getNameCount();
-	
+
+	/**
+	 * Returns the parent path of this command path
+	 * <br>For a slash command such as "<code>/show me something</code>", this would be "<code>/show me</code>"
+	 * <br>For a slash command such as "<code>/tag info</code>", this would be "<code>/tag</code>"
+	 * <br>For a slash command such as "<code>/say</code>", this would be <code>null</code>
+	 *
+	 * @return The parent path of this command path
+	 */
 	@Nullable
 	CommandPath getParent();
-	
+
+	/**
+	 * Returns the full <i>encoded</i> path of this command path
+	 * <br>Each path component is joined with a <code>/</code> delimiter
+	 * <br>For a slash command such as "<code>/show me something</code>", this would be "<code>show/me/something</code>"
+	 *
+	 * @return The full encoded path of this command path
+	 */
 	String getFullPath();
 
+	/**
+	 * Returns the right-most name of this command path
+	 * <br>For a slash command such as "<code>/show me something</code>", this would be "<code>something</code>"
+	 *
+	 * @return The right-most name of this command path
+	 */
 	@NotNull
 	String getLastName();
 
+	/**
+	 * Return the name at the <code>i</code> index
+	 *
+	 * @param i The index of the name to get
+	 * @return The name at the specified index
+	 */
 	@Nullable
 	String getNameAt(int i);
 
@@ -70,5 +124,12 @@ public interface CommandPath {
 	 */
 	String toString();
 
+	/**
+	 * Returns whether this command path starts with the supplied command path
+	 * <br>For example "<code>/show me something</code>" starts with "<code>/show me</code>"
+	 *
+	 * @param o The other path to test against
+	 * @return <code>true</code> if this path starts with the other, <code>false</code> otherwise
+	 */
 	boolean startsWith(CommandPath o);
 }

--- a/src/main/java/com/freya02/botcommands/api/application/CommandUpdateResult.java
+++ b/src/main/java/com/freya02/botcommands/api/application/CommandUpdateResult.java
@@ -1,0 +1,5 @@
+package com.freya02.botcommands.api.application;
+
+import net.dv8tion.jda.api.entities.Guild;
+
+public record CommandUpdateResult(Guild guild, boolean updatedCommands, boolean updatedPrivileges) {}

--- a/src/main/java/com/freya02/botcommands/api/application/annotations/AppOption.java
+++ b/src/main/java/com/freya02/botcommands/api/application/annotations/AppOption.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.api.application.annotations;
 
 import com.freya02.botcommands.api.annotations.Optional;
+import com.freya02.botcommands.api.application.slash.annotations.AutocompletionHandler;
 import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
@@ -17,8 +18,8 @@ import java.lang.annotation.Target;
  * <p>
  * {@linkplain #name()} is optional if the parameter name is available (add -parameters to your java compiler)
  *
- * @see Optional Optional (can also see @Nullable)
- * @see Nullable
+ * @see Optional @Optional
+ * @see Nullable @Nullable (same as @Optional but better)
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PARAMETER})
@@ -42,4 +43,9 @@ public @interface AppOption {
 	 * @return Description of the option
 	 */
 	String description() default "";
+
+	/**
+	 * Name of the autocompletion handler, must match a method annotated with {@link AutocompletionHandler} with the same name in it
+	 */
+	String autocomplete() default "";
 }

--- a/src/main/java/com/freya02/botcommands/api/application/annotations/AppOption.java
+++ b/src/main/java/com/freya02/botcommands/api/application/annotations/AppOption.java
@@ -1,8 +1,7 @@
 package com.freya02.botcommands.api.application.annotations;
 
 import com.freya02.botcommands.api.annotations.Optional;
-import com.freya02.botcommands.api.application.slash.annotations.AutocompletionHandler;
-import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
+import com.freya02.botcommands.api.application.slash.annotations.*;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.jetbrains.annotations.Nullable;
@@ -20,6 +19,9 @@ import java.lang.annotation.Target;
  *
  * @see Optional @Optional
  * @see Nullable @Nullable (same as @Optional but better)
+ * @see LongRange @LongRange
+ * @see DoubleRange @DoubleRange
+ * @see ChannelTypes @ChannelTypes
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PARAMETER})

--- a/src/main/java/com/freya02/botcommands/api/application/slash/annotations/AutocompletionHandler.java
+++ b/src/main/java/com/freya02/botcommands/api/application/slash/annotations/AutocompletionHandler.java
@@ -1,0 +1,50 @@
+package com.freya02.botcommands.api.application.slash.annotations;
+
+import com.freya02.botcommands.api.CommandsBuilder;
+import com.freya02.botcommands.api.application.annotations.AppOption;
+import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionMode;
+import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionTransformer;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+/**
+ * Annotation to mark methods as being autocompletion functions for {@link AppOption slash command options}
+ *
+ * <br>
+ * <br>The annotated method returns a {@link List} of things
+ * <br>These things can be, and are mapped as follows:
+ * <ul>
+ *     <li>String, Long, Double -> Choice(String, String), uses fuzzy matching to give the best choices first</li>
+ *     <li>Choice -> keep the same choice, same order as provided</li>
+ *     <li>Object -> Transformer -> Choice, same order as provided</li>
+ * </ul>
+ * <p>
+ * You can add more parameters with {@link CommandsBuilder#registerAutocompletionTransformer(Class, AutocompletionTransformer)}
+ *
+ * @see AppOption
+ * @see JDASlashCommand
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface AutocompletionHandler {
+	/**
+	 * Sets the name of the autocompletion handler, <b>it must be the same as what you set in {@link AppOption#autocomplete()}</b>
+	 * <br>The name must be unique, another handler cannot share it
+	 *
+	 * @return Name of the autocompletion handler
+	 */
+	String name();
+
+	/**
+	 * Sets the {@link AutocompletionMode autocompletion mode}
+	 * <br><b>This is only usable on collection return types of String, Double and Long</b>
+	 *
+	 * @return Mode of the autocompletion
+	 * @see AutocompletionMode
+	 */
+	AutocompletionMode mode() default AutocompletionMode.FUZZY;
+}

--- a/src/main/java/com/freya02/botcommands/api/application/slash/annotations/AutocompletionHandler.java
+++ b/src/main/java/com/freya02/botcommands/api/application/slash/annotations/AutocompletionHandler.java
@@ -4,6 +4,7 @@ import com.freya02.botcommands.api.CommandsBuilder;
 import com.freya02.botcommands.api.application.annotations.AppOption;
 import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionMode;
 import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionTransformer;
+import net.dv8tion.jda.api.events.interaction.CommandAutoCompleteEvent;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -14,8 +15,14 @@ import java.util.List;
 /**
  * Annotation to mark methods as being autocompletion functions for {@link AppOption slash command options}
  *
- * <br>
- * <br>The annotated method returns a {@link List} of things
+ * <br>Requirements:
+ * <ul>
+ *     <li>The method must be public</li>
+ *     <li>The method must be non-static</li>
+ *     <li>The first parameter must be {@link CommandAutoCompleteEvent}</li>
+ * </ul>
+ *
+ * The annotated method returns a {@link List} of things
  * <br>These things can be, and are mapped as follows:
  * <ul>
  *     <li>String, Long, Double -> Choice(String, String), uses fuzzy matching to give the best choices first</li>

--- a/src/main/java/com/freya02/botcommands/api/application/slash/annotations/AutocompletionHandler.java
+++ b/src/main/java/com/freya02/botcommands/api/application/slash/annotations/AutocompletionHandler.java
@@ -22,8 +22,30 @@ import java.util.List;
  *     <li>Choice -> keep the same choice, same order as provided</li>
  *     <li>Object -> Transformer -> Choice, same order as provided</li>
  * </ul>
+ * <b>Note that the first choice is always what the user typed</b>
+ *
  * <p>
- * You can add more parameters with {@link CommandsBuilder#registerAutocompletionTransformer(Class, AutocompletionTransformer)}
+ *
+ * You can add more List element types with {@link CommandsBuilder#registerAutocompletionTransformer(Class, AutocompletionTransformer)}
+ *
+ * <p>
+ *
+ * <h2>State aware autocompletion</h2>
+ * You can also use "state aware autocompletion", this means you can retrieve parameters the user has already entered and use it to make your autocompletion better
+ *
+ * <br>The requirements are as follows:
+ * <ul>
+ *     <li>The parameters must be annotated with {@link AppOption} if they are on the original slash commands too</li>
+ *     <li>The parameters must be named the same as in the original slash command</li>
+ *     <li>The parameters of the same name must have the same type as the original slash command</li>
+ * </ul>
+ *
+ * However:
+ * <ul>
+ *     <li>The parameters can be in any order</li>
+ *     <li>You are free to put as many or less parameters as the original slash commands</li>
+ *     <li>You can also use custom parameters, like getting a JDA instance, these do not have to be on the original slash commands</li>
+ * </ul>
  *
  * @see AppOption
  * @see JDASlashCommand

--- a/src/main/java/com/freya02/botcommands/api/application/slash/annotations/ChannelTypes.java
+++ b/src/main/java/com/freya02/botcommands/api/application/slash/annotations/ChannelTypes.java
@@ -1,0 +1,19 @@
+package com.freya02.botcommands.api.application.slash.annotations;
+
+
+import com.freya02.botcommands.api.application.annotations.AppOption;
+import net.dv8tion.jda.api.entities.ChannelType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Allows you to set the desired channel types for this {@link AppOption app option}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface ChannelTypes {
+	ChannelType[] value();
+}

--- a/src/main/java/com/freya02/botcommands/api/application/slash/annotations/DoubleRange.java
+++ b/src/main/java/com/freya02/botcommands/api/application/slash/annotations/DoubleRange.java
@@ -1,0 +1,25 @@
+package com.freya02.botcommands.api.application.slash.annotations;
+
+import com.freya02.botcommands.api.application.annotations.AppOption;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Allows setting minimum and maximum values on the specified {@link AppOption}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface DoubleRange {
+	/**
+	 * @return The minimum value of this parameter
+	 */
+	double from();
+
+	/**
+	 * @return The maximum value of this parameter
+	 */
+	double to();
+}

--- a/src/main/java/com/freya02/botcommands/api/application/slash/annotations/LongRange.java
+++ b/src/main/java/com/freya02/botcommands/api/application/slash/annotations/LongRange.java
@@ -1,0 +1,25 @@
+package com.freya02.botcommands.api.application.slash.annotations;
+
+import com.freya02.botcommands.api.application.annotations.AppOption;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Allows setting minimum and maximum values on the specified {@link AppOption}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface LongRange {
+	/**
+	 * @return The minimum value of this parameter
+	 */
+	double from();
+
+	/**
+	 * @return The maximum value of this parameter
+	 */
+	double to();
+}

--- a/src/main/java/com/freya02/botcommands/api/application/slash/autocomplete/AutocompletionMode.java
+++ b/src/main/java/com/freya02/botcommands/api/application/slash/autocomplete/AutocompletionMode.java
@@ -1,0 +1,22 @@
+package com.freya02.botcommands.api.application.slash.autocomplete;
+
+import me.xdrop.fuzzywuzzy.Applicable;
+import me.xdrop.fuzzywuzzy.FuzzySearch;
+
+import java.util.Collection;
+
+public enum AutocompletionMode {
+	/**
+	 * Sorts the strings by fuzzy search score
+	 * <br>This shows the most relevant results most of the time, regardless of if the user did a few mistakes when typing
+	 *
+	 * @see FuzzySearch#extractTop(String, Collection, Applicable, int)
+	 */
+	FUZZY,
+
+	/**
+	 * Sorts the strings by the smallest string that also starts with the user query
+	 * <br>Might be useful for when exact names are needed
+	 */
+	CONTINUITY
+}

--- a/src/main/java/com/freya02/botcommands/api/application/slash/autocomplete/AutocompletionTransformer.java
+++ b/src/main/java/com/freya02/botcommands/api/application/slash/autocomplete/AutocompletionTransformer.java
@@ -1,0 +1,7 @@
+package com.freya02.botcommands.api.application.slash.autocomplete;
+
+import net.dv8tion.jda.api.interactions.commands.SlashCommand;
+
+public interface AutocompletionTransformer<E> {
+	SlashCommand.Choice apply(E e);
+}

--- a/src/main/java/com/freya02/botcommands/api/components/ButtonConsumer.java
+++ b/src/main/java/com/freya02/botcommands/api/components/ButtonConsumer.java
@@ -1,0 +1,9 @@
+package com.freya02.botcommands.api.components;
+
+import com.freya02.botcommands.api.components.event.ButtonEvent;
+import org.jetbrains.annotations.NotNull;
+
+@FunctionalInterface
+public interface ButtonConsumer extends ComponentConsumer<ButtonEvent> {
+	void accept(@NotNull ButtonEvent btnEvt) throws Exception;
+}

--- a/src/main/java/com/freya02/botcommands/api/components/ComponentConsumer.java
+++ b/src/main/java/com/freya02/botcommands/api/components/ComponentConsumer.java
@@ -1,0 +1,8 @@
+package com.freya02.botcommands.api.components;
+
+import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
+import org.jetbrains.annotations.NotNull;
+
+public interface ComponentConsumer<T extends GenericComponentInteractionCreateEvent> {
+	void accept(@NotNull T t) throws Exception;
+}

--- a/src/main/java/com/freya02/botcommands/api/components/ComponentListener.java
+++ b/src/main/java/com/freya02/botcommands/api/components/ComponentListener.java
@@ -1,11 +1,11 @@
 package com.freya02.botcommands.api.components;
 
 import com.freya02.botcommands.api.ExceptionHandler;
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.components.event.ButtonEvent;
 import com.freya02.botcommands.api.components.event.SelectionEvent;
 import com.freya02.botcommands.api.parameters.ComponentParameterResolver;
 import com.freya02.botcommands.internal.BContextImpl;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.RunnableEx;
 import com.freya02.botcommands.internal.application.CommandParameter;
 import com.freya02.botcommands.internal.components.ComponentDescriptor;

--- a/src/main/java/com/freya02/botcommands/api/components/Components.java
+++ b/src/main/java/com/freya02/botcommands/api/components/Components.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.api.components;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.components.annotations.JDAButtonListener;
 import com.freya02.botcommands.api.components.annotations.JDASelectionMenuListener;
 import com.freya02.botcommands.api.components.builder.LambdaButtonBuilder;
@@ -9,7 +10,6 @@ import com.freya02.botcommands.api.components.builder.PersistentButtonBuilder;
 import com.freya02.botcommands.api.components.builder.PersistentSelectionMenuBuilder;
 import com.freya02.botcommands.api.components.event.ButtonEvent;
 import com.freya02.botcommands.api.components.event.SelectionEvent;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.interactions.components.ActionRow;

--- a/src/main/java/com/freya02/botcommands/api/components/Components.java
+++ b/src/main/java/com/freya02/botcommands/api/components/Components.java
@@ -54,7 +54,7 @@ import java.util.stream.Collectors;
  * </code></pre>
  */
 public class Components {
-	private static final List<Class<? extends ISnowflake>> RESTRICTED_CLASSES = List.of(Role.class, AbstractChannel.class, Guild.class, Emote.class, User.class, Message.class);
+	private static final List<Class<? extends ISnowflake>> RESTRICTED_CLASSES = List.of(Role.class, Channel.class, Guild.class, Emote.class, User.class, Message.class);
 	private static final Logger LOGGER = Logging.getLogger();
 
 	private static BContext context;

--- a/src/main/java/com/freya02/botcommands/api/components/Components.java
+++ b/src/main/java/com/freya02/botcommands/api/components/Components.java
@@ -71,7 +71,7 @@ public class Components {
 	 * @return The exact same components for chaining purposes
 	 */
 	@NotNull
-	public static Component[] group(@NotNull Component... components) {
+	public static Component[] group(@NotNull Component @NotNull... components) {
 		Utils.getComponentManager(context).registerGroup(
 				Arrays.stream(components)
 						.map(Component::getId)
@@ -107,7 +107,7 @@ public class Components {
 	 * @return The exact same components for chaining purposes
 	 */
 	@NotNull
-	public static ActionRow[] groupRows(@NotNull ActionRow... rows) {
+	public static ActionRow[] groupRows(@NotNull ActionRow @NotNull... rows) {
 		Utils.getComponentManager(context).registerGroup(
 				Arrays.stream(rows)
 						.flatMap(row -> row.getComponents().stream())
@@ -247,7 +247,7 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_, _ -> new")
-	public static PersistentButtonBuilder primaryButton(@NotNull String handlerName, Object... args) {
+	public static PersistentButtonBuilder primaryButton(@NotNull String handlerName,  @NotNull Object @NotNull... args) {
 		return new PersistentButtonBuilder(context, handlerName, processArgs(args), ButtonStyle.PRIMARY);
 	}
 
@@ -261,7 +261,7 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_, _ -> new")
-	public static PersistentButtonBuilder secondaryButton(@NotNull String handlerName, Object... args) {
+	public static PersistentButtonBuilder secondaryButton(@NotNull String handlerName, @NotNull Object @NotNull... args) {
 		return new PersistentButtonBuilder(context, handlerName, processArgs(args), ButtonStyle.SECONDARY);
 	}
 
@@ -275,7 +275,7 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_, _ -> new")
-	public static PersistentButtonBuilder dangerButton(@NotNull String handlerName, Object... args) {
+	public static PersistentButtonBuilder dangerButton(@NotNull String handlerName, @NotNull Object @NotNull... args) {
 		return new PersistentButtonBuilder(context, handlerName, processArgs(args), ButtonStyle.DANGER);
 	}
 
@@ -289,7 +289,7 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_, _ -> new")
-	public static PersistentButtonBuilder successButton(@NotNull String handlerName, Object... args) {
+	public static PersistentButtonBuilder successButton(@NotNull String handlerName, @NotNull Object @NotNull... args) {
 		return new PersistentButtonBuilder(context, handlerName, processArgs(args), ButtonStyle.SUCCESS);
 	}
 
@@ -303,7 +303,7 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_, _, _ -> new")
-	public static PersistentButtonBuilder button(@NotNull ButtonStyle style, @NotNull String handlerName, Object... args) {
+	public static PersistentButtonBuilder button(@NotNull ButtonStyle style, @NotNull String handlerName, @NotNull Object @NotNull... args) {
 		return new PersistentButtonBuilder(context, handlerName, processArgs(args), style);
 	}
 
@@ -332,7 +332,7 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_, _ -> new")
-	public static PersistentSelectionMenuBuilder selectionMenu(@NotNull String handlerName, Object... args) {
+	public static PersistentSelectionMenuBuilder selectionMenu(@NotNull String handlerName, @NotNull Object @NotNull... args) {
 		return new PersistentSelectionMenuBuilder(context, handlerName, processArgs(args));
 	}
 }

--- a/src/main/java/com/freya02/botcommands/api/components/Components.java
+++ b/src/main/java/com/freya02/botcommands/api/components/Components.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -144,7 +143,7 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_ -> new")
-	public static LambdaButtonBuilder primaryButton(@NotNull Consumer<ButtonEvent> consumer) {
+	public static LambdaButtonBuilder primaryButton(@NotNull ButtonConsumer consumer) {
 		checkCapturedVars(consumer);
 
 		return new LambdaButtonBuilder(context, consumer, ButtonStyle.PRIMARY);
@@ -159,7 +158,7 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_ -> new")
-	public static LambdaButtonBuilder secondaryButton(@NotNull Consumer<ButtonEvent> consumer) {
+	public static LambdaButtonBuilder secondaryButton(@NotNull ButtonConsumer consumer) {
 		checkCapturedVars(consumer);
 
 		return new LambdaButtonBuilder(context, consumer, ButtonStyle.SECONDARY);
@@ -174,7 +173,7 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_ -> new")
-	public static LambdaButtonBuilder dangerButton(@NotNull Consumer<ButtonEvent> consumer) {
+	public static LambdaButtonBuilder dangerButton(@NotNull ButtonConsumer consumer) {
 		checkCapturedVars(consumer);
 
 		return new LambdaButtonBuilder(context, consumer, ButtonStyle.DANGER);
@@ -189,7 +188,7 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_ -> new")
-	public static LambdaButtonBuilder successButton(@NotNull Consumer<ButtonEvent> consumer) {
+	public static LambdaButtonBuilder successButton(@NotNull ButtonConsumer consumer) {
 		checkCapturedVars(consumer);
 
 		return new LambdaButtonBuilder(context, consumer, ButtonStyle.SUCCESS);
@@ -204,13 +203,13 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_, _ -> new")
-	public static LambdaButtonBuilder button(@NotNull ButtonStyle style, @NotNull Consumer<ButtonEvent> consumer) {
+	public static LambdaButtonBuilder button(@NotNull ButtonStyle style, @NotNull ButtonConsumer consumer) {
 		checkCapturedVars(consumer);
 
 		return new LambdaButtonBuilder(context, consumer, style);
 	}
 
-	private static void checkCapturedVars(Consumer<?> consumer) {
+	private static void checkCapturedVars(Object consumer) {
 		for (Field field : consumer.getClass().getDeclaredFields()) {
 			for (Class<?> aClass : RESTRICTED_CLASSES) {
 				if (aClass.isAssignableFrom(field.getType())) {
@@ -316,7 +315,7 @@ public class Components {
 	 */
 	@NotNull
 	@Contract("_ -> new")
-	public static LambdaSelectionMenuBuilder selectionMenu(@NotNull Consumer<SelectionEvent> consumer) {
+	public static LambdaSelectionMenuBuilder selectionMenu(@NotNull SelectionConsumer consumer) {
 		checkCapturedVars(consumer);
 
 		return new LambdaSelectionMenuBuilder(context, consumer);

--- a/src/main/java/com/freya02/botcommands/api/components/DefaultComponentManager.java
+++ b/src/main/java/com/freya02/botcommands/api/components/DefaultComponentManager.java
@@ -1,9 +1,9 @@
 package com.freya02.botcommands.api.components;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.components.builder.*;
 import com.freya02.botcommands.api.components.event.ButtonEvent;
 import com.freya02.botcommands.api.components.event.SelectionEvent;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.components.HandleComponentResult;
 import com.freya02.botcommands.internal.components.data.LambdaButtonData;
 import com.freya02.botcommands.internal.components.data.LambdaSelectionMenuData;

--- a/src/main/java/com/freya02/botcommands/api/components/SelectionConsumer.java
+++ b/src/main/java/com/freya02/botcommands/api/components/SelectionConsumer.java
@@ -1,0 +1,9 @@
+package com.freya02.botcommands.api.components;
+
+import com.freya02.botcommands.api.components.event.SelectionEvent;
+import org.jetbrains.annotations.NotNull;
+
+@FunctionalInterface
+public interface SelectionConsumer extends ComponentConsumer<SelectionEvent> {
+	void accept(@NotNull SelectionEvent selectEvt) throws Exception;
+}

--- a/src/main/java/com/freya02/botcommands/api/components/builder/LambdaButtonBuilder.java
+++ b/src/main/java/com/freya02/botcommands/api/components/builder/LambdaButtonBuilder.java
@@ -32,13 +32,21 @@ public class LambdaButtonBuilder extends AbstractLambdaComponentBuilder<LambdaBu
 	}
 
 	public Button build(Emoji emoji) {
-		return new ButtonImpl(buildId(), "", buttonStyle, false, null).withEmoji(emoji);
+		return new ButtonImpl(buildId(), "", buttonStyle, false, emoji);
 	}
 
 	public Button build(ButtonContent content) {
-		return content.str() != null
-				? build(content.str())
-				: build(content.emoji());
+		//Build either a button with a label, an emoji, or both
+
+		if (content.str() != null) {
+			if (content.emoji() != null) { //both
+				return new ButtonImpl(buildId(), "", buttonStyle, false, content.emoji()).withLabel(content.str());
+			} else { //label
+				return new ButtonImpl(buildId(), "", buttonStyle, false, null).withLabel(content.str());
+			}
+		} else { //emoji
+			return new ButtonImpl(buildId(), "", buttonStyle, false, content.emoji());
+		}
 	}
 
 	public String buildId() {

--- a/src/main/java/com/freya02/botcommands/api/components/builder/LambdaButtonBuilder.java
+++ b/src/main/java/com/freya02/botcommands/api/components/builder/LambdaButtonBuilder.java
@@ -1,8 +1,8 @@
 package com.freya02.botcommands.api.components.builder;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.components.ButtonConsumer;
 import com.freya02.botcommands.api.components.ComponentManager;
-import com.freya02.botcommands.api.components.event.ButtonEvent;
 import com.freya02.botcommands.api.utils.ButtonContent;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.entities.Emoji;
@@ -10,20 +10,18 @@ import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.interactions.components.ButtonStyle;
 import net.dv8tion.jda.internal.interactions.ButtonImpl;
 
-import java.util.function.Consumer;
-
 public class LambdaButtonBuilder extends AbstractLambdaComponentBuilder<LambdaButtonBuilder> {
 	private final BContext context;
-	private final Consumer<ButtonEvent> consumer;
+	private final ButtonConsumer consumer;
 	private final ButtonStyle buttonStyle;
 
-	public LambdaButtonBuilder(BContext context, Consumer<ButtonEvent> consumer, ButtonStyle buttonStyle) {
+	public LambdaButtonBuilder(BContext context, ButtonConsumer consumer, ButtonStyle buttonStyle) {
 		this.context = context;
 		this.consumer = consumer;
 		this.buttonStyle = buttonStyle;
 	}
 
-	public Consumer<ButtonEvent> getConsumer() {
+	public ButtonConsumer getConsumer() {
 		return consumer;
 	}
 

--- a/src/main/java/com/freya02/botcommands/api/components/builder/LambdaButtonBuilder.java
+++ b/src/main/java/com/freya02/botcommands/api/components/builder/LambdaButtonBuilder.java
@@ -38,11 +38,11 @@ public class LambdaButtonBuilder extends AbstractLambdaComponentBuilder<LambdaBu
 	public Button build(ButtonContent content) {
 		//Build either a button with a label, an emoji, or both
 
-		if (content.str() != null) {
+		if (content.text() != null) {
 			if (content.emoji() != null) { //both
-				return new ButtonImpl(buildId(), "", buttonStyle, false, content.emoji()).withLabel(content.str());
+				return new ButtonImpl(buildId(), "", buttonStyle, false, content.emoji()).withLabel(content.text());
 			} else { //label
-				return new ButtonImpl(buildId(), "", buttonStyle, false, null).withLabel(content.str());
+				return new ButtonImpl(buildId(), "", buttonStyle, false, null).withLabel(content.text());
 			}
 		} else { //emoji
 			return new ButtonImpl(buildId(), "", buttonStyle, false, content.emoji());

--- a/src/main/java/com/freya02/botcommands/api/components/builder/LambdaSelectionMenuBuilder.java
+++ b/src/main/java/com/freya02/botcommands/api/components/builder/LambdaSelectionMenuBuilder.java
@@ -2,30 +2,29 @@ package com.freya02.botcommands.api.components.builder;
 
 import com.freya02.botcommands.api.BContext;
 import com.freya02.botcommands.api.components.ComponentManager;
-import com.freya02.botcommands.api.components.event.SelectionEvent;
+import com.freya02.botcommands.api.components.SelectionConsumer;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.interactions.components.selections.SelectionMenu;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 public class LambdaSelectionMenuBuilder extends SelectionMenu.Builder implements ComponentBuilder<LambdaSelectionMenuBuilder>, LambdaComponentBuilder<LambdaSelectionMenuBuilder> {
 	private final BContext context;
-	private final Consumer<SelectionEvent> consumer;
+	private final SelectionConsumer consumer;
 
 	private boolean oneUse;
 	private long ownerId;
 	private LambdaComponentTimeoutInfo timeoutInfo = new LambdaComponentTimeoutInfo(0, TimeUnit.MILLISECONDS, () -> {});
 
-	public LambdaSelectionMenuBuilder(BContext context, Consumer<SelectionEvent> consumer) {
+	public LambdaSelectionMenuBuilder(BContext context, SelectionConsumer consumer) {
 		super("fake");
 
 		this.context = context;
 		this.consumer = consumer;
 	}
 
-	public Consumer<SelectionEvent> getConsumer() {
+	public SelectionConsumer getConsumer() {
 		return consumer;
 	}
 

--- a/src/main/java/com/freya02/botcommands/api/components/builder/PersistentButtonBuilder.java
+++ b/src/main/java/com/freya02/botcommands/api/components/builder/PersistentButtonBuilder.java
@@ -37,13 +37,21 @@ public class PersistentButtonBuilder extends AbstractPersistentComponentBuilder<
 	}
 
 	public Button build(Emoji emoji) {
-		return new ButtonImpl(buildId(), "", buttonStyle, false, null).withEmoji(emoji);
+		return new ButtonImpl(buildId(), "", buttonStyle, false, emoji);
 	}
 
 	public Button build(ButtonContent content) {
-		return content.str() != null
-				? build(content.str())
-				: build(content.emoji());
+		//Build either a button with a label, an emoji, or both
+
+		if (content.str() != null) {
+			if (content.emoji() != null) { //both
+				return new ButtonImpl(buildId(), "", buttonStyle, false, content.emoji()).withLabel(content.str());
+			} else { //label
+				return new ButtonImpl(buildId(), "", buttonStyle, false, null).withLabel(content.str());
+			}
+		} else { //emoji
+			return new ButtonImpl(buildId(), "", buttonStyle, false, content.emoji());
+		}
 	}
 
 	public String buildId() {

--- a/src/main/java/com/freya02/botcommands/api/components/builder/PersistentButtonBuilder.java
+++ b/src/main/java/com/freya02/botcommands/api/components/builder/PersistentButtonBuilder.java
@@ -43,11 +43,11 @@ public class PersistentButtonBuilder extends AbstractPersistentComponentBuilder<
 	public Button build(ButtonContent content) {
 		//Build either a button with a label, an emoji, or both
 
-		if (content.str() != null) {
+		if (content.text() != null) {
 			if (content.emoji() != null) { //both
-				return new ButtonImpl(buildId(), "", buttonStyle, false, content.emoji()).withLabel(content.str());
+				return new ButtonImpl(buildId(), "", buttonStyle, false, content.emoji()).withLabel(content.text());
 			} else { //label
-				return new ButtonImpl(buildId(), "", buttonStyle, false, null).withLabel(content.str());
+				return new ButtonImpl(buildId(), "", buttonStyle, false, null).withLabel(content.text());
 			}
 		} else { //emoji
 			return new ButtonImpl(buildId(), "", buttonStyle, false, content.emoji());

--- a/src/main/java/com/freya02/botcommands/api/pagination/BasicPagination.java
+++ b/src/main/java/com/freya02/botcommands/api/pagination/BasicPagination.java
@@ -1,8 +1,8 @@
 package com.freya02.botcommands.api.pagination;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.components.ComponentManager;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;

--- a/src/main/java/com/freya02/botcommands/api/pagination/paginator/BasicPaginator.java
+++ b/src/main/java/com/freya02/botcommands/api/pagination/paginator/BasicPaginator.java
@@ -1,12 +1,12 @@
 package com.freya02.botcommands.api.pagination.paginator;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.components.Components;
 import com.freya02.botcommands.api.components.event.ButtonEvent;
 import com.freya02.botcommands.api.pagination.BasicPagination;
 import com.freya02.botcommands.api.pagination.PaginatorSupplier;
 import com.freya02.botcommands.api.pagination.TimeoutInfo;
 import com.freya02.botcommands.api.utils.ButtonContent;
-import com.freya02.botcommands.internal.Logging;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;

--- a/src/main/java/com/freya02/botcommands/api/parameters/ParameterResolver.java
+++ b/src/main/java/com/freya02/botcommands/api/parameters/ParameterResolver.java
@@ -1,6 +1,6 @@
 package com.freya02.botcommands.api.parameters;
 
-import com.freya02.botcommands.internal.Logging;
+import com.freya02.botcommands.api.Logging;
 import org.slf4j.Logger;
 
 /**

--- a/src/main/java/com/freya02/botcommands/api/parameters/ParameterResolvers.java
+++ b/src/main/java/com/freya02/botcommands/api/parameters/ParameterResolvers.java
@@ -3,6 +3,7 @@ package com.freya02.botcommands.api.parameters;
 import com.freya02.botcommands.api.entities.Emoji;
 import com.freya02.botcommands.api.entities.EmojiOrEmote;
 import com.freya02.botcommands.internal.parameters.*;
+import com.freya02.botcommands.internal.parameters.channels.*;
 import net.dv8tion.jda.api.entities.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,7 +32,7 @@ import java.util.stream.Collectors;
  *     <li>{@linkplain Role}</li>
  *     <li>{@linkplain User}</li>
  *     <li>{@linkplain Member}</li>
- *     <li>{@linkplain TextChannel}</li>
+ *     <li>{@linkplain GuildChannel all guild channels (in theory)}</li>
  *     <li>{@linkplain Message} (only message context commands)</li>
  * </ul>
  */
@@ -59,7 +60,14 @@ public class ParameterResolvers {
 		register(new MentionableResolver());
 		register(new RoleResolver());
 		register(new StringResolver());
+
+		register(new GuildChannelResolver());
 		register(new TextChannelResolver());
+		register(new VoiceChannelResolver());
+		register(new StoreChannelResolver());
+		register(new StageChannelResolver());
+		register(new CategoryResolver());
+
 		register(new UserResolver());
 		register(new MessageResolver());
 	}

--- a/src/main/java/com/freya02/botcommands/api/parameters/SlashParameterResolver.java
+++ b/src/main/java/com/freya02/botcommands/api/parameters/SlashParameterResolver.java
@@ -1,13 +1,22 @@
 package com.freya02.botcommands.api.parameters;
 
+import net.dv8tion.jda.api.events.interaction.CommandAutoCompleteEvent;
 import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Interface which indicates this class can resolve parameters for application commands
  */
 public interface SlashParameterResolver {
+	/**
+	 * Returns a resolved object for this {@link OptionMapping}
+	 *
+	 * @param event The event of this interaction, could be a {@link SlashCommandEvent} or a {@link CommandAutoCompleteEvent}
+	 * @param optionMapping The {@link OptionMapping} to be resolved
+	 * @return The resolved option mapping
+	 */
 	@Nullable
-	Object resolve(SlashCommandEvent event, OptionMapping optionMapping);
+	Object resolve(SlashCommandInteraction event, OptionMapping optionMapping);
 }

--- a/src/main/java/com/freya02/botcommands/api/utils/ButtonContent.java
+++ b/src/main/java/com/freya02/botcommands/api/utils/ButtonContent.java
@@ -8,15 +8,15 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Represents the visual content of a {@link Button}, this contains either an {@link Emoji} or a {@link String}
  */
-public record ButtonContent(String str, Emoji emoji) {
+public record ButtonContent(String text, Emoji emoji) {
 	/**
 	 * Constructs a {@link ButtonContent} from a {@link String}
 	 *
-	 * @param str The {@link String} to put in the {@link Button}
+	 * @param text The {@link String} to put in the {@link Button}
 	 * @return The {@link ButtonContent} with the string
 	 */
-	public static ButtonContent withString(@NotNull String str) {
-		return new ButtonContent(str, null);
+	public static ButtonContent withString(@NotNull String text) {
+		return new ButtonContent(text, null);
 	}
 
 	/**
@@ -30,13 +30,33 @@ public record ButtonContent(String str, Emoji emoji) {
 	}
 
 	/**
-	 * Constructs a {@link ButtonContent} from a unicode emoji
+	 * Constructs a {@link ButtonContent} from a {@link String} and an {@link Emoji}
+	 *
+	 * @param emoji The {@link Emoji} to put in the {@link Button}
+	 * @return The {@link ButtonContent} with the text and emoji
+	 */
+	public static ButtonContent withEmoji(@NotNull String text, @NotNull Emoji emoji) {
+		return new ButtonContent(text, emoji);
+	}
+
+	/**
+	 * Constructs a {@link ButtonContent} from an unicode emoji
 	 *
 	 * @param unicode The unicode emoji
 	 * @return The {@link ButtonContent} with the unicode emoji
 	 */
 	public static ButtonContent withEmoji(@NotNull String unicode) {
 		return new ButtonContent(null, Emoji.fromUnicode(unicode));
+	}
+
+	/**
+	 * Constructs a {@link ButtonContent} from a {@link String} and an unicode emoji
+	 *
+	 * @param unicode The unicode emoji
+	 * @return The {@link ButtonContent} with the text and unicode emoji
+	 */
+	public static ButtonContent withEmoji(@NotNull String text, @NotNull String unicode) {
+		return new ButtonContent(text, Emoji.fromUnicode(unicode));
 	}
 
 	/**
@@ -49,9 +69,19 @@ public record ButtonContent(String str, Emoji emoji) {
 		return new ButtonContent(null, EmojiUtils.resolveJDAEmoji(shortcode));
 	}
 
+	/**
+	 * Constructs a {@link ButtonContent} from a {@link String} and a shortcode emoji, such as <code>:joy:</code>
+	 *
+	 * @param shortcode The shortcode emoji
+	 * @return The {@link ButtonContent} with the text and shortcode emoji
+	 */
+	public static ButtonContent withShortcode(@NotNull String text, @NotNull String shortcode) {
+		return new ButtonContent(text, EmojiUtils.resolveJDAEmoji(shortcode));
+	}
+
 	@Nullable
-	public String str() {
-		return str;
+	public String text() {
+		return text;
 	}
 
 	@Nullable

--- a/src/main/java/com/freya02/botcommands/api/waiter/EventWaiter.java
+++ b/src/main/java/com/freya02/botcommands/api/waiter/EventWaiter.java
@@ -1,6 +1,6 @@
 package com.freya02.botcommands.api.waiter;
 
-import com.freya02.botcommands.internal.Logging;
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.internal.utils.EventUtils;
 import com.freya02.botcommands.internal.utils.Utils;
 import com.freya02.botcommands.internal.waiter.WaitingEvent;

--- a/src/main/java/com/freya02/botcommands/internal/ApplicationOptionData.java
+++ b/src/main/java/com/freya02/botcommands/internal/ApplicationOptionData.java
@@ -1,11 +1,13 @@
 package com.freya02.botcommands.internal;
 
 import com.freya02.botcommands.api.application.annotations.AppOption;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Parameter;
 
 public class ApplicationOptionData {
 	private final String effectiveName, effectiveDescription;
+	private final String autocompletionHandlerName;
 
 	public ApplicationOptionData(Parameter parameter) {
 		final AppOption option = parameter.getAnnotation(AppOption.class);
@@ -20,6 +22,12 @@ public class ApplicationOptionData {
 			effectiveDescription = "No description";
 		} else {
 			effectiveDescription = option.description();
+		}
+
+		if (option.autocomplete().isBlank()) {
+			autocompletionHandlerName = null;
+		} else {
+			autocompletionHandlerName = option.autocomplete();
 		}
 	}
 
@@ -56,5 +64,14 @@ public class ApplicationOptionData {
 	 */
 	public String getEffectiveDescription() {
 		return effectiveDescription;
+	}
+
+	public boolean hasAutocompletion() {
+		return getAutocompletionHandlerName() != null;
+	}
+
+	@Nullable
+	public String getAutocompletionHandlerName() {
+		return autocompletionHandlerName;
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
@@ -272,12 +272,28 @@ public class BContextImpl implements BContext {
 
 		final Map<CommandPath, SlashCommandInfo> slashCommandMap = getSlashCommandsMap();
 
+		//Checks below this block only check if shorter or equal commands exists
+		// We need to check if longer commands exists
+		//Would be more performant if we used a Trie
+		for (Map.Entry<CommandPath, SlashCommandInfo> entry : slashCommandMap.entrySet()) {
+			final CommandPath commandPath = entry.getKey();
+			final SlashCommandInfo mapInfo = entry.getValue();
+
+			if (commandPath.getNameCount() > path.getNameCount() && commandPath.startsWith(path)) {
+				throw new IllegalStateException(String.format("Tried to add a command with path '%s' (at %s) but a equal/longer path already exists: '%s' (at %s)",
+						path,
+						Utils.formatMethodShort(commandInfo.getCommandMethod()),
+						commandPath,
+						Utils.formatMethodShort(mapInfo.getCommandMethod())));
+			}
+		}
+
 		CommandPath p = path;
 		do {
 			final SlashCommandInfo mapInfo = slashCommandMap.get(p);
 			
 			if (mapInfo != null) {
-				throw new IllegalStateException(String.format("Tried to add a command with path %s (at %s) but a equal/shorter path already exists: %s (at %s)",
+				throw new IllegalStateException(String.format("Tried to add a command with path '%s' (at %s) but a equal/shorter path already exists: '%s' (at %s)",
 						path,
 						Utils.formatMethodShort(commandInfo.getCommandMethod()),
 						p,

--- a/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal;
 
 import com.freya02.botcommands.api.*;
+import com.freya02.botcommands.api.application.ApplicationCommandInfoMapView;
 import com.freya02.botcommands.api.application.CommandPath;
 import com.freya02.botcommands.api.application.CommandUpdateResult;
 import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionTransformer;

--- a/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
@@ -2,6 +2,7 @@ package com.freya02.botcommands.internal;
 
 import com.freya02.botcommands.api.*;
 import com.freya02.botcommands.api.application.CommandPath;
+import com.freya02.botcommands.api.application.CommandUpdateResult;
 import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionTransformer;
 import com.freya02.botcommands.api.components.ComponentManager;
 import com.freya02.botcommands.api.parameters.CustomResolver;
@@ -34,6 +35,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -396,8 +398,9 @@ public class BContextImpl implements BContext {
 	}
 
 	@Override
-	public boolean tryUpdateGuildCommands(Iterable<Guild> guilds) throws IOException {
-		return slashCommandsBuilder.tryUpdateGuildCommands(guilds);
+	@NotNull
+	public Map<Guild, CompletableFuture<CommandUpdateResult>> scheduleApplicationCommandsUpdate(Iterable<Guild> guilds) throws IOException {
+		return slashCommandsBuilder.scheduleApplicationCommandsUpdate(guilds);
 	}
 
 	@Override

--- a/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
 import org.slf4j.Logger;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -448,8 +447,12 @@ public class BContextImpl implements BContext {
 
 	@Override
 	@NotNull
-	public Map<Guild, CompletableFuture<CommandUpdateResult>> scheduleApplicationCommandsUpdate(Iterable<Guild> guilds) throws IOException {
-		return slashCommandsBuilder.scheduleApplicationCommandsUpdate(guilds);
+	public Map<Guild, CompletableFuture<CommandUpdateResult>> scheduleApplicationCommandsUpdate(Iterable<Guild> guilds, boolean force) {
+		return slashCommandsBuilder.scheduleApplicationCommandsUpdate(guilds, false);
+	}
+
+	public ApplicationCommandsBuilder getSlashCommandsBuilder() {
+		return slashCommandsBuilder;
 	}
 
 	@Override

--- a/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
@@ -2,6 +2,7 @@ package com.freya02.botcommands.internal;
 
 import com.freya02.botcommands.api.*;
 import com.freya02.botcommands.api.application.CommandPath;
+import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionTransformer;
 import com.freya02.botcommands.api.components.ComponentManager;
 import com.freya02.botcommands.api.parameters.CustomResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolvers;
@@ -70,6 +71,8 @@ public class BContextImpl implements BContext {
 	private ApplicationCommandsCache applicationCommandsCache;
 	private Function<Guild, DefaultMessages> defaultMessageProvider;
 	private ExceptionHandler uncaughtExceptionHandler;
+
+	private final Map<Class<?>, AutocompletionTransformer<?>> autocompletionTransformers = new HashMap<>();
 
 	@Override
 	@NotNull
@@ -446,5 +449,13 @@ public class BContextImpl implements BContext {
 	@Override
 	public ExceptionHandler getUncaughtExceptionHandler() {
 		return uncaughtExceptionHandler;
+	}
+
+	public AutocompletionTransformer<?> getAutocompletionTransformer(Class<?> type) {
+		return autocompletionTransformers.get(type);
+	}
+
+	public <T> void registerAutocompletionTransformer(Class<T> type, AutocompletionTransformer<T> autocompletionTransformer) {
+		autocompletionTransformers.put(type, autocompletionTransformer);
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
@@ -9,10 +9,7 @@ import com.freya02.botcommands.api.parameters.CustomResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolvers;
 import com.freya02.botcommands.api.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.prefixed.MessageInfo;
-import com.freya02.botcommands.internal.application.ApplicationCommandInfo;
-import com.freya02.botcommands.internal.application.ApplicationCommandInfoMap;
-import com.freya02.botcommands.internal.application.ApplicationCommandsBuilder;
-import com.freya02.botcommands.internal.application.ApplicationCommandsCache;
+import com.freya02.botcommands.internal.application.*;
 import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
 import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
@@ -30,6 +27,7 @@ import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.internal.utils.Checks;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -161,22 +159,52 @@ public class BContextImpl implements BContext {
 		return getMessageCommandsMap().get(CommandPath.ofName(name));
 	}
 
+	@NotNull
 	public ApplicationCommandInfoMap getApplicationCommandInfoMap() {
 		return applicationCommandInfoMap;
 	}
 
-	private ApplicationCommandInfoMap.CommandInfoMap<SlashCommandInfo> getSlashCommandsMap() {
-		return getApplicationCommandInfoMap().getSlashCommands();
-	}
-	
+	@Override
 	@NotNull
-	private ApplicationCommandInfoMap.CommandInfoMap<UserCommandInfo> getUserCommandsMap() {
-		return getApplicationCommandInfoMap().getUserCommands();
+	@UnmodifiableView
+	public ApplicationCommandInfoMapView getApplicationCommandInfoMapView() {
+		return applicationCommandInfoMap;
 	}
 
 	@NotNull
-	private ApplicationCommandInfoMap.CommandInfoMap<MessageCommandInfo> getMessageCommandsMap() {
+	private CommandInfoMap<SlashCommandInfo> getSlashCommandsMap() {
+		return getApplicationCommandInfoMap().getSlashCommands();
+	}
+
+	@Override
+	@NotNull
+	@UnmodifiableView
+	public CommandInfoMap<SlashCommandInfo> getSlashCommandsMapView() {
+		return getApplicationCommandInfoMapView().getSlashCommandsView();
+	}
+
+	@NotNull
+	private CommandInfoMap<UserCommandInfo> getUserCommandsMap() {
+		return getApplicationCommandInfoMap().getUserCommands();
+	}
+
+	@Override
+	@NotNull
+	@UnmodifiableView
+	public CommandInfoMap<UserCommandInfo> getUserCommandsMapView() {
+		return getApplicationCommandInfoMapView().getUserCommandsView();
+	}
+
+	@NotNull
+	private CommandInfoMap<MessageCommandInfo> getMessageCommandsMap() {
 		return getApplicationCommandInfoMap().getMessageCommands();
+	}
+
+	@Override
+	@NotNull
+	@UnmodifiableView
+	public CommandInfoMap<MessageCommandInfo> getMessageCommandsMapView() {
+		return getApplicationCommandInfoMapView().getMessageCommandsView();
 	}
 
 	@Override
@@ -302,8 +330,9 @@ public class BContextImpl implements BContext {
 		return Collections.unmodifiableCollection(textCommandMap.values());
 	}
 
-	public Collection<? extends ApplicationCommandInfo> getApplicationCommands() {
-		return applicationCommandInfoMap.getAllApplicationCommands();
+	@UnmodifiableView
+	public Collection<? extends ApplicationCommandInfo> getApplicationCommandsView() {
+		return applicationCommandInfoMap.getAllApplicationCommandsView();
 	}
 
 	public void dispatchException(String message, Throwable e) {

--- a/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/BContextImpl.java
@@ -116,7 +116,10 @@ public class BContextImpl implements BContext {
 	@Override
 	@Nullable
 	public TextCommandInfo findFirstCommand(@NotNull CommandPath path) {
-		return textCommandMap.get(path).findFirst();
+		final TextCommandCandidates candidates = textCommandMap.get(path);
+		if (candidates == null) return null;
+
+		return candidates.findFirst();
 	}
 
 	@Nullable

--- a/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
@@ -162,6 +162,9 @@ public final class CommandsBuilderImpl {
 			if (!method.canAccess(annotatedInstance))
 				throw new IllegalStateException(requiredClassDesc + " " + Utils.formatMethodShort(method) + " is not public");
 
+			if (Modifier.isStatic(method.getModifiers()))
+				throw new IllegalStateException(requiredClassDesc + " " + Utils.formatMethodShort(method) + " is static");
+
 			return annotatedInstance;
 		}
 

--- a/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
@@ -7,6 +7,7 @@ import com.freya02.botcommands.api.application.ApplicationCommand;
 import com.freya02.botcommands.api.application.CommandPath;
 import com.freya02.botcommands.api.application.context.annotations.JDAMessageCommand;
 import com.freya02.botcommands.api.application.context.annotations.JDAUserCommand;
+import com.freya02.botcommands.api.application.slash.annotations.AutocompletionHandler;
 import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
 import com.freya02.botcommands.api.prefixed.TextCommand;
 import com.freya02.botcommands.api.prefixed.annotations.JDATextCommand;
@@ -14,6 +15,7 @@ import com.freya02.botcommands.api.waiter.EventWaiter;
 import com.freya02.botcommands.internal.application.ApplicationCommandListener;
 import com.freya02.botcommands.internal.application.ApplicationCommandsBuilder;
 import com.freya02.botcommands.internal.application.ApplicationUpdaterListener;
+import com.freya02.botcommands.internal.application.slash.autocomplete.AutocompletionHandlersBuilder;
 import com.freya02.botcommands.internal.components.ComponentsBuilder;
 import com.freya02.botcommands.internal.events.EventListenersBuilder;
 import com.freya02.botcommands.internal.prefixed.CommandListener;
@@ -45,6 +47,7 @@ public final class CommandsBuilderImpl {
 	private final PrefixedCommandsBuilder prefixedCommandsBuilder;
 	private final ApplicationCommandsBuilder applicationCommandsBuilder;
 	private final EventListenersBuilder eventListenersBuilder;
+	private final AutocompletionHandlersBuilder autocompletionHandlersBuilder;
 
 	private final ComponentsBuilder componentsBuilder;
 
@@ -70,6 +73,7 @@ public final class CommandsBuilderImpl {
 		this.applicationCommandsBuilder = new ApplicationCommandsBuilder(context, slashGuildIds);
 
 		this.eventListenersBuilder = new EventListenersBuilder(context);
+		this.autocompletionHandlersBuilder = new AutocompletionHandlersBuilder(context);
 	}
 
 	private void buildClasses() {
@@ -116,6 +120,8 @@ public final class CommandsBuilderImpl {
 			}
 
 			eventListenersBuilder.postProcess();
+
+			autocompletionHandlersBuilder.postProcess();
 
 			context.getRegistrationListeners().forEach(RegistrationListener::onBuildComplete);
 
@@ -190,6 +196,13 @@ public final class CommandsBuilderImpl {
 		final Object eventListener = tryInstantiateMethod(JDAEventListener.class, Object.class, "JDA event listener", method);
 		if (eventListener != null) {
 			eventListenersBuilder.processEventListener(eventListener, method);
+
+			return true;
+		}
+
+		final Object autocompletionHandler = tryInstantiateMethod(AutocompletionHandler.class, Object.class, "Slash command auto completion", method);
+		if (autocompletionHandler != null) {
+			autocompletionHandlersBuilder.processHandler(autocompletionHandler, method);
 
 			return true;
 		}

--- a/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
@@ -23,6 +23,7 @@ import com.freya02.botcommands.internal.prefixed.HelpCommand;
 import com.freya02.botcommands.internal.prefixed.PrefixedCommandsBuilder;
 import com.freya02.botcommands.internal.prefixed.TextCommandInfo;
 import com.freya02.botcommands.internal.utils.ClassInstancer;
+import com.freya02.botcommands.internal.utils.ReflectionUtils;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
@@ -80,7 +81,7 @@ public final class CommandsBuilderImpl {
 		try {
 			classes.removeIf(c -> {
 				try {
-					return !Utils.isInstantiable(c);
+					return !ReflectionUtils.isInstantiable(c);
 				} catch (IllegalAccessException | InvocationTargetException e) {
 					LOGGER.error("An error occurred while trying to find if a class is instantiable", e);
 
@@ -235,7 +236,7 @@ public final class CommandsBuilderImpl {
 
 		setupContext(jda);
 
-		Utils.scanOptionals(classes);
+		ReflectionUtils.scanOptionals(classes);
 
 		buildClasses();
 

--- a/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
@@ -236,7 +236,7 @@ public final class CommandsBuilderImpl {
 
 		setupContext(jda);
 
-		ReflectionUtils.scanOptionals(classes);
+		ReflectionUtils.scanAnnotations(classes);
 
 		buildClasses();
 

--- a/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
@@ -28,6 +28,7 @@ import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.requests.GatewayIntent;
+import net.dv8tion.jda.api.sharding.ShardManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -217,6 +218,17 @@ public final class CommandsBuilderImpl {
 	 * @param jda The JDA instance of your bot
 	 */
 	public void build(JDA jda) throws IOException {
+		if (jda.getShardInfo().getShardId() != 0) {
+			LOGGER.warn("A shard other than 0 was passed to CommandsBuilder#build, shard 0 is needed to handle DMing exceptions, manually retrieving shard 0...");
+
+			final ShardManager manager = jda.getShardManager();
+			if (manager == null) throw new IllegalArgumentException("Unable to retrieve Shard 0 as shard manager is null");
+
+			jda = manager.getShardById(0);
+
+			if (jda == null) throw new IllegalArgumentException("Unable to retrieve Shard 0");
+		}
+
 		if (jda.getStatus() != JDA.Status.CONNECTED) {
 			try {
 				LOGGER.warn("JDA should already be ready when you call #build on CommandsBuilder !");

--- a/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
@@ -1,6 +1,8 @@
 package com.freya02.botcommands.internal;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.DefaultMessages;
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.RegistrationListener;
 import com.freya02.botcommands.api.annotations.JDAEventListener;
 import com.freya02.botcommands.api.application.ApplicationCommand;

--- a/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/CommandsBuilderImpl.java
@@ -33,7 +33,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -78,65 +77,55 @@ public final class CommandsBuilderImpl {
 		this.autocompletionHandlersBuilder = new AutocompletionHandlersBuilder(context);
 	}
 
-	private void buildClasses() {
-		try {
-			classes.removeIf(c -> {
-				try {
-					return !ReflectionUtils.isInstantiable(c);
-				} catch (IllegalAccessException | InvocationTargetException e) {
-					LOGGER.error("An error occurred while trying to find if a class is instantiable", e);
+	private void buildClasses() throws Exception {
+		classes.removeIf(c -> {
+			try {
+				return !ReflectionUtils.isInstantiable(c);
+			} catch (IllegalAccessException | InvocationTargetException e) {
+				LOGGER.error("An error occurred while trying to find if a class is instantiable", e);
 
-					throw new RuntimeException("An error occurred while trying to find if a class is instantiable", e);
-				}
-			});
-
-			for (Class<?> aClass : classes) {
-				processClass(aClass);
+				throw new RuntimeException("An error occurred while trying to find if a class is instantiable", e);
 			}
+		});
 
-			if (!context.isHelpDisabled()) {
-				processClass(HelpCommand.class);
-
-				final TextCommandInfo helpInfo = context.findFirstCommand(CommandPath.of("help"));
-				if (helpInfo == null) throw new IllegalStateException("HelpCommand did not build properly");
-
-				final HelpCommand help = (HelpCommand) helpInfo.getInstance();
-				help.generate();
-			}
-
-			prefixedCommandsBuilder.postProcess();
-
-			if (context.getComponentManager() != null) {
-				//Load button listeners
-				for (Class<?> aClass : classes) {
-					componentsBuilder.processClass(aClass);
-				}
-			} else {
-				LOGGER.info("ComponentManager is not set, the Components API, paginators and menus won't be usable");
-			}
-
-			applicationCommandsBuilder.postProcess();
-
-			if (context.getComponentManager() != null) {
-				componentsBuilder.postProcess();
-			}
-
-			eventListenersBuilder.postProcess();
-
-			autocompletionHandlersBuilder.postProcess();
-
-			context.getRegistrationListeners().forEach(RegistrationListener::onBuildComplete);
-
-			LOGGER.info("Finished registering all commands");
-		} catch (RuntimeException e) {
-			LOGGER.error("An error occurred while loading the commands, the commands will not work");
-
-			throw e;
-		} catch (Throwable e) {
-			LOGGER.error("An error occurred while loading the commands, the commands will not work");
-
-			throw new RuntimeException(e);
+		for (Class<?> aClass : classes) {
+			processClass(aClass);
 		}
+
+		if (!context.isHelpDisabled()) {
+			processClass(HelpCommand.class);
+
+			final TextCommandInfo helpInfo = context.findFirstCommand(CommandPath.of("help"));
+			if (helpInfo == null) throw new IllegalStateException("HelpCommand did not build properly");
+
+			final HelpCommand help = (HelpCommand) helpInfo.getInstance();
+			help.generate();
+		}
+
+		prefixedCommandsBuilder.postProcess();
+
+		if (context.getComponentManager() != null) {
+			//Load button listeners
+			for (Class<?> aClass : classes) {
+				componentsBuilder.processClass(aClass);
+			}
+		} else {
+			LOGGER.info("ComponentManager is not set, the Components API, paginators and menus won't be usable");
+		}
+
+		applicationCommandsBuilder.postProcess();
+
+		if (context.getComponentManager() != null) {
+			componentsBuilder.postProcess();
+		}
+
+		eventListenersBuilder.postProcess();
+
+		autocompletionHandlersBuilder.postProcess();
+
+		context.getRegistrationListeners().forEach(RegistrationListener::onBuildComplete);
+
+		LOGGER.info("Finished registering all commands");
 	}
 
 	private void processClass(Class<?> aClass) throws InvocationTargetException, IllegalAccessException, InstantiationException {
@@ -217,7 +206,7 @@ public final class CommandsBuilderImpl {
 	 *
 	 * @param jda The JDA instance of your bot
 	 */
-	public void build(JDA jda) throws IOException {
+	public void build(JDA jda) throws Exception {
 		if (jda.getShardInfo().getShardId() != 0) {
 			LOGGER.warn("A shard other than 0 was passed to CommandsBuilder#build, shard 0 is needed to handle DMing exceptions, manually retrieving shard 0...");
 

--- a/src/main/java/com/freya02/botcommands/internal/ConflictDetector.java
+++ b/src/main/java/com/freya02/botcommands/internal/ConflictDetector.java
@@ -1,5 +1,6 @@
 package com.freya02.botcommands.internal;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.internal.utils.IOUtils;
 import org.slf4j.Logger;
 

--- a/src/main/java/com/freya02/botcommands/internal/CooldownStrategy.java
+++ b/src/main/java/com/freya02/botcommands/internal/CooldownStrategy.java
@@ -19,6 +19,10 @@ public class CooldownStrategy {
 		return cooldown;
 	}
 
+	public long getCooldownMillis() {
+		return unit.toMillis(cooldown);
+	}
+
 	public TimeUnit getUnit() {
 		return unit;
 	}

--- a/src/main/java/com/freya02/botcommands/internal/Cooldownable.java
+++ b/src/main/java/com/freya02/botcommands/internal/Cooldownable.java
@@ -25,8 +25,8 @@ public abstract class Cooldownable {
 		this.cooldownStrategy = cooldownStrategy;
 	}
 
-	public long getCooldown() {
-		return cooldownStrategy.getCooldown();
+	public long getCooldownMillis() {
+		return cooldownStrategy.getCooldownMillis();
 	}
 
 	public CooldownScope getCooldownScope() {
@@ -35,9 +35,9 @@ public abstract class Cooldownable {
 
 	public void applyCooldown(GuildMessageReceivedEvent event) {
 		switch (getCooldownScope()) {
-			case USER -> getGuildUserCooldownMap(event.getGuild()).put(event.getAuthor().getIdLong(), System.currentTimeMillis() + getCooldown());
-			case GUILD -> guildCooldowns.put(event.getGuild().getIdLong(), System.currentTimeMillis() + getCooldown());
-			case CHANNEL -> channelCooldowns.put(event.getChannel().getIdLong(), System.currentTimeMillis() + getCooldown());
+			case USER -> getGuildUserCooldownMap(event.getGuild()).put(event.getAuthor().getIdLong(), System.currentTimeMillis() + getCooldownMillis());
+			case GUILD -> guildCooldowns.put(event.getGuild().getIdLong(), System.currentTimeMillis() + getCooldownMillis());
+			case CHANNEL -> channelCooldowns.put(event.getChannel().getIdLong(), System.currentTimeMillis() + getCooldownMillis());
 		}
 	}
 
@@ -50,15 +50,15 @@ public abstract class Cooldownable {
 		switch (getCooldownScope()) {
 			case USER -> {
 				if (event.getGuild() == null) break;
-				getGuildUserCooldownMap(event.getGuild()).put(event.getUser().getIdLong(), System.currentTimeMillis() + getCooldown());
+				getGuildUserCooldownMap(event.getGuild()).put(event.getUser().getIdLong(), System.currentTimeMillis() + getCooldownMillis());
 			}
 			case GUILD -> {
 				if (event.getGuild() == null) break;
-				guildCooldowns.put(event.getGuild().getIdLong(), System.currentTimeMillis() + getCooldown());
+				guildCooldowns.put(event.getGuild().getIdLong(), System.currentTimeMillis() + getCooldownMillis());
 			}
 			case CHANNEL -> {
 				if (event.getChannel() == null) break;
-				channelCooldowns.put(event.getChannel().getIdLong(), System.currentTimeMillis() + getCooldown());
+				channelCooldowns.put(event.getChannel().getIdLong(), System.currentTimeMillis() + getCooldownMillis());
 			}
 		}
 	}

--- a/src/main/java/com/freya02/botcommands/internal/Cooldownable.java
+++ b/src/main/java/com/freya02/botcommands/internal/Cooldownable.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal;
 
 import com.freya02.botcommands.api.CooldownScope;
+import com.freya02.botcommands.api.Logging;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.Interaction;

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandInfo.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandInfo.java
@@ -1,10 +1,13 @@
 package com.freya02.botcommands.internal.application;
 
+import com.freya02.botcommands.api.BContext;
 import com.freya02.botcommands.api.application.ApplicationCommand;
 import com.freya02.botcommands.internal.AbstractCommandInfo;
 import com.freya02.botcommands.internal.MethodParameters;
 import com.freya02.botcommands.internal.utils.Utils;
+import net.dv8tion.jda.api.entities.Guild;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -34,5 +37,9 @@ public abstract class ApplicationCommandInfo extends AbstractCommandInfo<Applica
 	@Override
 	public List<? extends ApplicationCommandParameter<?>> getOptionParameters() {
 		return (List<? extends ApplicationCommandParameter<?>>) super.getOptionParameters();
+	}
+
+	public LocalizedCommandData getLocalizedData(@NotNull BContext context, @Nullable Guild guild) {
+		return LocalizedCommandData.of(context, guild, this);
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandInfoMap.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandInfoMap.java
@@ -6,39 +6,9 @@ import com.freya02.botcommands.internal.application.context.user.UserCommandInfo
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
 import net.dv8tion.jda.api.interactions.commands.CommandType;
 
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.function.Function;
 
-public class ApplicationCommandInfoMap {
-	public static class CommandInfoMap<T extends ApplicationCommandInfo> extends HashMap<CommandPath, T> {}
-
-	//Might or might not be localized
-	private final EnumMap<CommandType, CommandInfoMap<? extends ApplicationCommandInfo>> typeMap = new EnumMap<>(CommandType.class);
-	
-	public Collection<? extends ApplicationCommandInfo> getAllApplicationCommands() {
-		return typeMap.values()
-				.stream()
-				.flatMap(map -> map.values().stream())
-				.toList();
-	}
-
-	public <T extends ApplicationCommandInfo> T computeIfAbsent(CommandType type, CommandPath path, Function<CommandPath, T> mappingFunction) {
-		// it works :tm:
-		return this.<T>getTypeMap(type).computeIfAbsent(path, mappingFunction);
-	}
-
-	public <T extends ApplicationCommandInfo> T put(CommandType type, CommandPath path, T value) {
-		// it works :tm:
-
-		return this.<T>getTypeMap(type).put(path, value);
-	}
-
-	public ApplicationCommandInfo get(CommandType type, CommandPath path) {
-		return getTypeMap(type).get(path);
-	}
-
+public class ApplicationCommandInfoMap extends ApplicationCommandInfoMapView {
 	public CommandInfoMap<SlashCommandInfo> getSlashCommands() {
 		return getTypeMap(CommandType.SLASH);
 	}
@@ -51,8 +21,14 @@ public class ApplicationCommandInfoMap {
 		return getTypeMap(CommandType.MESSAGE_CONTEXT);
 	}
 
-	@SuppressWarnings("unchecked")
-	private <T extends ApplicationCommandInfo> CommandInfoMap<T> getTypeMap(CommandType type) {
-		return (CommandInfoMap<T>) typeMap.computeIfAbsent(type, x -> new CommandInfoMap<>());
+	public <T extends ApplicationCommandInfo> T computeIfAbsent(CommandType type, CommandPath path, Function<CommandPath, T> mappingFunction) {
+		// it works :tm:
+		return this.<T>getTypeMap(type).computeIfAbsent(path, mappingFunction);
+	}
+
+	public <T extends ApplicationCommandInfo> T put(CommandType type, CommandPath path, T value) {
+		// it works :tm:
+
+		return this.<T>getTypeMap(type).put(path, value);
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandInfoMap.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandInfoMap.java
@@ -1,5 +1,6 @@
 package com.freya02.botcommands.internal.application;
 
+import com.freya02.botcommands.api.application.ApplicationCommandInfoMapView;
 import com.freya02.botcommands.api.application.CommandPath;
 import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
 import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandInfoMapView.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandInfoMapView.java
@@ -1,0 +1,54 @@
+package com.freya02.botcommands.internal.application;
+
+import com.freya02.botcommands.api.application.CommandPath;
+import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
+import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;
+import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
+import net.dv8tion.jda.api.interactions.commands.CommandType;
+import org.jetbrains.annotations.UnmodifiableView;
+
+import java.util.Collection;
+import java.util.EnumMap;
+
+public abstract class ApplicationCommandInfoMapView {
+	//Might or might not be localized
+	protected final EnumMap<CommandType, CommandInfoMap<? extends ApplicationCommandInfo>> typeMap = new EnumMap<>(CommandType.class);
+
+	@UnmodifiableView
+	public Collection<? extends ApplicationCommandInfo> getAllApplicationCommandsView() {
+		return typeMap.values()
+				.stream()
+				.flatMap(map -> map.values().stream())
+				.toList();
+	}
+
+	public ApplicationCommandInfo get(CommandType type, CommandPath path) {
+		return getTypeMap(type).get(path);
+	}
+
+	@UnmodifiableView
+	public CommandInfoMap<SlashCommandInfo> getSlashCommandsView() {
+		final CommandInfoMap<SlashCommandInfo> typeMap = getTypeMap(CommandType.SLASH);
+
+		return typeMap.unmodifiable();
+	}
+
+	@UnmodifiableView
+	public CommandInfoMap<UserCommandInfo> getUserCommandsView() {
+		final CommandInfoMap<UserCommandInfo> map = getTypeMap(CommandType.USER_CONTEXT);
+
+		return map.unmodifiable();
+	}
+
+	@UnmodifiableView
+	public CommandInfoMap<MessageCommandInfo> getMessageCommandsView() {
+		final CommandInfoMap<MessageCommandInfo> map = getTypeMap(CommandType.MESSAGE_CONTEXT);
+
+		return map.unmodifiable();
+	}
+
+	@SuppressWarnings("unchecked")
+	protected <T extends ApplicationCommandInfo> CommandInfoMap<T> getTypeMap(CommandType type) {
+		return (CommandInfoMap<T>) typeMap.computeIfAbsent(type, x -> new CommandInfoMap<>());
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandListener.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandListener.java
@@ -1,9 +1,13 @@
 package com.freya02.botcommands.internal.application;
 
 import com.freya02.botcommands.api.CooldownScope;
+import com.freya02.botcommands.api.DefaultMessages;
 import com.freya02.botcommands.api.ExceptionHandler;
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.application.CommandPath;
-import com.freya02.botcommands.internal.*;
+import com.freya02.botcommands.internal.BContextImpl;
+import com.freya02.botcommands.internal.RunnableEx;
+import com.freya02.botcommands.internal.Usability;
 import com.freya02.botcommands.internal.Usability.UnusableReason;
 import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
 import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandListener.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandListener.java
@@ -10,7 +10,6 @@ import com.freya02.botcommands.internal.application.context.user.UserCommandInfo
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.events.interaction.commands.GenericCommandEvent;
 import net.dv8tion.jda.api.events.interaction.commands.MessageContextCommandEvent;
 import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
@@ -138,7 +137,7 @@ public final class ApplicationCommandListener extends ListenerAdapter {
 
 				//Take needed permissions, extract bot current permissions
 				final EnumSet<Permission> missingPerms = applicationCommand.getBotPermissions();
-				missingPerms.removeAll(event.getGuild().getSelfMember().getPermissions((GuildChannel) event.getChannel()));
+				missingPerms.removeAll(event.getGuild().getSelfMember().getPermissions(event.getTextChannel()));
 
 				for (Permission botPermission : missingPerms) {
 					missingBuilder.add(botPermission.getName());

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsBuilder.java
@@ -27,18 +27,22 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.locks.ReentrantLock;
 
 public final class ApplicationCommandsBuilder {
 	private static final Logger LOGGER = Logging.getLogger();
 	private final ExecutorService es = Executors.newFixedThreadPool(Math.min(4, Runtime.getRuntime().availableProcessors()));
 	private final BContextImpl context;
 	private final List<Long> slashGuildIds;
+
+	private final Map<Long, ReentrantLock> lockMap = Collections.synchronizedMap(new HashMap<>());
 
 	public ApplicationCommandsBuilder(@NotNull BContextImpl context, List<Long> slashGuildIds) {
 		this.context = context;
@@ -125,77 +129,92 @@ public final class ApplicationCommandsBuilder {
 
 		context.setApplicationCommandsCache(new ApplicationCommandsCache(context));
 
-		final ApplicationCommandsUpdater globalUpdater = ApplicationCommandsUpdater.ofGlobal(context);
-		if (globalUpdater.shouldUpdateCommands()) {
-			globalUpdater.updateCommands();
-			LOGGER.debug("Global commands were updated");
-		} else {
-			LOGGER.debug("Global commands does not have to be updated");
-		}
+		es.submit(() -> {
+			try {
+				final ApplicationCommandsUpdater globalUpdater = ApplicationCommandsUpdater.ofGlobal(context);
+				if (globalUpdater.shouldUpdateCommands()) {
+					globalUpdater.updateCommands();
+					LOGGER.debug("Global commands were updated");
+				} else {
+					LOGGER.debug("Global commands does not have to be updated");
+				}
+			} catch (IOException e) {
+				LOGGER.error("An error occurred while updating global commands", e);
+			}
+		});
 
 		final Map<Guild, CompletableFuture<CommandUpdateResult>> map;
 		final ShardManager shardManager = context.getJDA().getShardManager();
 		if (shardManager != null) {
-			map = scheduleApplicationCommandsUpdate(shardManager.getGuildCache());
+			map = scheduleApplicationCommandsUpdate(shardManager.getGuildCache(), false);
 		} else {
-			map = scheduleApplicationCommandsUpdate(context.getJDA().getGuildCache());
+			map = scheduleApplicationCommandsUpdate(context.getJDA().getGuildCache(), false);
 		}
 
 		map.forEach((guild, future) -> {
-			future.whenComplete((result, throwable) -> {
-				if (throwable != null) {
-					ErrorResponseException e = Utils.getErrorResponseException(throwable);
-
-					if (e != null && e.getErrorResponse() == ErrorResponse.MISSING_ACCESS) {
-						final String inviteUrl = context.getJDA().getInviteUrl() + "&guild_id=" + guild.getId();
-
-						LOGGER.warn("Could not register guild commands for guild '{}' ({}) as it appears the OAuth2 grants misses applications.commands, you can re-invite the bot in this guild with its already existing permission with this link: {}", guild.getName(), guild.getId(), inviteUrl);
-						context.getRegistrationListeners().forEach(r -> r.onGuildSlashCommandMissingAccess(guild, inviteUrl));
-					} else {
-						LOGGER.error("Encountered an exception while updating commands for guild '{}' ({})", guild.getName(), guild.getId(), e);
-					}
-				}
-			});
+			future.whenComplete((result, throwable) -> handleApplicationUpdateException(guild, throwable));
 		});
 	}
 
+	void handleApplicationUpdateException(Guild guild, Throwable throwable) {
+		if (throwable != null) {
+			ErrorResponseException e = Utils.getErrorResponseException(throwable);
+
+			if (e != null && e.getErrorResponse() == ErrorResponse.MISSING_ACCESS) {
+				final String inviteUrl = context.getJDA().getInviteUrl() + "&guild_id=" + guild.getId();
+
+				LOGGER.warn("Could not register guild commands for guild '{}' ({}) as it appears the OAuth2 grants misses applications.commands, you can re-invite the bot in this guild with its already existing permission with this link: {}", guild.getName(), guild.getId(), inviteUrl);
+				context.getRegistrationListeners().forEach(r -> r.onGuildSlashCommandMissingAccess(guild, inviteUrl));
+			} else {
+				LOGGER.error("Encountered an exception while updating commands for guild '{}' ({})", guild.getName(), guild.getId(), e);
+			}
+		}
+	}
+
 	@NotNull
-	public Map<Guild, CompletableFuture<CommandUpdateResult>> scheduleApplicationCommandsUpdate(@NotNull Iterable<Guild> guilds) throws IOException {
+	public Map<Guild, CompletableFuture<CommandUpdateResult>> scheduleApplicationCommandsUpdate(@NotNull Iterable<Guild> guilds, boolean force) {
 		final Map<Guild, CompletableFuture<CommandUpdateResult>> map = new HashMap<>();
 
 		for (Guild guild : guilds) {
 			if (!slashGuildIds.isEmpty() && !slashGuildIds.contains(guild.getIdLong())) continue;
 
-			map.put(guild, scheduleApplicationCommandsUpdate(guild));
+			map.put(guild, scheduleApplicationCommandsUpdate(guild, force));
 		}
 
 		return map;
 	}
 
 	@NotNull
-	public CompletableFuture<CommandUpdateResult> scheduleApplicationCommandsUpdate(Guild guild) throws IOException {
-		final ApplicationCommandsUpdater updater = ApplicationCommandsUpdater.ofGuild(context, guild);
-
+	public CompletableFuture<CommandUpdateResult> scheduleApplicationCommandsUpdate(Guild guild, boolean force) {
 		return CompletableFuture.supplyAsync(() -> {
+			final ReentrantLock lock;
+			synchronized (lockMap) {
+				lock = lockMap.computeIfAbsent(guild.getIdLong(), x -> new ReentrantLock());
+			}
+
 			try {
+				lock.lock();
+
+				final ApplicationCommandsUpdater updater = ApplicationCommandsUpdater.ofGuild(context, guild);
+
 				boolean updatedCommands = false, updatedPrivileges = false;
 
-				if (updater.shouldUpdateCommands()) {
-					updater.updateCommands().get();
+				if (force || updater.shouldUpdateCommands()) {
+					updater.updateCommands();
 
 					updatedCommands = true;
 
-					LOGGER.debug("Guild '{}' ({}) commands were updated", guild.getName(), guild.getId());
+					LOGGER.debug("Guild '{}' ({}) commands were{} updated", guild.getName(), guild.getId(), force ? "force" : "");
 				} else {
 					LOGGER.debug("Guild '{}' ({}) commands does not have to be updated", guild.getName(), guild.getId());
 				}
 
-				if (updater.shouldUpdatePrivileges()) {
+				if (force || updater.shouldUpdatePrivileges()) {
 					updater.updatePrivileges();
 
 					updatedPrivileges = true;
 
-					LOGGER.debug("Guild '{}' ({}) commands privileges were updated", guild.getName(), guild.getId());
+					LOGGER.debug("Guild '{}' ({}) commands privileges were{} updated", guild.getName(), guild.getId(), force ? "force" : "");
 				} else {
 					LOGGER.debug("Guild '{}' ({}) commands privileges does not have to be updated", guild.getName(), guild.getId());
 				}
@@ -203,6 +222,8 @@ public final class ApplicationCommandsBuilder {
 				return new CommandUpdateResult(guild, updatedCommands, updatedPrivileges);
 			} catch (Throwable e) {
 				throw new RuntimeException("An exception occurred while updating guild commands for guild '" + guild.getName() + "' (" + guild.getId() + ")", e);
+			} finally {
+				lock.unlock();
 			}
 		}, es);
 	}

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsBuilder.java
@@ -1,5 +1,6 @@
 package com.freya02.botcommands.internal.application;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.application.ApplicationCommand;
 import com.freya02.botcommands.api.application.CommandUpdateResult;
 import com.freya02.botcommands.api.application.context.annotations.JDAMessageCommand;
@@ -12,7 +13,6 @@ import com.freya02.botcommands.api.application.slash.GlobalSlashEvent;
 import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
 import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
 import com.freya02.botcommands.internal.BContextImpl;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
 import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsBuilder.java
@@ -15,6 +15,7 @@ import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
 import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
+import com.freya02.botcommands.internal.utils.ReflectionUtils;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
@@ -58,15 +59,15 @@ public final class ApplicationCommandsBuilder {
 
 	private void processUserCommand(ApplicationCommand applicationCommand, Method method) {
 		if (method.getAnnotation(JDAUserCommand.class).guildOnly()) {
-			if (!Utils.hasFirstParameter(method, GlobalUserEvent.class) && !Utils.hasFirstParameter(method, GuildUserEvent.class))
+			if (!ReflectionUtils.hasFirstParameter(method, GlobalUserEvent.class) && !ReflectionUtils.hasFirstParameter(method, GuildUserEvent.class))
 				throw new IllegalArgumentException("User command at " + Utils.formatMethodShort(method) + " must have a GuildUserEvent or GlobalUserEvent as first parameter");
 
-			if (!Utils.hasFirstParameter(method, GuildUserEvent.class)) {
+			if (!ReflectionUtils.hasFirstParameter(method, GuildUserEvent.class)) {
 				//If type is correct but guild specialization isn't used
 				LOGGER.warn("Guild-only user command {} uses GlobalUserEvent, consider using GuildUserEvent to remove warnings related to guild stuff's nullability", Utils.formatMethodShort(method));
 			}
 		} else {
-			if (!Utils.hasFirstParameter(method, GlobalUserEvent.class))
+			if (!ReflectionUtils.hasFirstParameter(method, GlobalUserEvent.class))
 				throw new IllegalArgumentException("User command at " + Utils.formatMethodShort(method) + " must have a GlobalUserEvent as first parameter");
 		}
 
@@ -78,15 +79,15 @@ public final class ApplicationCommandsBuilder {
 
 	private void processMessageCommand(ApplicationCommand applicationCommand, Method method) {
 		if (method.getAnnotation(JDAMessageCommand.class).guildOnly()) {
-			if (!Utils.hasFirstParameter(method, GlobalMessageEvent.class) && !Utils.hasFirstParameter(method, GuildMessageEvent.class))
+			if (!ReflectionUtils.hasFirstParameter(method, GlobalMessageEvent.class) && !ReflectionUtils.hasFirstParameter(method, GuildMessageEvent.class))
 				throw new IllegalArgumentException("Message command at " + Utils.formatMethodShort(method) + " must have a GuildMessageEvent or GlobalMessageEvent as first parameter");
 
-			if (!Utils.hasFirstParameter(method, GuildMessageEvent.class)) {
+			if (!ReflectionUtils.hasFirstParameter(method, GuildMessageEvent.class)) {
 				//If type is correct but guild specialization isn't used
 				LOGGER.warn("Guild-only message command {} uses GlobalMessageEvent, consider using GuildMessageEvent to remove warnings related to guild stuff's nullability", Utils.formatMethodShort(method));
 			}
 		} else {
-			if (!Utils.hasFirstParameter(method, GlobalMessageEvent.class))
+			if (!ReflectionUtils.hasFirstParameter(method, GlobalMessageEvent.class))
 				throw new IllegalArgumentException("Message command at " + Utils.formatMethodShort(method) + " must have a GlobalMessageEvent as first parameter");
 		}
 
@@ -98,15 +99,15 @@ public final class ApplicationCommandsBuilder {
 
 	private void processSlashCommand(ApplicationCommand applicationCommand, Method method) {
 		if (method.getAnnotation(JDASlashCommand.class).guildOnly()) {
-			if (!Utils.hasFirstParameter(method, GlobalSlashEvent.class) && !Utils.hasFirstParameter(method, GuildSlashEvent.class))
+			if (!ReflectionUtils.hasFirstParameter(method, GlobalSlashEvent.class) && !ReflectionUtils.hasFirstParameter(method, GuildSlashEvent.class))
 				throw new IllegalArgumentException("Slash command at " + Utils.formatMethodShort(method) + " must have a GuildSlashEvent or GlobalSlashEvent as first parameter");
 
-			if (!Utils.hasFirstParameter(method, GuildSlashEvent.class)) {
+			if (!ReflectionUtils.hasFirstParameter(method, GuildSlashEvent.class)) {
 				//If type is correct but guild specialization isn't used
 				LOGGER.warn("Guild-only slash command {} uses GlobalSlashEvent, consider using GuildSlashEvent to remove warnings related to guild stuff's nullability", Utils.formatMethodShort(method));
 			}
 		} else {
-			if (!Utils.hasFirstParameter(method, GlobalSlashEvent.class))
+			if (!ReflectionUtils.hasFirstParameter(method, GlobalSlashEvent.class))
 				throw new IllegalArgumentException("Slash command at " + Utils.formatMethodShort(method) + " must have a GlobalSlashEvent as first parameter");
 		}
 

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsBuilder.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.application;
 
 import com.freya02.botcommands.api.application.ApplicationCommand;
+import com.freya02.botcommands.api.application.CommandUpdateResult;
 import com.freya02.botcommands.api.application.context.annotations.JDAMessageCommand;
 import com.freya02.botcommands.api.application.context.annotations.JDAUserCommand;
 import com.freya02.botcommands.api.application.context.message.GlobalMessageEvent;
@@ -20,6 +21,7 @@ import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.sharding.ShardManager;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.tuple.ImmutablePair;
 import org.jetbrains.annotations.NotNull;
@@ -28,12 +30,17 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public final class ApplicationCommandsBuilder {
 	private static final Logger LOGGER = Logging.getLogger();
+	private final ExecutorService es = Executors.newFixedThreadPool(Math.min(4, Runtime.getRuntime().availableProcessors()));
 	private final BContextImpl context;
 	private final List<Long> slashGuildIds;
 
@@ -130,14 +137,78 @@ public final class ApplicationCommandsBuilder {
 			LOGGER.debug("Global commands does not have to be updated");
 		}
 
-		final List<Guild> guildCache;
-		if (context.getJDA().getShardManager() != null) {
-			guildCache = context.getJDA().getShardManager().getGuilds();
+		final Map<Guild, CompletableFuture<CommandUpdateResult>> map;
+		final ShardManager shardManager = context.getJDA().getShardManager();
+		if (shardManager != null) {
+			map = scheduleApplicationCommandsUpdate(shardManager.getGuildCache());
 		} else {
-			guildCache = context.getJDA().getGuilds();
+			map = scheduleApplicationCommandsUpdate(context.getJDA().getGuildCache());
 		}
 
-		tryUpdateGuildCommands(guildCache);
+		map.forEach((guild, future) -> {
+			future.whenComplete((result, throwable) -> {
+				if (throwable != null) {
+					ErrorResponseException e = Utils.getErrorResponseException(throwable);
+
+					if (e != null && e.getErrorResponse() == ErrorResponse.MISSING_ACCESS) {
+						final String inviteUrl = context.getJDA().getInviteUrl() + "&guild_id=" + guild.getId();
+
+						LOGGER.warn("Could not register guild commands for guild '{}' ({}) as it appears the OAuth2 grants misses applications.commands, you can re-invite the bot in this guild with its already existing permission with this link: {}", guild.getName(), guild.getId(), inviteUrl);
+						context.getRegistrationListeners().forEach(r -> r.onGuildSlashCommandMissingAccess(guild, inviteUrl));
+					} else {
+						LOGGER.error("Encountered an exception while updating commands for guild '{}' ({})", guild.getName(), guild.getId(), e);
+					}
+				}
+			});
+		});
+	}
+
+	@NotNull
+	public Map<Guild, CompletableFuture<CommandUpdateResult>> scheduleApplicationCommandsUpdate(@NotNull Iterable<Guild> guilds) throws IOException {
+		final Map<Guild, CompletableFuture<CommandUpdateResult>> map = new HashMap<>();
+
+		for (Guild guild : guilds) {
+			if (!slashGuildIds.isEmpty() && !slashGuildIds.contains(guild.getIdLong())) continue;
+
+			map.put(guild, scheduleApplicationCommandsUpdate(guild));
+		}
+
+		return map;
+	}
+
+	@NotNull
+	public CompletableFuture<CommandUpdateResult> scheduleApplicationCommandsUpdate(Guild guild) throws IOException {
+		final ApplicationCommandsUpdater updater = ApplicationCommandsUpdater.ofGuild(context, guild);
+
+		return CompletableFuture.supplyAsync(() -> {
+			try {
+				boolean updatedCommands = false, updatedPrivileges = false;
+
+				if (updater.shouldUpdateCommands()) {
+					updater.updateCommands().get();
+
+					updatedCommands = true;
+
+					LOGGER.debug("Guild '{}' ({}) commands were updated", guild.getName(), guild.getId());
+				} else {
+					LOGGER.debug("Guild '{}' ({}) commands does not have to be updated", guild.getName(), guild.getId());
+				}
+
+				if (updater.shouldUpdatePrivileges()) {
+					updater.updatePrivileges();
+
+					updatedPrivileges = true;
+
+					LOGGER.debug("Guild '{}' ({}) commands privileges were updated", guild.getName(), guild.getId());
+				} else {
+					LOGGER.debug("Guild '{}' ({}) commands privileges does not have to be updated", guild.getName(), guild.getId());
+				}
+
+				return new CommandUpdateResult(guild, updatedCommands, updatedPrivileges);
+			} catch (Throwable e) {
+				throw new RuntimeException("An exception occurred while updating guild commands for guild '" + guild.getName() + "' (" + guild.getId() + ")", e);
+			}
+		}, es);
 	}
 
 	public boolean tryUpdateGuildCommands(Iterable<Guild> guilds) throws IOException {

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsCache.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsCache.java
@@ -1,19 +1,24 @@
 package com.freya02.botcommands.internal.application;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.internal.BContextImpl;
+import com.google.gson.Gson;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.interactions.commands.privileges.CommandPrivilege;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public class ApplicationCommandsCache {
+	private static final Logger LOGGER = Logging.getLogger();
 	private final Path cachePath;
 
 	ApplicationCommandsCache(BContextImpl context) throws IOException {
@@ -22,16 +27,10 @@ public class ApplicationCommandsCache {
 		Files.createDirectories(cachePath);
 	}
 
-	Path getGlobalCommandsPath() {
-		return cachePath.resolve("globalCommands.json");
-	}
+	public void deleteGuildCache(Guild guild) throws IOException {
+		final Path path = getGuildCommandsPath(guild);
 
-	Path getGuildCommandsPath(Guild guild) {
-		return cachePath.resolve(guild.getId()).resolve("commands.json");
-	}
-
-	Path getGuildPrivilegesPath(Guild guild) {
-		return cachePath.resolve(guild.getId()).resolve("privileges.json");
+		Files.deleteIfExists(path);
 	}
 
 	static byte[] getCommandsBytes(Collection<CommandData> commandData) {
@@ -53,5 +52,74 @@ public class ApplicationCommandsCache {
 		});
 
 		return array.toJson();
+	}
+
+	public static boolean isJsonContentSame(byte[] oldContentBytes, byte[] newContentBytes) {
+		final String oldContent = new String(oldContentBytes);
+		final String newContent = new String(newContentBytes);
+
+		final Object oldMap = new Gson().fromJson(oldContent, Object.class);
+		final Object newMap = new Gson().fromJson(newContent, Object.class);
+
+		return checkDiff(oldMap, newMap);
+	}
+
+	@SuppressWarnings("SuspiciousMethodCalls")
+	private static boolean checkDiff(Object oldObj, Object newObj) {
+		if (oldObj.getClass() != newObj.getClass()) {
+			LOGGER.trace("Class type not equal: {} to {}", oldObj.getClass().getSimpleName(), newObj.getClass().getSimpleName());
+
+			return false;
+		}
+
+		if (oldObj instanceof Map<?, ?> oldMap && newObj instanceof Map<?, ?> newMap) {
+			if (!oldMap.keySet().containsAll(newMap.keySet())) return false;
+
+			for (Object key : oldMap.keySet()) {
+				if (!checkDiff(oldMap.get(key), newMap.get(key))) {
+					LOGGER.trace("Map value not equal for key '{}': {} to {}", key, oldMap.get(key), newMap.get(key));
+
+					return false;
+				}
+			}
+		} else if (oldObj instanceof List<?> oldList && newObj instanceof List<?> newList) {
+			if (oldList.size() != newList.size()) return false;
+
+			for (int i = 0; i < oldList.size(); i++) {
+				final int index = newList.indexOf(oldList.get(i));
+				if (index > -1) {
+					//Not a change - don't log it
+//					LOGGER.trace("Found exact object at index {} (original object at {}) : {}", index, i, oldList.get(i));
+
+					continue;
+				}
+
+				if (!checkDiff(oldList.get(i), newList.get(i))) {
+					LOGGER.trace("List item not equal: {} to {}", oldList.get(i), newList.get(i));
+
+					return false;
+				}
+			}
+		} else {
+			final boolean equals = oldObj.equals(newObj);
+
+			if (!equals) LOGGER.trace("Not same object: {} to {}", oldObj, newObj);
+
+			return equals;
+		}
+
+		return true;
+	}
+
+	Path getGlobalCommandsPath() {
+		return cachePath.resolve("globalCommands.json");
+	}
+
+	Path getGuildCommandsPath(Guild guild) {
+		return cachePath.resolve(guild.getId()).resolve("commands.json");
+	}
+
+	Path getGuildPrivilegesPath(Guild guild) {
+		return cachePath.resolve(guild.getId()).resolve("privileges.json");
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsUpdater.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsUpdater.java
@@ -153,7 +153,7 @@ public class ApplicationCommandsUpdater {
 	}
 
 	private void computeCommands() {
-		final List<ApplicationCommandInfo> guildApplicationCommands = context.getApplicationCommands().stream()
+		final List<ApplicationCommandInfo> guildApplicationCommands = context.getApplicationCommandsView().stream()
 				.filter(info -> {
 					if (info.isGuildOnly() && guild == null) { //Do not update guild-only commands in global context
 						return false;

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsUpdater.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsUpdater.java
@@ -7,6 +7,7 @@ import com.freya02.botcommands.internal.BContextImpl;
 import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
 import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
+import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.CommandType;
@@ -254,7 +255,7 @@ public class ApplicationCommandsUpdater {
 							}
 						}
 					} catch (Exception e) {
-						throw new RuntimeException("An exception occurred while processing command " + notLocalizedPath, e);
+						throw new RuntimeException("An exception occurred while processing command '" + notLocalizedPath + "' at " + Utils.formatMethodShort(info.getCommandMethod()), e);
 					}
 				});
 	}

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsUpdater.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsUpdater.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.interactions.commands.build.SubcommandGroupData;
 import net.dv8tion.jda.api.interactions.commands.privileges.CommandPrivilege;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -28,7 +29,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -52,6 +52,7 @@ public class ApplicationCommandsUpdater {
 	private final Map<String, String> localizedBaseNameToBaseName = new HashMap<>();
 	private final Map<String, Collection<? extends CommandPrivilege>> cmdIdToPrivilegesMap = new HashMap<>();
 	private final Map<String, Collection<? extends CommandPrivilege>> cmdBaseNameToPrivilegesMap = new HashMap<>();
+	private final Collection<CommandData> allCommandData;
 
 	private ApplicationCommandsUpdater(@NotNull BContextImpl context, @Nullable Guild guild) throws IOException {
 		this.context = context;
@@ -72,6 +73,8 @@ public class ApplicationCommandsUpdater {
 		}
 
 		computeCommands();
+
+		this.allCommandData = map.getAllCommandData();
 	}
 
 	public static ApplicationCommandsUpdater ofGlobal(@NotNull BContextImpl context) throws IOException {
@@ -88,24 +91,40 @@ public class ApplicationCommandsUpdater {
 	}
 
 	public boolean shouldUpdateCommands() throws IOException {
-		if (Files.notExists(commandsCachePath)) return true;
+		if (Files.notExists(commandsCachePath)) {
+			LOGGER.trace("Updating commands because cache file does not exists");
+
+			return true;
+		}
 
 		final byte[] oldBytes = Files.readAllBytes(commandsCachePath);
-		final byte[] newBytes = ApplicationCommandsCache.getCommandsBytes(map.getAllCommandData());
+		final byte[] newBytes = ApplicationCommandsCache.getCommandsBytes(allCommandData);
 
-		return !Arrays.equals(oldBytes, newBytes);
+		final boolean needUpdate = !ApplicationCommandsCache.isJsonContentSame(oldBytes, newBytes);
+
+		if (needUpdate) {
+			LOGGER.trace("Updating commands because content is not equal");
+
+//			LOGGER.trace("Old commands bytes: {}", new String(oldBytes));
+//			LOGGER.trace("New commands bytes: {}", new String(newBytes));
+		}
+
+		return needUpdate;
 	}
 
-	public CompletableFuture<?> updateCommands() {
-		final Collection<CommandData> commandData = map.getAllCommandData();
-
+	@Blocking
+	public void updateCommands() {
 		final CommandListUpdateAction updateAction = guild != null ? guild.updateCommands() : context.getJDA().updateCommands();
 
-		final CompletableFuture<List<Command>> future = updateAction
-				.addCommands(commandData)
-				.submit();
+		final List<Command> commands = updateAction
+				.addCommands(allCommandData)
+				.complete();
 
-		return guild != null ? thenAcceptGuild(commandData, future, guild) : thenAcceptGlobal(commandData, future);
+		if (guild != null) {
+			thenAcceptGuild(commands, guild);
+		} else {
+			thenAcceptGlobal(commands);
+		}
 	}
 
 	public boolean shouldUpdatePrivileges() throws IOException {
@@ -113,29 +132,46 @@ public class ApplicationCommandsUpdater {
 
 		if (!commands.isEmpty()) return true; //If the list is not empty, this means commands got updated, so the ids changed
 
-		if (Files.notExists(privilegesCachePath)) return true;
+		if (Files.notExists(privilegesCachePath)) {
+			LOGGER.trace("Updating privileges because privilege cache does not exists");
+
+			return true;
+		}
 
 		final byte[] oldBytes = Files.readAllBytes(privilegesCachePath);
 		final byte[] newBytes = ApplicationCommandsCache.getPrivilegesBytes(cmdBaseNameToPrivilegesMap);
 
-		return !Arrays.equals(oldBytes, newBytes);
+		final boolean needUpdate = !ApplicationCommandsCache.isJsonContentSame(oldBytes, newBytes);
+
+		if (needUpdate) {
+			LOGGER.trace("Updating privileges because content is not equal");
+
+//			LOGGER.trace("Old privileges bytes: {}", new String(oldBytes));
+//			LOGGER.trace("New privileges bytes: {}", new String(newBytes));
+		}
+
+		return needUpdate;
 	}
 
-	public CompletableFuture<?> updatePrivileges() {
+	@Blocking
+	public void updatePrivileges() {
 		if (guild == null) {
-			return CompletableFuture.completedFuture(null);
+			return;
 		}
 
 		if (commands.isEmpty()) {
 			LOGGER.info("Privileges has changed but commands were not updated, retrieving current command list");
 
-			return guild.retrieveCommands().submit().thenApply(retrievedCommands -> updatePrivileges0(guild, retrievedCommands));
+			final List<Command> retrievedCommands = guild.retrieveCommands().complete();
+
+			updatePrivileges0(guild, retrievedCommands);
 		} else {
-			return updatePrivileges0(guild, commands);
+			updatePrivileges0(guild, commands);
 		}
 	}
 
-	private CompletableFuture<?> updatePrivileges0(@NotNull Guild guild, @NotNull List<Command> commands) {
+	@Blocking
+	private void updatePrivileges0(@NotNull Guild guild, @NotNull List<Command> commands) {
 		for (Command command : commands) {
 			final Collection<? extends CommandPrivilege> privileges = cmdBaseNameToPrivilegesMap.get(localizedBaseNameToBaseName.get(command.getName()));
 
@@ -144,13 +180,13 @@ public class ApplicationCommandsUpdater {
 			}
 		}
 
-		return guild.updateCommandPrivileges(cmdIdToPrivilegesMap).submit().thenAccept(privilegesMap -> {
-			try {
-				Files.write(privilegesCachePath, ApplicationCommandsCache.getPrivilegesBytes(cmdBaseNameToPrivilegesMap), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-			} catch (IOException e) {
-				LOGGER.error("An exception occurred while temporarily saving guild ({} ({})) command privileges", guild.getName(), guild.getId(), e);
-			}
-		});
+		guild.updateCommandPrivileges(cmdIdToPrivilegesMap).complete();
+
+		try {
+			Files.write(privilegesCachePath, ApplicationCommandsCache.getPrivilegesBytes(cmdBaseNameToPrivilegesMap), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+		} catch (IOException e) {
+			LOGGER.error("An exception occurred while temporarily saving guild ({} ({})) command privileges", guild.getName(), guild.getId(), e);
+		}
 	}
 
 	private void computeCommands() {
@@ -315,53 +351,49 @@ public class ApplicationCommandsUpdater {
 		return List.of();
 	}
 
-	private CompletableFuture<?> thenAcceptGuild(Collection<CommandData> commandData, CompletableFuture<List<Command>> future, @NotNull Guild guild) {
-		return future.thenAccept(commands -> {
-			for (Command command : commands) {
-				if (command instanceof SlashCommand) {
-					context.getRegistrationListeners().forEach(l -> l.onGuildSlashCommandRegistered(this.guild, (SlashCommand) command));
-				}
+	private void thenAcceptGuild(List<Command> commands, @NotNull Guild guild) {
+		for (Command command : commands) {
+			if (command instanceof SlashCommand) {
+				context.getRegistrationListeners().forEach(l -> l.onGuildSlashCommandRegistered(this.guild, (SlashCommand) command));
 			}
+		}
 
-			this.commands.addAll(commands);
+		this.commands.addAll(commands);
 
-			try {
-				Files.write(commandsCachePath, ApplicationCommandsCache.getCommandsBytes(commandData), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-			} catch (IOException e) {
-				LOGGER.error("An exception occurred while temporarily saving guild ({} ({})) commands in '{}'", guild.getName(), guild.getId(), commandsCachePath.toAbsolutePath(), e);
-			}
+		try {
+			Files.write(commandsCachePath, ApplicationCommandsCache.getCommandsBytes(allCommandData), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+		} catch (IOException e) {
+			LOGGER.error("An exception occurred while temporarily saving guild ({} ({})) commands in '{}'", guild.getName(), guild.getId(), commandsCachePath.toAbsolutePath(), e);
+		}
 
-			if (!LOGGER.isTraceEnabled()) return;
+		if (!LOGGER.isTraceEnabled()) return;
 
-			final StringBuilder sb = new StringBuilder("Updated commands for ");
-			sb.append(guild.getName()).append(" :\n");
-			appendCommands(commands, sb);
+		final StringBuilder sb = new StringBuilder("Updated " + commands.size() + " / " + allCommandData.size() + " ( " + context.getApplicationCommandsView().size() + ") commands for ");
+		sb.append(guild.getName()).append(" :\n");
+		appendCommands(commands, sb);
 
-			LOGGER.trace(sb.toString().trim());
-		});
+		LOGGER.trace(sb.toString().trim());
 	}
 
-	private CompletableFuture<?> thenAcceptGlobal(Collection<CommandData> commandData, CompletableFuture<List<Command>> future) {
-		return future.thenAccept(commands -> {
-			for (Command command : commands) {
-				if (command instanceof SlashCommand) {
-					context.getRegistrationListeners().forEach(l -> l.onGlobalSlashCommandRegistered((SlashCommand) command));
-				}
+	private void thenAcceptGlobal(List<Command> commands) {
+		for (Command command : commands) {
+			if (command instanceof SlashCommand) {
+				context.getRegistrationListeners().forEach(l -> l.onGlobalSlashCommandRegistered((SlashCommand) command));
 			}
+		}
 
-			try {
-				Files.write(commandsCachePath, ApplicationCommandsCache.getCommandsBytes(commandData), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-			} catch (IOException e) {
-				LOGGER.error("An exception occurred while temporarily saving {} commands in '{}'", guild == null ? "global" : String.format("guild '%s' (%s)", guild.getName(), guild.getId()), commandsCachePath.toAbsolutePath(), e);
-			}
+		try {
+			Files.write(commandsCachePath, ApplicationCommandsCache.getCommandsBytes(allCommandData), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+		} catch (IOException e) {
+			LOGGER.error("An exception occurred while temporarily saving {} commands in '{}'", guild == null ? "global" : String.format("guild '%s' (%s)", guild.getName(), guild.getId()), commandsCachePath.toAbsolutePath(), e);
+		}
 
-			if (!LOGGER.isTraceEnabled()) return;
+		if (!LOGGER.isTraceEnabled()) return;
 
-			final StringBuilder sb = new StringBuilder("Updated global commands:\n");
-			appendCommands(commands, sb);
+		final StringBuilder sb = new StringBuilder("Updated global commands:\n");
+		appendCommands(commands, sb);
 
-			LOGGER.trace(sb.toString().trim());
-		});
+		LOGGER.trace(sb.toString().trim());
 	}
 
 	//See how to integrate this step on the command build in order to use localized base names instead of resolving the not-localized one

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsUpdater.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsUpdater.java
@@ -153,24 +153,7 @@ public class ApplicationCommandsUpdater {
 	}
 
 	private void computeCommands() {
-		final List<ApplicationCommandInfo> guildApplicationCommands = context.getApplicationCommandsView().stream()
-				.filter(info -> {
-					if (info.isGuildOnly() && guild == null) { //Do not update guild-only commands in global context
-						return false;
-					} else if (!info.isGuildOnly() && guild != null) { //Do not update global commands in guild context
-						return false;
-					}
-
-					//Get the actual usable commands in this context (dm or guild)
-					if (guild == null) return true;
-
-					final SettingsProvider settingsProvider = context.getSettingsProvider();
-					if (settingsProvider == null) return true; //If no settings, assume it's not filtered
-
-					return settingsProvider.getGuildCommands(guild).getFilter().test(info.getPath());
-				})
-				.sorted(Comparator.comparingInt(info -> info.getPath().getNameCount()))
-				.collect(Collectors.toCollection(ArrayList::new)); //Ensure spliterator is ORDERED for future Stream usage
+		final List<ApplicationCommandInfo> guildApplicationCommands = context.getApplicationCommandInfoMap().filterByGuild(context, guild);
 
 		computeSlashCommands(guildApplicationCommands);
 

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsUpdater.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationCommandsUpdater.java
@@ -1,9 +1,9 @@
 package com.freya02.botcommands.internal.application;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.SettingsProvider;
 import com.freya02.botcommands.api.application.CommandPath;
 import com.freya02.botcommands.internal.BContextImpl;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.application.context.message.MessageCommandInfo;
 import com.freya02.botcommands.internal.application.context.user.UserCommandInfo;
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationUpdaterListener.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationUpdaterListener.java
@@ -1,7 +1,7 @@
 package com.freya02.botcommands.internal.application;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.internal.BContextImpl;
-import com.freya02.botcommands.internal.Logging;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.GuildAvailableEvent;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationUpdaterListener.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationUpdaterListener.java
@@ -5,7 +5,7 @@ import com.freya02.botcommands.internal.BContextImpl;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.GuildAvailableEvent;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
-import net.dv8tion.jda.api.events.guild.member.GuildMemberUpdateEvent;
+import net.dv8tion.jda.api.events.guild.member.update.GenericGuildMemberUpdateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -36,7 +36,7 @@ public class ApplicationUpdaterListener extends ListenerAdapter {
 	}
 
 	@Override
-	public void onGuildMemberUpdate(@NotNull GuildMemberUpdateEvent event) {
+	public void onGenericGuildMemberUpdate(@NotNull GenericGuildMemberUpdateEvent event) {
 		if (event.getMember().getIdLong() == event.getJDA().getSelfUser().getIdLong()) {
 			tryUpdate(event.getGuild());
 		}

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationUpdaterListener.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationUpdaterListener.java
@@ -5,21 +5,20 @@ import com.freya02.botcommands.internal.BContextImpl;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.GuildAvailableEvent;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
-import net.dv8tion.jda.api.events.guild.member.update.GenericGuildMemberUpdateEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberUpdateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ApplicationUpdaterListener extends ListenerAdapter {
 	private static final Logger LOGGER = Logging.getLogger();
-	private final BContextImpl context;
 
-	private final List<Long> updatedJoinedGuilds = new ArrayList<>();
+	private final BContextImpl context;
+	private final Set<Long> failedGuilds = Collections.synchronizedSet(new HashSet<>());
 
 	public ApplicationUpdaterListener(BContextImpl context) {
 		this.context = context;
@@ -27,32 +26,33 @@ public class ApplicationUpdaterListener extends ListenerAdapter {
 
 	@Override
 	public void onGuildAvailable(@NotNull GuildAvailableEvent event) {
-		tryUpdate(event.getGuild());
+		tryUpdate(event.getGuild(), true);
 	}
 
 	@Override
 	public void onGuildJoin(@NotNull GuildJoinEvent event) {
-		tryUpdate(event.getGuild());
+		tryUpdate(event.getGuild(), true);
 	}
 
+	//Use this as a mean to detect OAuth scope changes
 	@Override
-	public void onGenericGuildMemberUpdate(@NotNull GenericGuildMemberUpdateEvent event) {
+	public void onGuildMemberUpdate(@NotNull GuildMemberUpdateEvent event) {
 		if (event.getMember().getIdLong() == event.getJDA().getSelfUser().getIdLong()) {
-			tryUpdate(event.getGuild());
+			tryUpdate(event.getGuild(), false);
 		}
 	}
 
-	private void tryUpdate(Guild guild) {
-		synchronized (updatedJoinedGuilds) {
-			if (updatedJoinedGuilds.contains(guild.getIdLong())) return;
+	private void tryUpdate(Guild guild, boolean force) {
+		final boolean hadFailed = failedGuilds.remove(guild.getIdLong());
 
-			updatedJoinedGuilds.add(guild.getIdLong());
-		}
+		context.getSlashCommandsBuilder()
+				.scheduleApplicationCommandsUpdate(guild, force || hadFailed)
+				.whenCompleteAsync((commandUpdateResult, e) -> {
+			if (e != null) {
+				failedGuilds.add(guild.getIdLong());
 
-		try {
-			context.scheduleApplicationCommandsUpdate(Collections.singleton(guild));
-		} catch (IOException e) {
-			LOGGER.error("An error occurred while updating guild '{}' ({}) commands (on guild join / on unavailable guild join but became available later)", guild.getName(), guild.getIdLong(), e);
-		}
+				context.getSlashCommandsBuilder().handleApplicationUpdateException(guild, e);
+			}
+		});
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/application/ApplicationUpdaterListener.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/ApplicationUpdaterListener.java
@@ -5,6 +5,7 @@ import com.freya02.botcommands.internal.Logging;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.GuildAvailableEvent;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberUpdateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -34,6 +35,13 @@ public class ApplicationUpdaterListener extends ListenerAdapter {
 		tryUpdate(event.getGuild());
 	}
 
+	@Override
+	public void onGuildMemberUpdate(@NotNull GuildMemberUpdateEvent event) {
+		if (event.getMember().getIdLong() == event.getJDA().getSelfUser().getIdLong()) {
+			tryUpdate(event.getGuild());
+		}
+	}
+
 	private void tryUpdate(Guild guild) {
 		synchronized (updatedJoinedGuilds) {
 			if (updatedJoinedGuilds.contains(guild.getIdLong())) return;
@@ -42,7 +50,7 @@ public class ApplicationUpdaterListener extends ListenerAdapter {
 		}
 
 		try {
-			context.tryUpdateGuildCommands(Collections.singleton(guild));
+			context.scheduleApplicationCommandsUpdate(Collections.singleton(guild));
 		} catch (IOException e) {
 			LOGGER.error("An error occurred while updating guild '{}' ({}) commands (on guild join / on unavailable guild join but became available later)", guild.getName(), guild.getIdLong(), e);
 		}

--- a/src/main/java/com/freya02/botcommands/internal/application/CommandInfoMap.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/CommandInfoMap.java
@@ -1,0 +1,110 @@
+package com.freya02.botcommands.internal.application;
+
+import com.freya02.botcommands.api.application.CommandPath;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+@SuppressWarnings({"EqualsWhichDoesntCheckParameterClass", "SuspiciousMethodCalls"})
+public class CommandInfoMap<T extends ApplicationCommandInfo> implements Map<CommandPath, T> {
+	private final Map<CommandPath, T> map;
+
+	public CommandInfoMap() {
+		map = new HashMap<>();
+	}
+
+	public CommandInfoMap(Map<CommandPath, T> map) {
+		this.map = map;
+	}
+
+	@UnmodifiableView
+	public CommandInfoMap<T> unmodifiable() {
+		return new CommandInfoMap<>(Collections.unmodifiableMap(map));
+	}
+
+	@Override
+	public int size() {return map.size();}
+
+	@Override
+	public boolean isEmpty() {return map.isEmpty();}
+
+	@Override
+	public boolean containsKey(Object key) {return map.containsKey(key);}
+
+	@Override
+	public boolean containsValue(Object value) {return map.containsValue(value);}
+
+	@Override
+	public T get(Object key) {return map.get(key);}
+
+	@Nullable
+	@Override
+	public T put(CommandPath key, T value) {return map.put(key, value);}
+
+	@Override
+	public T remove(Object key) {return map.remove(key);}
+
+	@Override
+	public void putAll(@NotNull Map<? extends CommandPath, ? extends T> m) {map.putAll(m);}
+
+	@Override
+	public void clear() {map.clear();}
+
+	@NotNull
+	@Override
+	public Set<CommandPath> keySet() {return map.keySet();}
+
+	@NotNull
+	@Override
+	public Collection<T> values() {return map.values();}
+
+	@NotNull
+	@Override
+	public Set<Entry<CommandPath, T>> entrySet() {return map.entrySet();}
+
+	@Override
+	public boolean equals(Object o) {return map.equals(o);}
+
+	@Override
+	public int hashCode() {return map.hashCode();}
+
+	@Override
+	public T getOrDefault(Object key, T defaultValue) {return map.getOrDefault(key, defaultValue);}
+
+	@Override
+	public void forEach(BiConsumer<? super CommandPath, ? super T> action) {map.forEach(action);}
+
+	@Override
+	public void replaceAll(BiFunction<? super CommandPath, ? super T, ? extends T> function) {map.replaceAll(function);}
+
+	@Nullable
+	@Override
+	public T putIfAbsent(CommandPath key, T value) {return map.putIfAbsent(key, value);}
+
+	@Override
+	public boolean remove(Object key, Object value) {return map.remove(key, value);}
+
+	@Override
+	public boolean replace(CommandPath key, T oldValue, T newValue) {return map.replace(key, oldValue, newValue);}
+
+	@Nullable
+	@Override
+	public T replace(CommandPath key, T value) {return map.replace(key, value);}
+
+	@Override
+	public T computeIfAbsent(CommandPath key, @NotNull Function<? super CommandPath, ? extends T> mappingFunction) {return map.computeIfAbsent(key, mappingFunction);}
+
+	@Override
+	public T computeIfPresent(CommandPath key, @NotNull BiFunction<? super CommandPath, ? super T, ? extends T> remappingFunction) {return map.computeIfPresent(key, remappingFunction);}
+
+	@Override
+	public T compute(CommandPath key, @NotNull BiFunction<? super CommandPath, ? super T, ? extends T> remappingFunction) {return map.compute(key, remappingFunction);}
+
+	@Override
+	public T merge(CommandPath key, @NotNull T value, @NotNull BiFunction<? super T, ? super T, ? extends T> remappingFunction) {return map.merge(key, value, remappingFunction);}
+}

--- a/src/main/java/com/freya02/botcommands/internal/application/CommandParameter.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/CommandParameter.java
@@ -4,6 +4,7 @@ import com.freya02.botcommands.api.parameters.CustomResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolvers;
 import com.freya02.botcommands.internal.utils.AnnotationUtils;
+import com.freya02.botcommands.internal.utils.ReflectionUtils;
 import com.freya02.botcommands.internal.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,7 +27,7 @@ public class CommandParameter<RESOLVER> {
 		this.boxedType = Utils.getBoxedType(parameter.getType());
 		this.index = index;
 
-		this.optional = Utils.isOptional(parameter);
+		this.optional = ReflectionUtils.isOptional(parameter);
 		this.isPrimitive = parameter.getType().isPrimitive();
 
 		final ParameterResolver resolver = ParameterResolvers.of(this.boxedType);

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandInfo.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandInfo.java
@@ -4,12 +4,12 @@ import com.freya02.botcommands.api.BContext;
 import com.freya02.botcommands.api.application.ApplicationCommand;
 import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
 import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
-import com.freya02.botcommands.api.prefixed.annotations.TextOption;
 import com.freya02.botcommands.internal.ApplicationOptionData;
 import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.MethodParameters;
 import com.freya02.botcommands.internal.application.ApplicationCommandInfo;
 import com.freya02.botcommands.internal.utils.Utils;
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
@@ -52,9 +52,6 @@ public class SlashCommandInfo extends ApplicationCommandInfo {
 
 		this.instance = instance;
 		this.commandParameters = MethodParameters.of(commandMethod, (parameter, i) -> {
-			if (parameter.isAnnotationPresent(TextOption.class))
-				throw new IllegalArgumentException(String.format("Slash command parameter #%d of %s#%s cannot be annotated with @TextOption", i, commandMethod.getDeclaringClass().getName(), commandMethod.getName()));
-
 			final Class<?> type = parameter.getType();
 
 			if (Member.class.isAssignableFrom(type)
@@ -94,7 +91,7 @@ public class SlashCommandInfo extends ApplicationCommandInfo {
 		}};
 
 		int optionIndex = 0;
-		final List<String> optionNames = event.getGuild() != null ? localizedOptionMap.get(event.getGuild().getIdLong()) : null;
+		final List<String> optionNames = event.getGuild() != null ? getLocalizedOptions(event.getGuild()) : null;
 		for (final SlashCommandParameter parameter : commandParameters) {
 			final ApplicationOptionData applicationOptionData = parameter.getApplicationOptionData();
 
@@ -161,12 +158,16 @@ public class SlashCommandInfo extends ApplicationCommandInfo {
 		return true;
 	}
 
+	public List<String> getLocalizedOptions(@NotNull Guild guild) {
+		return localizedOptionMap.get(guild.getIdLong());
+	}
+
 	@Nullable
 	public String getAutocompletionHandlerName(CommandAutoCompleteEvent event) {
 		final OptionMapping focusedOption = event.getFocusedOptionType();
 
 		int optionIndex = 0;
-		final List<String> optionNames = event.getGuild() != null ? localizedOptionMap.get(event.getGuild().getIdLong()) : null;
+		final List<String> optionNames = event.getGuild() != null ? getLocalizedOptions(event.getGuild()) : null;
 		for (final SlashCommandParameter parameter : commandParameters) {
 			final ApplicationOptionData applicationOptionData = parameter.getApplicationOptionData();
 
@@ -190,5 +191,11 @@ public class SlashCommandInfo extends ApplicationCommandInfo {
 	@Override
 	public MethodParameters<SlashCommandParameter> getParameters() {
 		return commandParameters;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public List<? extends SlashCommandParameter> getOptionParameters() {
+		return (List<? extends SlashCommandParameter>) super.getOptionParameters();
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandInfo.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandInfo.java
@@ -13,9 +13,11 @@ import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.interaction.CommandAutoCompleteEvent;
 import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.lang.reflect.Method;
@@ -26,13 +28,17 @@ import java.util.Map;
 
 public class SlashCommandInfo extends ApplicationCommandInfo {
 	private static final Logger LOGGER = Logging.getLogger();
-	/** This is NOT localized */
+	/**
+	 * This is NOT localized
+	 */
 	private final String description;
 
 	private final Object instance;
 	private final MethodParameters<SlashCommandParameter> commandParameters;
 
-	/** guild id => localized option names */
+	/**
+	 * guild id => localized option names
+	 */
 	private final Map<Long, List<String>> localizedOptionMap = new HashMap<>();
 
 	public SlashCommandInfo(ApplicationCommand instance, Method commandMethod) {
@@ -53,7 +59,7 @@ public class SlashCommandInfo extends ApplicationCommandInfo {
 
 			if (Member.class.isAssignableFrom(type)
 					|| Role.class.isAssignableFrom(type)
-					|| GuildChannel.class.isAssignableFrom(type) ) {
+					|| GuildChannel.class.isAssignableFrom(type)) {
 				if (!annotation.guildOnly())
 					throw new IllegalArgumentException("The slash command " + Utils.formatMethodShort(commandMethod) + " cannot have a " + type.getSimpleName() + " parameter as it is not guild-only");
 			}
@@ -61,16 +67,19 @@ public class SlashCommandInfo extends ApplicationCommandInfo {
 			return new SlashCommandParameter(parameter, i);
 		});
 
-		if (!annotation.group().isBlank() && annotation.subcommand().isBlank()) throw new IllegalArgumentException("Command group for " + Utils.formatMethodShort(commandMethod) + " is present but has no subcommand");
+		if (!annotation.group().isBlank() && annotation.subcommand().isBlank())
+			throw new IllegalArgumentException("Command group for " + Utils.formatMethodShort(commandMethod) + " is present but has no subcommand");
 
 		this.description = annotation.description();
 	}
-	
+
 	public void putLocalizedOptions(long guildId, @NotNull List<String> optionNames) {
 		localizedOptionMap.put(guildId, optionNames);
 	}
 
-	/** This is NOT localized */
+	/**
+	 * This is NOT localized
+	 */
 	public String getDescription() {
 		return description;
 	}
@@ -110,7 +119,7 @@ public class SlashCommandInfo extends ApplicationCommandInfo {
 
 						continue;
 					} else {
-						throw new RuntimeException("Slash parameter couldn't be resolved for method " + Utils.formatMethodShort(commandMethod) + " at parameter " + applicationOptionData.getEffectiveName());
+						throw new RuntimeException("Slash parameter couldn't be resolved for method " + Utils.formatMethodShort(commandMethod) + " at parameter " + applicationOptionData.getEffectiveName() + " (localized '" + optionName + "'");
 					}
 				}
 
@@ -150,6 +159,32 @@ public class SlashCommandInfo extends ApplicationCommandInfo {
 		commandMethod.invoke(instance, objects.toArray());
 
 		return true;
+	}
+
+	@Nullable
+	public String getAutocompletionHandlerName(CommandAutoCompleteEvent event) {
+		final OptionMapping focusedOption = event.getFocusedOptionType();
+
+		int optionIndex = 0;
+		final List<String> optionNames = event.getGuild() != null ? localizedOptionMap.get(event.getGuild().getIdLong()) : null;
+		for (final SlashCommandParameter parameter : commandParameters) {
+			final ApplicationOptionData applicationOptionData = parameter.getApplicationOptionData();
+
+			if (parameter.isOption()) {
+				final String optionName = optionNames == null ? applicationOptionData.getEffectiveName() : optionNames.get(optionIndex);
+				if (optionName == null) {
+					throw new IllegalArgumentException(String.format("Option name #%d (%s) could not be resolved for %s", optionIndex, applicationOptionData.getEffectiveName(), Utils.formatMethodShort(getCommandMethod())));
+				}
+
+				optionIndex++;
+
+				if (optionName.equals(focusedOption.getName())) {
+					return applicationOptionData.getAutocompletionHandlerName();
+				}
+			}
+		}
+
+		return null;
 	}
 
 	@Override

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandInfo.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandInfo.java
@@ -1,11 +1,11 @@
 package com.freya02.botcommands.internal.application.slash;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.application.ApplicationCommand;
 import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
 import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
 import com.freya02.botcommands.internal.ApplicationOptionData;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.MethodParameters;
 import com.freya02.botcommands.internal.application.ApplicationCommandInfo;
 import com.freya02.botcommands.internal.utils.Utils;

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandParameter.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandParameter.java
@@ -1,12 +1,41 @@
 package com.freya02.botcommands.internal.application.slash;
 
+import com.freya02.botcommands.api.application.slash.annotations.DoubleRange;
+import com.freya02.botcommands.api.application.slash.annotations.LongRange;
 import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import com.freya02.botcommands.internal.application.ApplicationCommandParameter;
+import com.freya02.botcommands.internal.utils.ReflectionUtils;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 
 import java.lang.reflect.Parameter;
 
 public class SlashCommandParameter extends ApplicationCommandParameter<SlashParameterResolver> {
+	private final Number minValue, maxValue;
+
 	public SlashCommandParameter(Parameter parameter, int index) {
 		super(SlashParameterResolver.class, parameter, index);
+
+		final LongRange longRange = ReflectionUtils.getLongRange(parameter);
+		if (longRange != null) {
+			minValue = longRange.from();
+			maxValue = longRange.to();
+		} else {
+			final DoubleRange doubleRange = ReflectionUtils.getDoubleRange(parameter);
+			if (doubleRange != null) {
+				minValue = doubleRange.from();
+				maxValue = doubleRange.to();
+			} else {
+				minValue = OptionData.MIN_NEGATIVE_NUMBER;
+				maxValue = OptionData.MAX_POSITIVE_NUMBER;
+			}
+		}
+	}
+
+	public Number getMinValue() {
+		return minValue;
+	}
+
+	public Number getMaxValue() {
+		return maxValue;
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandParameter.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandParameter.java
@@ -4,13 +4,18 @@ import com.freya02.botcommands.api.application.slash.annotations.DoubleRange;
 import com.freya02.botcommands.api.application.slash.annotations.LongRange;
 import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import com.freya02.botcommands.internal.application.ApplicationCommandParameter;
+import com.freya02.botcommands.internal.utils.AnnotationUtils;
 import com.freya02.botcommands.internal.utils.ReflectionUtils;
+import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 
 import java.lang.reflect.Parameter;
+import java.util.Collections;
+import java.util.EnumSet;
 
 public class SlashCommandParameter extends ApplicationCommandParameter<SlashParameterResolver> {
 	private final Number minValue, maxValue;
+	private final EnumSet<ChannelType> channelTypes = EnumSet.noneOf(ChannelType.class);
 
 	public SlashCommandParameter(Parameter parameter, int index) {
 		super(SlashParameterResolver.class, parameter, index);
@@ -29,6 +34,12 @@ public class SlashCommandParameter extends ApplicationCommandParameter<SlashPara
 				maxValue = OptionData.MAX_POSITIVE_NUMBER;
 			}
 		}
+
+		Collections.addAll(channelTypes, AnnotationUtils.getEffectiveChannelTypes(parameter));
+	}
+
+	public EnumSet<ChannelType> getChannelTypes() {
+		return channelTypes;
 	}
 
 	public Number getMinValue() {

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandParameter.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/SlashCommandParameter.java
@@ -3,6 +3,7 @@ package com.freya02.botcommands.internal.application.slash;
 import com.freya02.botcommands.api.application.slash.annotations.DoubleRange;
 import com.freya02.botcommands.api.application.slash.annotations.LongRange;
 import com.freya02.botcommands.api.parameters.SlashParameterResolver;
+import com.freya02.botcommands.api.prefixed.annotations.TextOption;
 import com.freya02.botcommands.internal.application.ApplicationCommandParameter;
 import com.freya02.botcommands.internal.utils.AnnotationUtils;
 import com.freya02.botcommands.internal.utils.ReflectionUtils;
@@ -19,6 +20,9 @@ public class SlashCommandParameter extends ApplicationCommandParameter<SlashPara
 
 	public SlashCommandParameter(Parameter parameter, int index) {
 		super(SlashParameterResolver.class, parameter, index);
+
+		if (parameter.isAnnotationPresent(TextOption.class))
+			throw new IllegalArgumentException(String.format("Slash command parameter #%d of %s#%s cannot be annotated with @TextOption", index, parameter.getDeclaringExecutable().getDeclaringClass().getName(), parameter.getDeclaringExecutable().getName()));
 
 		final LongRange longRange = ReflectionUtils.getLongRange(parameter);
 		if (longRange != null) {

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/SlashUtils.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/SlashUtils.java
@@ -7,6 +7,7 @@ import com.freya02.botcommands.internal.ApplicationOptionData;
 import com.freya02.botcommands.internal.application.ApplicationCommandInfo;
 import com.freya02.botcommands.internal.application.ApplicationCommandParameter;
 import com.freya02.botcommands.internal.application.LocalizedCommandData;
+import com.freya02.botcommands.internal.parameters.channels.AbstractChannelResolver;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.interactions.commands.Command;
@@ -59,8 +60,16 @@ public class SlashUtils {
 				data = new OptionData(OptionType.USER, name, description);
 			} else if (boxedType == Role.class) {
 				data = new OptionData(OptionType.ROLE, name, description);
-			} else if (boxedType == TextChannel.class) {
+			} else if (GuildChannel.class.isAssignableFrom(boxedType)) {
 				data = new OptionData(OptionType.CHANNEL, name, description);
+
+				if (parameter.getChannelTypes().isEmpty()) {
+					final AbstractChannelResolver<?> resolver = (AbstractChannelResolver<?>) parameter.getResolver();
+
+					data.setChannelTypes(resolver.getChannelType());
+				} else {
+					data.setChannelTypes(parameter.getChannelTypes());
+				}
 			} else if (boxedType == IMentionable.class) {
 				data = new OptionData(OptionType.MENTIONABLE, name, description);
 			} else if (boxedType == Boolean.class) {

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/SlashUtils.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/SlashUtils.java
@@ -67,8 +67,14 @@ public class SlashUtils {
 				data = new OptionData(OptionType.BOOLEAN, name, description);
 			} else if (boxedType == Long.class) {
 				data = new OptionData(OptionType.INTEGER, name, description);
+
+				data.setMinValue(parameter.getMinValue().longValue());
+				data.setMaxValue(parameter.getMaxValue().longValue());
 			} else if (boxedType == Double.class) {
 				data = new OptionData(OptionType.NUMBER, name, description);
+
+				data.setMinValue(parameter.getMinValue().doubleValue());
+				data.setMaxValue(parameter.getMaxValue().doubleValue());
 			} else if (ParameterResolvers.exists(boxedType)) {
 				data = new OptionData(OptionType.STRING, name, description);
 			} else {

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/SlashUtils.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/SlashUtils.java
@@ -75,16 +75,30 @@ public class SlashUtils {
 				throw new IllegalArgumentException("Unknown slash command option: " + boxedType.getName());
 			}
 
+			if (applicationOptionData.hasAutocompletion()) {
+				if (!data.getType().canSupportChoices()) {
+					throw new IllegalArgumentException("Slash command parameter #" + i + " of " + Utils.formatMethodShort(info.getCommandMethod()) + " does not support autocompletion");
+				}
+
+				data.setAutoComplete(true);
+			}
+
 			if (data.getType().canSupportChoices()) {
-				//choices might just be empty
-				if (optionsChoices.size() >= i) {
+				//optionChoices might just be empty
+				// choices of the option might also be empty as an empty list might be generated
+				// do not add choices if it's empty, to not trigger checks
+				if (optionsChoices.size() >= i && !optionsChoices.get(i - 1).isEmpty()) {
+					if (applicationOptionData.hasAutocompletion()) {
+						throw new IllegalArgumentException("Slash command parameter #" + i + " of " + Utils.formatMethodShort(info.getCommandMethod()) + " cannot have autocompletion and choices at the same time");
+					}
+
 					data.addChoices(optionsChoices.get(i - 1));
 				}
 			}
 
-			list.add(data);
-
 			data.setRequired(!parameter.isOptional());
+
+			list.add(data);
 
 			i++;
 		}

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlerInfo.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlerInfo.java
@@ -1,11 +1,11 @@
 package com.freya02.botcommands.internal.application.slash.autocomplete;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.application.slash.annotations.AutocompletionHandler;
 import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionMode;
 import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionTransformer;
 import com.freya02.botcommands.internal.ApplicationOptionData;
 import com.freya02.botcommands.internal.BContextImpl;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.MethodParameters;
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.application.slash.SlashCommandParameter;

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlerInfo.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlerInfo.java
@@ -3,7 +3,12 @@ package com.freya02.botcommands.internal.application.slash.autocomplete;
 import com.freya02.botcommands.api.application.slash.annotations.AutocompletionHandler;
 import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionMode;
 import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionTransformer;
+import com.freya02.botcommands.internal.ApplicationOptionData;
 import com.freya02.botcommands.internal.BContextImpl;
+import com.freya02.botcommands.internal.Logging;
+import com.freya02.botcommands.internal.MethodParameters;
+import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
+import com.freya02.botcommands.internal.application.slash.SlashCommandParameter;
 import com.freya02.botcommands.internal.utils.Utils;
 import me.xdrop.fuzzywuzzy.FuzzySearch;
 import me.xdrop.fuzzywuzzy.model.ExtractedResult;
@@ -12,7 +17,9 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.SlashCommand;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,27 +32,28 @@ import java.util.stream.Collectors;
 //      Object -> Transformer -> Choice
 @SuppressWarnings("unchecked")
 public class AutocompletionHandlerInfo {
+	private static final Logger LOGGER = Logging.getLogger();
 	private static final int MAX_CHOICES = OptionData.MAX_CHOICES - 1; //accommodate for user input
 
 	private final Object autocompletionHandler;
 	private final Method method;
-
-	private final Class<?> collectionReturnType;
 
 	private final String handlerName;
 
 	private final ChoiceSupplier choiceSupplier;
 	private final AutocompletionTransformer<Object> transformer;
 
+	private final MethodParameters<SlashCommandParameter> autocompleteParameters;
+
 	public AutocompletionHandlerInfo(BContextImpl context, Object autocompletionHandler, Method method) {
 		this.autocompletionHandler = autocompletionHandler;
 		this.method = method;
-		this.collectionReturnType = ClassUtils.getCollectionReturnType(method);
 
 		final AutocompletionHandler annotation = method.getAnnotation(AutocompletionHandler.class);
 		final AutocompletionMode autocompletionMode = annotation.mode();
 		this.handlerName = annotation.name();
 
+		Class<?> collectionReturnType = ClassUtils.getCollectionReturnType(method);
 		this.transformer = (AutocompletionTransformer<Object>) context.getAutocompletionTransformer(collectionReturnType);
 
 		if (collectionReturnType == null) {
@@ -63,19 +71,80 @@ public class AutocompletionHandlerInfo {
 
 			this.choiceSupplier = generateSupplierFromItems();
 		}
+
+		this.autocompleteParameters = MethodParameters.of(method, SlashCommandParameter::new);
+	}
+
+	private Object invokeAutocompletionHandler(SlashCommandInfo slashCommand, CommandAutoCompleteEvent event) throws IllegalAccessException, InvocationTargetException {
+		List<Object> objects = new ArrayList<>(autocompleteParameters.size() + 1);
+
+		objects.add(event);
+
+		int optionIndex = 0;
+		final List<String> optionNames = event.getGuild() != null ? slashCommand.getLocalizedOptions(event.getGuild()) : null;
+		for (final SlashCommandParameter parameter : autocompleteParameters) {
+			final ApplicationOptionData applicationOptionData = parameter.getApplicationOptionData();
+
+			final Object obj;
+			if (parameter.isOption()) {
+				String optionName = optionNames == null ? applicationOptionData.getEffectiveName() : optionNames.get(optionIndex);
+				if (optionName == null) {
+					throw new IllegalArgumentException(String.format("Option name #%d (%s) could not be resolved for %s", optionIndex, applicationOptionData.getEffectiveName(), Utils.formatMethodShort(method)));
+				}
+
+				optionIndex++;
+
+				final OptionMapping optionMapping = event.getOption(optionName);
+
+				if (optionMapping == null) {
+					if (parameter.isPrimitive()) {
+						objects.add(0);
+					} else {
+						objects.add(null);
+					}
+
+					continue;
+
+					//Don't throw if option mapping is not found, this is normal under autocompletion, only some options are sent
+				}
+
+				obj = parameter.getResolver().resolve(event, optionMapping);
+
+				if (obj == null) {
+					//Not a warning, could be normal if the user did not supply a valid string for user-defined resolvers
+					LOGGER.trace("The parameter '{}' of value '{}' could not be resolved into a {}", applicationOptionData.getEffectiveName(), optionMapping.getAsString(), parameter.getBoxedType().getSimpleName());
+
+					return false;
+				}
+
+				if (!parameter.getBoxedType().isAssignableFrom(obj.getClass())) {
+					LOGGER.error("The parameter '{}' of value '{}' is not a valid type (expected a {})", applicationOptionData.getEffectiveName(), optionMapping.getAsString(), parameter.getBoxedType().getSimpleName());
+
+					return false;
+				}
+			} else {
+				obj = parameter.getCustomResolver().resolve(event);
+			}
+
+			//For some reason using an array list instead of a regular array
+			// magically unboxes primitives when passed to Method#invoke
+			objects.add(obj);
+		}
+
+		return method.invoke(autocompletionHandler, objects.toArray());
 	}
 
 	private ChoiceSupplier generateSupplierFromChoices() {
-		return event -> {
-			final List<SlashCommand.Choice> choices = (List<SlashCommand.Choice>) method.invoke(autocompletionHandler, event);
+		return (slashCommand, event) -> {
+			final List<SlashCommand.Choice> choices = (List<SlashCommand.Choice>) invokeAutocompletionHandler(slashCommand, event);
 
 			return choices.subList(0, Math.min(MAX_CHOICES, choices.size()));
 		};
 	}
 
 	private ChoiceSupplier generateSupplierFromItems() {
-		return event -> {
-			final List<Object> results = (List<Object>) method.invoke(autocompletionHandler, event);
+		return (slashCommand, event) -> {
+			final List<Object> results = (List<Object>) invokeAutocompletionHandler(slashCommand, event);
 
 			return results.stream()
 					.limit(MAX_CHOICES)
@@ -93,11 +162,11 @@ public class AutocompletionHandlerInfo {
 	}
 
 	private ChoiceSupplier generateContinuitySupplier() {
-		return event -> {
+		return (slashCommand, event) -> {
 			final OptionMapping optionMapping = event.getFocusedOptionType();
 
 			final String query = optionMapping.getAsString();
-			final List<String> list = ((List<Object>) method.invoke(autocompletionHandler, event))
+			final List<String> list = ((List<Object>) invokeAutocompletionHandler(slashCommand, event))
 					.stream()
 					.map(Object::toString)
 					.filter(s -> s.startsWith(query))
@@ -118,8 +187,8 @@ public class AutocompletionHandlerInfo {
 
 	@NotNull
 	private ChoiceSupplier generateFuzzySupplier() {
-		return event -> {
-			final List<String> list = ((List<Object>) method.invoke(autocompletionHandler, event))
+		return (slashCommand, event) -> {
+			final List<String> list = ((List<Object>) invokeAutocompletionHandler(slashCommand, event))
 					.stream()
 					.map(Object::toString)
 					.sorted()
@@ -154,18 +223,14 @@ public class AutocompletionHandlerInfo {
 		};
 	}
 
-	public Class<?> getCollectionReturnType() {
-		return collectionReturnType;
-	}
-
 	public String getHandlerName() {
 		return handlerName;
 	}
 
-	public List<SlashCommand.Choice> getChoices(CommandAutoCompleteEvent event) throws Exception {
+	public List<SlashCommand.Choice> getChoices(SlashCommandInfo slashCommand, CommandAutoCompleteEvent event) throws Exception {
 		final List<SlashCommand.Choice> actualChoices = new ArrayList<>(25);
 
-		final List<SlashCommand.Choice> suppliedChoices = choiceSupplier.apply(event);
+		final List<SlashCommand.Choice> suppliedChoices = choiceSupplier.apply(slashCommand, event);
 
 		final OptionMapping optionMapping = event.getFocusedOptionType();
 		if (!optionMapping.getAsString().isBlank())
@@ -180,5 +245,34 @@ public class AutocompletionHandlerInfo {
 
 	public Method getMethod() {
 		return method;
+	}
+
+	public void checkParameters(SlashCommandInfo info) {
+		final List<? extends SlashCommandParameter> slashOptions = info.getOptionParameters();
+
+		autocompleteParameterLoop:
+		for (SlashCommandParameter autocompleteParameter : autocompleteParameters) {
+			if (!autocompleteParameter.isOption()) continue;
+
+			for (SlashCommandParameter slashCommandParameter : slashOptions) {
+				if (slashCommandParameter.getApplicationOptionData().getEffectiveName().equals(autocompleteParameter.getApplicationOptionData().getEffectiveName())) {
+					checkParameter(slashCommandParameter, autocompleteParameter);
+
+					continue autocompleteParameterLoop;
+				}
+			}
+
+			throw new IllegalArgumentException("Couldn't find parameter named %s in slash command %s".formatted(autocompleteParameter.getApplicationOptionData().getEffectiveName(), Utils.formatMethodShort(info.getCommandMethod())));
+		}
+	}
+
+	private void checkParameter(SlashCommandParameter slashCommandParameter, SlashCommandParameter autocompleteParameter) {
+		if (!slashCommandParameter.isOption()) return;
+
+		final Class<?> slashParameterType = slashCommandParameter.getBoxedType();
+		final Class<?> autocompleteParameterType = autocompleteParameter.getBoxedType();
+		if (!slashParameterType.equals(autocompleteParameterType)) {
+			throw new IllegalArgumentException("Autocompletion handler parameter #%d does not have the same type as slash command parameter: Provided: %s, correct: %s".formatted(autocompleteParameter.getIndex(), autocompleteParameterType, slashParameterType));
+		}
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlerInfo.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlerInfo.java
@@ -122,12 +122,19 @@ public class AutocompletionHandlerInfo {
 					.toList();
 
 			final OptionMapping optionMapping = event.getFocusedOptionType();
-			final List<ExtractedResult> results = FuzzySearch.extractTop(optionMapping.getAsString(),
+			//First sort the results by similarities but by taking into account an incomplete input
+			final List<ExtractedResult> bigLengthDiffResults = FuzzySearch.extractTop(optionMapping.getAsString(),
 					list,
 					FuzzySearch::partialRatio,
 					25);
 
-			return results.stream()
+			//Then sort the results by similarities but don't take length into account
+			final List<ExtractedResult> similarities = FuzzySearch.extractTop(optionMapping.getAsString(),
+					bigLengthDiffResults.stream().map(ExtractedResult::getString).toList(),
+					FuzzySearch::ratio,
+					25);
+
+			return similarities.stream()
 					.limit(OptionData.MAX_CHOICES)
 					.map(c -> getChoice(optionMapping, c))
 					.toList();

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlerInfo.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlerInfo.java
@@ -1,0 +1,167 @@
+package com.freya02.botcommands.internal.application.slash.autocomplete;
+
+import com.freya02.botcommands.api.application.slash.annotations.AutocompletionHandler;
+import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionMode;
+import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionTransformer;
+import com.freya02.botcommands.internal.BContextImpl;
+import com.freya02.botcommands.internal.utils.Utils;
+import me.xdrop.fuzzywuzzy.FuzzySearch;
+import me.xdrop.fuzzywuzzy.model.ExtractedResult;
+import net.dv8tion.jda.api.events.interaction.CommandAutoCompleteEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.SlashCommand;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+// The annotated method returns a list of things
+// These things can be, and are mapped as follows:
+//      String -> Choice(String, String)
+//      Choice -> keep the same choice
+//      Object -> Transformer -> Choice
+@SuppressWarnings("unchecked")
+public class AutocompletionHandlerInfo {
+	private final Object autocompletionHandler;
+	private final Method method;
+
+	private final Class<?> collectionReturnType;
+
+	private final String handlerName;
+
+	private final ChoiceSupplier choiceSupplier;
+	private final AutocompletionTransformer<Object> transformer;
+
+	public AutocompletionHandlerInfo(BContextImpl context, Object autocompletionHandler, Method method) {
+		this.autocompletionHandler = autocompletionHandler;
+		this.method = method;
+		this.collectionReturnType = ClassUtils.getCollectionReturnType(method);
+
+		final AutocompletionHandler annotation = method.getAnnotation(AutocompletionHandler.class);
+		final AutocompletionMode autocompletionMode = annotation.mode();
+		this.handlerName = annotation.name();
+
+		this.transformer = (AutocompletionTransformer<Object>) context.getAutocompletionTransformer(collectionReturnType);
+
+		if (collectionReturnType == null) {
+			throw new IllegalArgumentException("Unable to determine return type of " + Utils.formatMethodShort(method) + ", is the collection a List ?");
+		}
+
+		if (String.class.isAssignableFrom(collectionReturnType) || Long.class.isAssignableFrom(collectionReturnType) || Double.class.isAssignableFrom(collectionReturnType)) {
+			this.choiceSupplier = generateSupplierFromStrings(autocompletionMode);
+		} else if (SlashCommand.Choice.class.isAssignableFrom(collectionReturnType)) {
+			this.choiceSupplier = generateSupplierFromChoices();
+		} else {
+			if (context.getAutocompletionTransformer(collectionReturnType) == null) {
+				throw new IllegalArgumentException("No autocompletion transformer has been register for objects of type '" + collectionReturnType.getSimpleName() + "', for method " + Utils.formatMethodShort(method) + ", you may also check the docs for " + AutocompletionHandler.class.getSimpleName());
+			}
+
+			this.choiceSupplier = generateSupplierFromItems();
+		}
+	}
+
+	private ChoiceSupplier generateSupplierFromChoices() {
+		return event -> {
+			final List<SlashCommand.Choice> choices = (List<SlashCommand.Choice>) method.invoke(autocompletionHandler, event);
+
+			return choices.subList(0, Math.min(OptionData.MAX_CHOICES, choices.size()));
+		};
+	}
+
+	private ChoiceSupplier generateSupplierFromItems() {
+		return event -> {
+			final List<Object> results = (List<Object>) method.invoke(autocompletionHandler, event);
+
+			return results.stream()
+					.limit(OptionData.MAX_CHOICES)
+					.map(transformer::apply)
+					.collect(Collectors.toList());
+		};
+	}
+
+	private ChoiceSupplier generateSupplierFromStrings(AutocompletionMode autocompletionMode) {
+		if (autocompletionMode == AutocompletionMode.FUZZY) {
+			return generateFuzzySupplier();
+		} else {
+			return generateContinuitySupplier();
+		}
+	}
+
+	private ChoiceSupplier generateContinuitySupplier() {
+		return event -> {
+			final List<String> list = ((List<Object>) method.invoke(autocompletionHandler, event))
+					.stream()
+					.map(Object::toString)
+					.collect(Collectors.toCollection(ArrayList::new));
+
+			final OptionMapping optionMapping = event.getFocusedOptionType();
+
+			list.removeIf(s -> !s.startsWith(optionMapping.getAsString()));
+
+			final List<ExtractedResult> results = FuzzySearch.extractTop(optionMapping.getAsString(),
+					list,
+					FuzzySearch::ratio,
+					25);
+
+			return results.stream()
+					.limit(OptionData.MAX_CHOICES)
+					.map(c -> getChoice(optionMapping, c))
+					.toList();
+		};
+	}
+
+	@NotNull
+	private ChoiceSupplier generateFuzzySupplier() {
+		return event -> {
+			final List<String> list = ((List<Object>) method.invoke(autocompletionHandler, event))
+					.stream()
+					.map(Object::toString)
+					.toList();
+
+			final OptionMapping optionMapping = event.getFocusedOptionType();
+			final List<ExtractedResult> results = FuzzySearch.extractTop(optionMapping.getAsString(),
+					list,
+					FuzzySearch::partialRatio,
+					25);
+
+			return results.stream()
+					.limit(OptionData.MAX_CHOICES)
+					.map(c -> getChoice(optionMapping, c))
+					.toList();
+		};
+	}
+
+	private SlashCommand.Choice getChoice(OptionMapping optionMapping, ExtractedResult result) {
+		return switch (optionMapping.getType()) {
+			case STRING -> new SlashCommand.Choice(result.getString(), result.getString());
+			case INTEGER -> new SlashCommand.Choice(result.getString(), Long.parseLong(result.getString()));
+			case NUMBER -> new SlashCommand.Choice(result.getString(), Double.parseDouble(result.getString()));
+			default -> throw new IllegalArgumentException("Invalid autocompletion option type: " + optionMapping.getType());
+		};
+	}
+
+	public Class<?> getCollectionReturnType() {
+		return collectionReturnType;
+	}
+
+	public String getHandlerName() {
+		return handlerName;
+	}
+
+	public List<SlashCommand.Choice> getChoices(CommandAutoCompleteEvent event) throws Exception {
+		final List<SlashCommand.Choice> choices = choiceSupplier.apply(event);
+
+		if (choices.size() > OptionData.MAX_CHOICES) {
+			return choices.subList(0, OptionData.MAX_CHOICES);
+		} else {
+			return choices;
+		}
+	}
+
+	public Method getMethod() {
+		return method;
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlersBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlersBuilder.java
@@ -1,0 +1,70 @@
+package com.freya02.botcommands.internal.application.slash.autocomplete;
+
+import com.freya02.botcommands.internal.ApplicationOptionData;
+import com.freya02.botcommands.internal.BContextImpl;
+import com.freya02.botcommands.internal.Logging;
+import com.freya02.botcommands.internal.MethodParameters;
+import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
+import com.freya02.botcommands.internal.application.slash.SlashCommandParameter;
+import com.freya02.botcommands.internal.utils.Utils;
+import net.dv8tion.jda.api.events.interaction.CommandAutoCompleteEvent;
+import org.slf4j.Logger;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AutocompletionHandlersBuilder {
+	private static final Logger LOGGER = Logging.getLogger();
+
+	private final BContextImpl context;
+	private final Map<String, AutocompletionHandlerInfo> autocompleteHandlersMap = new HashMap<>();
+
+	public AutocompletionHandlersBuilder(BContextImpl context) {
+		this.context = context;
+	}
+
+	public void processHandler(Object autocompleteHandler, Method method) {
+		try {
+			if (!Utils.hasFirstParameter(method, CommandAutoCompleteEvent.class))
+				throw new IllegalArgumentException("Autocompletion handler at " + Utils.formatMethodShort(method) + " must have a " + CommandAutoCompleteEvent.class.getSimpleName() + " event as first parameter");
+
+			final AutocompletionHandlerInfo handler = new AutocompletionHandlerInfo(context, autocompleteHandler, method);
+
+			final AutocompletionHandlerInfo oldHandler = autocompleteHandlersMap.put(handler.getHandlerName(), handler);
+
+			if (oldHandler != null) {
+				throw new IllegalArgumentException("Tried to register autocompletion handler '" + handler.getHandlerName() + "' at " + Utils.formatMethodShort(method) + " was already registered at " + Utils.formatMethodShort(oldHandler.getMethod()));
+			}
+
+			LOGGER.debug("Adding autocompletion handler '{}' for method {}", handler.getHandlerName(), Utils.formatMethodShort(method));
+		} catch (Exception e) {
+			throw new RuntimeException("An exception occurred while processing an autocompletion handler at " + Utils.formatMethodShort(method), e);
+		}
+	}
+
+	public void postProcess() {
+		for (SlashCommandInfo info : context.getApplicationCommandInfoMap().getSlashCommands().values()) {
+			MethodParameters<SlashCommandParameter> parameters = info.getParameters();
+			for (int i = 0, parametersSize = parameters.size(); i < parametersSize; i++) {
+				SlashCommandParameter parameter = parameters.get(i);
+
+				if (!parameter.isOption()) continue;
+
+				final ApplicationOptionData applicationOptionData = parameter.getApplicationOptionData();
+
+				final String autocompleteHandlerName = applicationOptionData.getAutocompletionHandlerName();
+
+				if (autocompleteHandlerName != null) {
+					final AutocompletionHandlerInfo handler = autocompleteHandlersMap.get(autocompleteHandlerName);
+
+					if (handler == null) {
+						throw new IllegalArgumentException("Slash command parameter #" + i + " at " + Utils.formatMethodShort(info.getCommandMethod()) + " uses autocompletion but has no handler assigned, did you misspell the handler name ? Consider using a constant variable to share with the handler and the option");
+					}
+				}
+			}
+		}
+
+		context.getJDA().addEventListener(new AutocompletionListener(context, autocompleteHandlersMap));
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlersBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlersBuilder.java
@@ -6,6 +6,7 @@ import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.MethodParameters;
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.application.slash.SlashCommandParameter;
+import com.freya02.botcommands.internal.utils.ReflectionUtils;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.events.interaction.CommandAutoCompleteEvent;
 import org.slf4j.Logger;
@@ -26,7 +27,7 @@ public class AutocompletionHandlersBuilder {
 
 	public void processHandler(Object autocompleteHandler, Method method) {
 		try {
-			if (!Utils.hasFirstParameter(method, CommandAutoCompleteEvent.class))
+			if (!ReflectionUtils.hasFirstParameter(method, CommandAutoCompleteEvent.class))
 				throw new IllegalArgumentException("Autocompletion handler at " + Utils.formatMethodShort(method) + " must have a " + CommandAutoCompleteEvent.class.getSimpleName() + " event as first parameter");
 
 			final AutocompletionHandlerInfo handler = new AutocompletionHandlerInfo(context, autocompleteHandler, method);

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlersBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlersBuilder.java
@@ -66,6 +66,6 @@ public class AutocompletionHandlersBuilder {
 			}
 		}
 
-		context.getJDA().addEventListener(new AutocompletionListener(context, autocompleteHandlersMap));
+		context.addEventListeners(new AutocompletionListener(context, autocompleteHandlersMap));
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlersBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlersBuilder.java
@@ -62,6 +62,8 @@ public class AutocompletionHandlersBuilder {
 					if (handler == null) {
 						throw new IllegalArgumentException("Slash command parameter #" + i + " at " + Utils.formatMethodShort(info.getCommandMethod()) + " uses autocompletion but has no handler assigned, did you misspell the handler name ? Consider using a constant variable to share with the handler and the option");
 					}
+
+					handler.checkParameters(info);
 				}
 			}
 		}

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlersBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionHandlersBuilder.java
@@ -1,8 +1,8 @@
 package com.freya02.botcommands.internal.application.slash.autocomplete;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.internal.ApplicationOptionData;
 import com.freya02.botcommands.internal.BContextImpl;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.MethodParameters;
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.application.slash.SlashCommandParameter;

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionListener.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionListener.java
@@ -1,9 +1,9 @@
 package com.freya02.botcommands.internal.application.slash.autocomplete;
 
 import com.freya02.botcommands.api.ExceptionHandler;
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.application.CommandPath;
 import com.freya02.botcommands.internal.BContextImpl;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.RunnableEx;
 import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.utils.Utils;

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionListener.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionListener.java
@@ -1,0 +1,104 @@
+package com.freya02.botcommands.internal.application.slash.autocomplete;
+
+import com.freya02.botcommands.api.ExceptionHandler;
+import com.freya02.botcommands.api.application.CommandPath;
+import com.freya02.botcommands.internal.BContextImpl;
+import com.freya02.botcommands.internal.Logging;
+import com.freya02.botcommands.internal.RunnableEx;
+import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
+import com.freya02.botcommands.internal.utils.Utils;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.interaction.CommandAutoCompleteEvent;
+import net.dv8tion.jda.api.hooks.EventListener;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+public class AutocompletionListener implements EventListener {
+	private static final Logger LOGGER = Logging.getLogger();
+
+	private final BContextImpl context;
+	private final Map<String, AutocompletionHandlerInfo> autocompletionHandlersMap;
+
+	private int autocompletionThreadNumber = 0;
+	private final ExecutorService autocompletionService = Utils.createCommandPool(r -> {
+		final Thread thread = new Thread(r);
+		thread.setDaemon(false);
+		thread.setUncaughtExceptionHandler((t, e) -> Utils.printExceptionString("An unexpected exception happened in an autocompletion thread '" + t.getName() + "':", e));
+		thread.setName("Autocompletion thread #" + autocompletionThreadNumber++);
+
+		return thread;
+	});
+
+	public AutocompletionListener(BContextImpl context, Map<String, AutocompletionHandlerInfo> autocompletionHandlersMap) {
+		this.context = context;
+		this.autocompletionHandlersMap = autocompletionHandlersMap;
+	}
+
+	@Override
+	public void onEvent(@NotNull GenericEvent genericEvent) {
+		if (genericEvent instanceof CommandAutoCompleteEvent event) {
+			runAutocompletion(() -> {
+				final SlashCommandInfo slashCommand = context.findSlashCommand(CommandPath.of(event.getCommandPath()));
+
+				if (slashCommand == null) {
+					event.reply(context.getDefaultMessages(event.getGuild()).getApplicationCommandNotFoundMsg()).queue();
+					return;
+				}
+
+				final String autocompletionHandler = slashCommand.getAutocompletionHandlerName(event);
+				if (autocompletionHandler == null) {
+					LOGGER.warn("Found no autocompletion handler name for option '{}' in command '{}'", event.getFocusedOptionType().getName(), slashCommand.getPath());
+
+					return;
+				}
+
+				final AutocompletionHandlerInfo handler = autocompletionHandlersMap.get(autocompletionHandler);
+				if (handler == null) {
+					LOGGER.warn("Found no autocompletion handler for '{}'", autocompletionHandler);
+
+					return;
+				}
+
+				event.respondChoices(handler.getChoices(event)).queue();
+			}, event);
+		}
+	}
+
+	private void runAutocompletion(RunnableEx code, CommandAutoCompleteEvent event) {
+		autocompletionService.execute(() -> {
+			try {
+				code.run();
+			} catch (Throwable e) {
+				final ExceptionHandler handler = context.getUncaughtExceptionHandler();
+				if (handler != null) {
+					handler.onException(context, event, e);
+
+					return;
+				}
+
+				Throwable baseEx = Utils.getException(e);
+
+				Utils.printExceptionString("Unhandled exception in thread '" + Thread.currentThread().getName() + "' while autocompleting a command option '" + reconstructCommand(event) + "'", baseEx);
+				if (event.isAcknowledged()) {
+					event.getHook().sendMessage(context.getDefaultMessages(event.getGuild()).getApplicationCommandErrorMsg()).setEphemeral(true).queue();
+				} else {
+					event.reply(context.getDefaultMessages(event.getGuild()).getApplicationCommandErrorMsg()).setEphemeral(true).queue();
+				}
+
+				context.dispatchException("Exception while autocompleting '" + reconstructCommand(event) + "'", baseEx);
+			}
+		});
+	}
+
+	private String reconstructCommand(CommandAutoCompleteEvent event) {
+		StringBuilder builder = new StringBuilder("/" + event.getName());
+		if (event.getSubcommandGroup() != null)
+			builder.append(' ').append(event.getSubcommandGroup());
+		if (event.getSubcommandName() != null)
+			builder.append(' ').append(event.getSubcommandName());
+		return builder.toString();
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionListener.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/AutocompletionListener.java
@@ -62,7 +62,7 @@ public class AutocompletionListener implements EventListener {
 					return;
 				}
 
-				event.respondChoices(handler.getChoices(event)).queue();
+				event.respondChoices(handler.getChoices(slashCommand, event)).queue();
 			}, event);
 		}
 	}

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/ChoiceSupplier.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/ChoiceSupplier.java
@@ -1,0 +1,10 @@
+package com.freya02.botcommands.internal.application.slash.autocomplete;
+
+import net.dv8tion.jda.api.events.interaction.CommandAutoCompleteEvent;
+import net.dv8tion.jda.api.interactions.commands.SlashCommand;
+
+import java.util.List;
+
+public interface ChoiceSupplier {
+	List<SlashCommand.Choice> apply(CommandAutoCompleteEvent event) throws Exception;
+}

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/ChoiceSupplier.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/ChoiceSupplier.java
@@ -1,10 +1,11 @@
 package com.freya02.botcommands.internal.application.slash.autocomplete;
 
+import com.freya02.botcommands.internal.application.slash.SlashCommandInfo;
 import net.dv8tion.jda.api.events.interaction.CommandAutoCompleteEvent;
 import net.dv8tion.jda.api.interactions.commands.SlashCommand;
 
 import java.util.List;
 
 public interface ChoiceSupplier {
-	List<SlashCommand.Choice> apply(CommandAutoCompleteEvent event) throws Exception;
+	List<SlashCommand.Choice> apply(SlashCommandInfo slashCommand, CommandAutoCompleteEvent event) throws Exception;
 }

--- a/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/ClassUtils.java
+++ b/src/main/java/com/freya02/botcommands/internal/application/slash/autocomplete/ClassUtils.java
@@ -1,0 +1,52 @@
+package com.freya02.botcommands.internal.application.slash.autocomplete;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ClassUtils {
+	@Nullable
+	private static Class<?> getCollectionReturnType(Class<?> returnClass, Type returnType) {
+		if (returnType instanceof ParameterizedType type) {
+			final Class<?> rawType = (Class<?>) type.getRawType();
+
+			if (List.class.isAssignableFrom(rawType) && type.getOwnerType() == null) {
+				return (Class<?>) type.getActualTypeArguments()[0];
+			}
+		}
+
+		List<Class<?>> superclasses = new ArrayList<>();
+		List<Type> supertypes = new ArrayList<>();
+
+		if (returnClass.getGenericSuperclass() != null) {
+			superclasses.add(returnClass.getSuperclass());
+			supertypes.add(returnClass.getGenericSuperclass());
+		}
+
+		superclasses.addAll(Arrays.asList(returnClass.getInterfaces()));
+		supertypes.addAll(Arrays.asList(returnClass.getGenericInterfaces()));
+
+		for (int i = 0, supertypesSize = supertypes.size(); i < supertypesSize; i++) {
+			final Class<?> listReturnType = getCollectionReturnType(superclasses.get(i), supertypes.get(i));
+
+			if (listReturnType != null) {
+				return listReturnType;
+			}
+		}
+
+		return null;
+	}
+
+	@Nullable
+	public static Class<?> getCollectionReturnType(@NotNull Method method) {
+		Type returnType = method.getGenericReturnType();
+
+		return getCollectionReturnType(method.getReturnType(), returnType);
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/components/ComponentsBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/components/ComponentsBuilder.java
@@ -7,6 +7,7 @@ import com.freya02.botcommands.api.components.event.ButtonEvent;
 import com.freya02.botcommands.api.components.event.SelectionEvent;
 import com.freya02.botcommands.internal.BContextImpl;
 import com.freya02.botcommands.internal.utils.ClassInstancer;
+import com.freya02.botcommands.internal.utils.ReflectionUtils;
 import com.freya02.botcommands.internal.utils.Utils;
 
 import java.lang.reflect.InvocationTargetException;
@@ -40,7 +41,7 @@ public class ComponentsBuilder {
 	}
 
 	private void handleComponentListener(Method method, String handlerName, Map<String, ComponentDescriptor> map, Class<?> firstRequiredArg, String componentType) {
-		if (!Utils.hasFirstParameter(method, firstRequiredArg))
+		if (!ReflectionUtils.hasFirstParameter(method, firstRequiredArg))
 			throw new IllegalArgumentException("First parameter of method " + Utils.formatMethodShort(method) + " should be a " + firstRequiredArg.getSimpleName());
 
 		try {

--- a/src/main/java/com/freya02/botcommands/internal/components/data/LambdaButtonData.java
+++ b/src/main/java/com/freya02/botcommands/internal/components/data/LambdaButtonData.java
@@ -1,18 +1,16 @@
 package com.freya02.botcommands.internal.components.data;
 
-import com.freya02.botcommands.api.components.event.ButtonEvent;
+import com.freya02.botcommands.api.components.ButtonConsumer;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.function.Consumer;
-
 public class LambdaButtonData {
-	private final Consumer<ButtonEvent> consumer;
+	private final ButtonConsumer consumer;
 
-	public LambdaButtonData(@NotNull Consumer<ButtonEvent> consumer) {
+	public LambdaButtonData(@NotNull ButtonConsumer consumer) {
 		this.consumer = consumer;
 	}
 
-	public Consumer<ButtonEvent> getConsumer() {
+	public ButtonConsumer getConsumer() {
 		return consumer;
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/components/data/LambdaSelectionMenuData.java
+++ b/src/main/java/com/freya02/botcommands/internal/components/data/LambdaSelectionMenuData.java
@@ -1,18 +1,16 @@
 package com.freya02.botcommands.internal.components.data;
 
-import com.freya02.botcommands.api.components.event.SelectionEvent;
+import com.freya02.botcommands.api.components.SelectionConsumer;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.function.Consumer;
-
 public class LambdaSelectionMenuData {
-	private final Consumer<SelectionEvent> consumer;
+	private final SelectionConsumer consumer;
 
-	public LambdaSelectionMenuData(@NotNull Consumer<SelectionEvent> consumer) {
+	public LambdaSelectionMenuData(@NotNull SelectionConsumer consumer) {
 		this.consumer = consumer;
 	}
 
-	public Consumer<SelectionEvent> getConsumer() {
+	public SelectionConsumer getConsumer() {
 		return consumer;
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/components/sql/SqlComponentData.java
+++ b/src/main/java/com/freya02/botcommands/internal/components/sql/SqlComponentData.java
@@ -1,6 +1,6 @@
 package com.freya02.botcommands.internal.components.sql;
 
-import com.freya02.botcommands.internal.Logging;
+import com.freya02.botcommands.api.Logging;
 import org.slf4j.Logger;
 
 import java.sql.Connection;

--- a/src/main/java/com/freya02/botcommands/internal/events/EventListenersBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/events/EventListenersBuilder.java
@@ -162,6 +162,6 @@ public class EventListenersBuilder {
 	}
 
 	public void postProcess() {
-		context.getJDA().addEventListener(new EventListenerImpl(context, eventListenersMap));
+		context.addEventListeners(new EventListenerImpl(context, eventListenersMap));
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/events/EventListenersBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/events/EventListenersBuilder.java
@@ -4,6 +4,7 @@ import com.freya02.botcommands.internal.BContextImpl;
 import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.MethodParameters;
 import com.freya02.botcommands.internal.utils.EventUtils;
+import com.freya02.botcommands.internal.utils.ReflectionUtils;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.GenericEvent;
@@ -80,7 +81,7 @@ public class EventListenersBuilder {
 	@SuppressWarnings("unchecked")
 	public void processEventListener(Object eventListener, Method method) {
 		try {
-			if (!Utils.hasFirstParameter(method, Event.class))
+			if (!ReflectionUtils.hasFirstParameter(method, Event.class))
 				throw new IllegalArgumentException("Event listener at " + Utils.formatMethodShort(method) + " must have a valid (extends Event) JDA event as first parameter");
 
 			final Class<?> eventType = method.getParameterTypes()[0];

--- a/src/main/java/com/freya02/botcommands/internal/events/EventListenersBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/events/EventListenersBuilder.java
@@ -1,7 +1,7 @@
 package com.freya02.botcommands.internal.events;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.internal.BContextImpl;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.MethodParameters;
 import com.freya02.botcommands.internal.utils.EventUtils;
 import com.freya02.botcommands.internal.utils.ReflectionUtils;

--- a/src/main/java/com/freya02/botcommands/internal/parameters/BooleanResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/BooleanResolver.java
@@ -5,9 +5,9 @@ import com.freya02.botcommands.api.parameters.ParameterResolver;
 import com.freya02.botcommands.api.parameters.RegexParameterResolver;
 import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,7 +38,7 @@ public class BooleanResolver extends ParameterResolver implements RegexParameter
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		return optionMapping.getAsBoolean();
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/DoubleResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/DoubleResolver.java
@@ -5,9 +5,9 @@ import com.freya02.botcommands.api.parameters.ParameterResolver;
 import com.freya02.botcommands.api.parameters.RegexParameterResolver;
 import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,7 +38,7 @@ public class DoubleResolver extends ParameterResolver implements RegexParameterR
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		return Double.valueOf(optionMapping.getAsString());
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/EmojiOrEmoteResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/EmojiOrEmoteResolver.java
@@ -9,9 +9,9 @@ import com.freya02.botcommands.api.utils.EmojiUtils;
 import com.freya02.botcommands.internal.entities.EmojiOrEmoteImpl;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -44,7 +44,7 @@ public class EmojiOrEmoteResolver extends ParameterResolver implements RegexPara
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		final Matcher emoteMatcher = Message.MentionType.EMOTE.getPattern().matcher(optionMapping.getAsString());
 		if (emoteMatcher.find()) {
 			return new EmojiOrEmoteImpl(emoteMatcher.group(1), emoteMatcher.group(2));

--- a/src/main/java/com/freya02/botcommands/internal/parameters/EmojiResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/EmojiResolver.java
@@ -8,9 +8,9 @@ import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import com.freya02.botcommands.api.utils.EmojiUtils;
 import com.freya02.botcommands.internal.entities.EmojiImpl;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -41,7 +41,7 @@ public class EmojiResolver extends ParameterResolver implements RegexParameterRe
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		return getEmoji(optionMapping.getAsString());
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/EmoteResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/EmoteResolver.java
@@ -8,10 +8,10 @@ import net.dv8tion.jda.api.entities.Emote;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -42,7 +42,7 @@ public class EmoteResolver extends ParameterResolver implements RegexParameterRe
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		final Guild guild = event.getGuild();
 
 		if (guild != null) {

--- a/src/main/java/com/freya02/botcommands/internal/parameters/GuildResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/GuildResolver.java
@@ -7,9 +7,9 @@ import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,7 +40,7 @@ public class GuildResolver extends ParameterResolver implements RegexParameterRe
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/LongResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/LongResolver.java
@@ -5,9 +5,9 @@ import com.freya02.botcommands.api.parameters.ParameterResolver;
 import com.freya02.botcommands.api.parameters.RegexParameterResolver;
 import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,7 +38,7 @@ public class LongResolver extends ParameterResolver implements RegexParameterRes
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		return optionMapping.getAsLong();
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/MemberResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/MemberResolver.java
@@ -4,11 +4,11 @@ import com.freya02.botcommands.api.parameters.*;
 import com.freya02.botcommands.internal.prefixed.Utils;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.interaction.commands.UserContextCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -52,7 +52,7 @@ public class MemberResolver extends ParameterResolver implements RegexParameterR
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		return optionMapping.getAsMember();
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/MentionableResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/MentionableResolver.java
@@ -3,8 +3,8 @@ package com.freya02.botcommands.internal.parameters;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
 import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import net.dv8tion.jda.api.entities.IMentionable;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.Nullable;
 
 public class MentionableResolver extends ParameterResolver implements SlashParameterResolver {
@@ -14,7 +14,7 @@ public class MentionableResolver extends ParameterResolver implements SlashParam
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		return optionMapping.getAsMentionable();
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/parameters/RoleResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/RoleResolver.java
@@ -6,9 +6,9 @@ import com.freya02.botcommands.api.parameters.RegexParameterResolver;
 import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -44,7 +44,7 @@ public class RoleResolver extends ParameterResolver implements RegexParameterRes
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		return optionMapping.getAsRole();
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/StringResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/StringResolver.java
@@ -2,9 +2,9 @@ package com.freya02.botcommands.internal.parameters;
 
 import com.freya02.botcommands.api.parameters.*;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,7 +40,7 @@ public class StringResolver extends ParameterResolver implements RegexParameterR
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		return optionMapping.getAsString();
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/UserResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/UserResolver.java
@@ -4,11 +4,11 @@ import com.freya02.botcommands.api.parameters.*;
 import com.freya02.botcommands.internal.prefixed.Utils;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.interaction.commands.UserContextCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,7 +50,7 @@ public class UserResolver extends ParameterResolver implements RegexParameterRes
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		return optionMapping.getAsUser();
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/channels/AbstractChannelResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/channels/AbstractChannelResolver.java
@@ -1,10 +1,12 @@
-package com.freya02.botcommands.internal.parameters;
+package com.freya02.botcommands.internal.parameters.channels;
 
 import com.freya02.botcommands.api.parameters.ComponentParameterResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
 import com.freya02.botcommands.api.parameters.RegexParameterResolver;
 import com.freya02.botcommands.api.parameters.SlashParameterResolver;
-import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
@@ -13,19 +15,30 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 
-public class TextChannelResolver extends ParameterResolver implements RegexParameterResolver, SlashParameterResolver, ComponentParameterResolver {
+public abstract class AbstractChannelResolver<T extends GuildChannel> extends ParameterResolver implements RegexParameterResolver, SlashParameterResolver, ComponentParameterResolver {
 	private static final Pattern PATTERN = Pattern.compile("(?:<#)?(\\d+)>?");
+	private final ChannelType channelType;
+	private final BiFunction<Guild, String, T> channelResolver;
 
-	public TextChannelResolver() {
-		super(TextChannel.class);
+	public AbstractChannelResolver(Class<T> channelClass, @Nullable ChannelType channelType, BiFunction<Guild, String, T> channelResolver) {
+		super(channelClass);
+
+		this.channelType = channelType;
+		this.channelResolver = channelResolver;
+	}
+
+	@Nullable
+	public ChannelType getChannelType() {
+		return channelType;
 	}
 
 	@Override
 	@Nullable
 	public Object resolve(GuildMessageReceivedEvent event, String[] args) {
-		return event.getGuild().getTextChannelById(args[0]);
+		return channelResolver.apply(event.getGuild(), args[0]);
 	}
 
 	@Override
@@ -51,6 +64,6 @@ public class TextChannelResolver extends ParameterResolver implements RegexParam
 	public Object resolve(GenericComponentInteractionCreateEvent event, String arg) {
 		Objects.requireNonNull(event.getGuild(), "Can't get a guild from DMs");
 
-		return event.getGuild().getTextChannelById(arg);
+		return channelResolver.apply(event.getGuild(), arg);
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/parameters/channels/AbstractChannelResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/channels/AbstractChannelResolver.java
@@ -8,9 +8,9 @@ import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.events.interaction.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.interactions.SlashCommandInteraction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -55,7 +55,7 @@ public abstract class AbstractChannelResolver<T extends GuildChannel> extends Pa
 
 	@Override
 	@Nullable
-	public Object resolve(SlashCommandEvent event, OptionMapping optionMapping) {
+	public Object resolve(SlashCommandInteraction event, OptionMapping optionMapping) {
 		return optionMapping.getAsGuildChannel();
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/channels/CategoryResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/channels/CategoryResolver.java
@@ -1,0 +1,11 @@
+package com.freya02.botcommands.internal.parameters.channels;
+
+import net.dv8tion.jda.api.entities.Category;
+import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.Guild;
+
+public class CategoryResolver extends AbstractChannelResolver<Category> {
+	public CategoryResolver() {
+		super(Category.class, ChannelType.CATEGORY, Guild::getCategoryById);
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/parameters/channels/GuildChannelResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/channels/GuildChannelResolver.java
@@ -1,0 +1,10 @@
+package com.freya02.botcommands.internal.parameters.channels;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.GuildChannel;
+
+public class GuildChannelResolver extends AbstractChannelResolver<GuildChannel> {
+	public GuildChannelResolver() {
+		super(GuildChannel.class, null, Guild::getGuildChannelById);
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/parameters/channels/StageChannelResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/channels/StageChannelResolver.java
@@ -1,0 +1,11 @@
+package com.freya02.botcommands.internal.parameters.channels;
+
+import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.StageChannel;
+
+public class StageChannelResolver extends AbstractChannelResolver<StageChannel> {
+	public StageChannelResolver() {
+		super(StageChannel.class, ChannelType.STAGE, Guild::getStageChannelById);
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/parameters/channels/StoreChannelResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/channels/StoreChannelResolver.java
@@ -1,0 +1,11 @@
+package com.freya02.botcommands.internal.parameters.channels;
+
+import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.StoreChannel;
+
+public class StoreChannelResolver extends AbstractChannelResolver<StoreChannel> {
+	public StoreChannelResolver() {
+		super(StoreChannel.class, ChannelType.STORE, Guild::getStoreChannelById);
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/parameters/channels/TextChannelResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/channels/TextChannelResolver.java
@@ -1,0 +1,11 @@
+package com.freya02.botcommands.internal.parameters.channels;
+
+import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+public class TextChannelResolver extends AbstractChannelResolver<TextChannel> {
+	public TextChannelResolver() {
+		super(TextChannel.class, ChannelType.TEXT, Guild::getTextChannelById);
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/parameters/channels/VoiceChannelResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/channels/VoiceChannelResolver.java
@@ -1,0 +1,11 @@
+package com.freya02.botcommands.internal.parameters.channels;
+
+import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.VoiceChannel;
+
+public class VoiceChannelResolver extends AbstractChannelResolver<VoiceChannel> {
+	public VoiceChannelResolver() {
+		super(VoiceChannel.class, ChannelType.VOICE, Guild::getVoiceChannelById);
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/prefixed/BaseCommandEventImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/prefixed/BaseCommandEventImpl.java
@@ -1,10 +1,10 @@
 package com.freya02.botcommands.internal.prefixed;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.utils.EmojiUtils;
 import com.freya02.botcommands.internal.BContextImpl;
-import com.freya02.botcommands.internal.Logging;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Message;

--- a/src/main/java/com/freya02/botcommands/internal/prefixed/CommandEventImpl.java
+++ b/src/main/java/com/freya02/botcommands/internal/prefixed/CommandEventImpl.java
@@ -1,12 +1,12 @@
 package com.freya02.botcommands.internal.prefixed;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.prefixed.CommandEvent;
 import com.freya02.botcommands.api.prefixed.exceptions.BadIdException;
 import com.freya02.botcommands.api.prefixed.exceptions.NoIdException;
 import com.freya02.botcommands.api.utils.RichTextFinder;
 import com.freya02.botcommands.api.utils.RichTextType;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.entities.EmojiImpl;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;

--- a/src/main/java/com/freya02/botcommands/internal/prefixed/CommandListener.java
+++ b/src/main/java/com/freya02/botcommands/internal/prefixed/CommandListener.java
@@ -1,11 +1,11 @@
 package com.freya02.botcommands.internal.prefixed;
 
-import com.freya02.botcommands.api.CooldownScope;
-import com.freya02.botcommands.api.ExceptionHandler;
-import com.freya02.botcommands.api.SettingsProvider;
+import com.freya02.botcommands.api.*;
 import com.freya02.botcommands.api.application.CommandPath;
 import com.freya02.botcommands.api.prefixed.MessageInfo;
-import com.freya02.botcommands.internal.*;
+import com.freya02.botcommands.internal.BContextImpl;
+import com.freya02.botcommands.internal.RunnableEx;
+import com.freya02.botcommands.internal.Usability;
 import com.freya02.botcommands.internal.Usability.UnusableReason;
 import com.freya02.botcommands.internal.utils.Utils;
 import me.xdrop.fuzzywuzzy.FuzzySearch;

--- a/src/main/java/com/freya02/botcommands/internal/prefixed/CommandListener.java
+++ b/src/main/java/com/freya02/botcommands/internal/prefixed/CommandListener.java
@@ -153,6 +153,8 @@ public final class CommandListener extends ListenerAdapter {
 			if (helpCommand != null) {
 				helpCommand.sendCommandHelp(new BaseCommandEventImpl(context, event, ""),
 						candidates.first().getPath());
+			} else if (context.getHelpConsumer() != null) {
+				context.getHelpConsumer().accept(new BaseCommandEventImpl(context, event, args));
 			}
 		}, msg, event);
 	}

--- a/src/main/java/com/freya02/botcommands/internal/prefixed/PrefixedCommandsBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/prefixed/PrefixedCommandsBuilder.java
@@ -1,9 +1,9 @@
 package com.freya02.botcommands.internal.prefixed;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.prefixed.TextCommand;
 import com.freya02.botcommands.internal.BContextImpl;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.application.CommandParameter;
 import com.freya02.botcommands.internal.utils.ReflectionUtils;
 import com.freya02.botcommands.internal.utils.Utils;

--- a/src/main/java/com/freya02/botcommands/internal/prefixed/PrefixedCommandsBuilder.java
+++ b/src/main/java/com/freya02/botcommands/internal/prefixed/PrefixedCommandsBuilder.java
@@ -5,6 +5,7 @@ import com.freya02.botcommands.api.prefixed.TextCommand;
 import com.freya02.botcommands.internal.BContextImpl;
 import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.application.CommandParameter;
+import com.freya02.botcommands.internal.utils.ReflectionUtils;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.Permission;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ public class PrefixedCommandsBuilder {
 
 	public void processPrefixedCommand(TextCommand command, Method method) {
 		try {
-			if (!Utils.hasFirstParameter(method, BaseCommandEvent.class)) //Handles CommandEvent (and subtypes) too
+			if (!ReflectionUtils.hasFirstParameter(method, BaseCommandEvent.class)) //Handles CommandEvent (and subtypes) too
 				throw new IllegalArgumentException("Prefixed command at " + Utils.formatMethodShort(method) + " must have a BaseCommandEvent or a CommandEvent as first parameter");
 
 			final TextCommandInfo info = new TextCommandInfo(command, method);

--- a/src/main/java/com/freya02/botcommands/internal/prefixed/TextCommandComparator.java
+++ b/src/main/java/com/freya02/botcommands/internal/prefixed/TextCommandComparator.java
@@ -1,8 +1,8 @@
 package com.freya02.botcommands.internal.prefixed;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.prefixed.CommandEvent;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.utils.Utils;
 import org.slf4j.Logger;
 

--- a/src/main/java/com/freya02/botcommands/internal/prefixed/TextCommandInfo.java
+++ b/src/main/java/com/freya02/botcommands/internal/prefixed/TextCommandInfo.java
@@ -12,6 +12,7 @@ import com.freya02.botcommands.internal.BContextImpl;
 import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.MethodParameters;
 import com.freya02.botcommands.internal.utils.AnnotationUtils;
+import com.freya02.botcommands.internal.utils.ReflectionUtils;
 import com.freya02.botcommands.internal.utils.Utils;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import org.jetbrains.annotations.NotNull;
@@ -58,7 +59,7 @@ public final class TextCommandInfo extends AbstractCommandInfo<TextCommand> {
 
 		order = jdaCommand.order();
 
-		final boolean isRegexMethod = !Utils.hasFirstParameter(commandMethod, CommandEvent.class);
+		final boolean isRegexMethod = !ReflectionUtils.hasFirstParameter(commandMethod, CommandEvent.class);
 		parameters = MethodParameters.of(commandMethod, (parameter, index) -> {
 			if (parameter.isAnnotationPresent(AppOption.class))
 				throw new IllegalArgumentException(String.format("Text command parameter #%d of %s#%s cannot be annotated with @AppOption", index, commandMethod.getDeclaringClass().getName(), commandMethod.getName()));

--- a/src/main/java/com/freya02/botcommands/internal/prefixed/TextCommandInfo.java
+++ b/src/main/java/com/freya02/botcommands/internal/prefixed/TextCommandInfo.java
@@ -1,5 +1,6 @@
 package com.freya02.botcommands.internal.prefixed;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.application.CommandPath;
 import com.freya02.botcommands.api.application.annotations.AppOption;
 import com.freya02.botcommands.api.parameters.RegexParameterResolver;
@@ -9,7 +10,6 @@ import com.freya02.botcommands.api.prefixed.annotations.JDATextCommand;
 import com.freya02.botcommands.api.prefixed.annotations.TextOption;
 import com.freya02.botcommands.internal.AbstractCommandInfo;
 import com.freya02.botcommands.internal.BContextImpl;
-import com.freya02.botcommands.internal.Logging;
 import com.freya02.botcommands.internal.MethodParameters;
 import com.freya02.botcommands.internal.utils.AnnotationUtils;
 import com.freya02.botcommands.internal.utils.ReflectionUtils;

--- a/src/main/java/com/freya02/botcommands/internal/prefixed/Utils.java
+++ b/src/main/java/com/freya02/botcommands/internal/prefixed/Utils.java
@@ -1,12 +1,12 @@
 package com.freya02.botcommands.internal.prefixed;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.entities.Emoji;
 import com.freya02.botcommands.api.entities.EmojiOrEmote;
 import com.freya02.botcommands.api.parameters.QuotableRegexParameterResolver;
 import com.freya02.botcommands.api.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.prefixed.annotations.Category;
 import com.freya02.botcommands.api.prefixed.annotations.Description;
-import com.freya02.botcommands.internal.Logging;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/freya02/botcommands/internal/utils/AnnotationUtils.java
+++ b/src/main/java/com/freya02/botcommands/internal/utils/AnnotationUtils.java
@@ -3,10 +3,12 @@ package com.freya02.botcommands.internal.utils;
 import com.freya02.botcommands.api.CooldownScope;
 import com.freya02.botcommands.api.annotations.*;
 import com.freya02.botcommands.api.application.annotations.AppOption;
+import com.freya02.botcommands.api.application.slash.annotations.ChannelTypes;
 import com.freya02.botcommands.api.prefixed.annotations.Hidden;
 import com.freya02.botcommands.api.prefixed.annotations.TextOption;
 import com.freya02.botcommands.internal.CooldownStrategy;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.ChannelType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -124,5 +126,12 @@ public class AnnotationUtils {
 		} else {
 			return method.getDeclaringClass().getAnnotation(annotationType);
 		}
+	}
+
+	public static ChannelType[] getEffectiveChannelTypes(Parameter parameter) {
+		final ChannelTypes annotation = parameter.getAnnotation(ChannelTypes.class);
+		if (annotation == null) return new ChannelType[0];
+
+		return annotation.value();
 	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/utils/BResourceBundle.java
+++ b/src/main/java/com/freya02/botcommands/internal/utils/BResourceBundle.java
@@ -1,6 +1,6 @@
 package com.freya02.botcommands.internal.utils;
 
-import com.freya02.botcommands.internal.Logging;
+import com.freya02.botcommands.api.Logging;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;

--- a/src/main/java/com/freya02/botcommands/internal/utils/IOUtils.java
+++ b/src/main/java/com/freya02/botcommands/internal/utils/IOUtils.java
@@ -1,18 +1,8 @@
 package com.freya02.botcommands.internal.utils;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public final class IOUtils {
-	public static Path getJarPath(Class<?> classs) throws IOException {
-		try {
-			return Paths.get(classs.getProtectionDomain().getCodeSource().getLocation().toURI());
-		} catch (URISyntaxException e) {
-			throw new IOException("Could not get the location of " + classs, e);
-		}
-	}
 
 	public static String getFileExtension(Path path) {
 		final String pathStr = path.toString();

--- a/src/main/java/com/freya02/botcommands/internal/utils/ReflectionUtils.java
+++ b/src/main/java/com/freya02/botcommands/internal/utils/ReflectionUtils.java
@@ -1,10 +1,10 @@
 package com.freya02.botcommands.internal.utils;
 
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.annotations.ConditionalUse;
 import com.freya02.botcommands.api.annotations.Optional;
 import com.freya02.botcommands.api.application.slash.annotations.DoubleRange;
 import com.freya02.botcommands.api.application.slash.annotations.LongRange;
-import com.freya02.botcommands.internal.Logging;
 import io.github.classgraph.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/com/freya02/botcommands/internal/utils/ReflectionUtils.java
+++ b/src/main/java/com/freya02/botcommands/internal/utils/ReflectionUtils.java
@@ -3,11 +3,11 @@ package com.freya02.botcommands.internal.utils;
 import com.freya02.botcommands.api.annotations.ConditionalUse;
 import com.freya02.botcommands.api.annotations.Optional;
 import com.freya02.botcommands.api.application.slash.annotations.DoubleRange;
+import com.freya02.botcommands.api.application.slash.annotations.LongRange;
 import com.freya02.botcommands.internal.Logging;
 import io.github.classgraph.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.Range;
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -111,11 +111,11 @@ public class ReflectionUtils {
 	}
 
 	@Nullable
-	public static Range getLongRange(Parameter parameter) {
+	public static LongRange getLongRange(Parameter parameter) {
 		final Map<Class<?>, Annotation> map = paramAnnotationsMap.get(parameter);
 		if (map == null) return null;
 
-		return (Range) map.get(Range.class);
+		return (LongRange) map.get(LongRange.class);
 	}
 
 	@Nullable

--- a/src/main/java/com/freya02/botcommands/internal/utils/ReflectionUtils.java
+++ b/src/main/java/com/freya02/botcommands/internal/utils/ReflectionUtils.java
@@ -1,0 +1,137 @@
+package com.freya02.botcommands.internal.utils;
+
+import com.freya02.botcommands.api.annotations.ConditionalUse;
+import com.freya02.botcommands.internal.Logging;
+import io.github.classgraph.*;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ReflectionUtils {
+	private static final Logger LOGGER = Logging.getLogger();
+
+	private static final Set<Parameter> optionalSet = new HashSet<>();
+
+	@NotNull
+	public static Set<Class<?>> getPackageClasses(@NotNull String packageName, int maxDepth) throws IOException {
+		final Set<Class<?>> classes = new HashSet<>();
+		final String packagePath = packageName.replace('.', File.separatorChar);
+
+		final String classPath = System.getProperty("java.class.path");
+		for (String strPath : classPath.split(";")) {
+			final Path jarPath = Path.of(strPath);
+
+			final Path walkRoot;
+			final boolean isJar = strPath.endsWith("jar");
+			if (isJar) {
+				final FileSystem zfs = FileSystems.newFileSystem(jarPath, (ClassLoader) null);
+				walkRoot = zfs.getPath(packagePath);
+			} else {
+				walkRoot = jarPath.resolve(packagePath);
+			}
+
+			if (Files.notExists(walkRoot)) {
+				continue;
+			}
+
+			Files.walk(walkRoot, maxDepth)
+					.filter(Files::isRegularFile)
+					.filter(p -> IOUtils.getFileExtension(p).equals("class"))
+					.forEach(p -> {
+						// Change from a/b/c/d to c/d
+						final String relativePath = walkRoot.relativize(p).toString().replace('\\',  '.');
+
+						//Remove .class suffix and add package prefix
+						final String result = packageName + "." + relativePath.substring(0, relativePath.length() - 6);
+
+						try {
+							classes.add(Class.forName(result, false, Utils.class.getClassLoader()));
+						} catch (ClassNotFoundException e) {
+							LOGGER.error("Unable to load class {}", result);
+						}
+					});
+
+			break;
+		}
+
+		return classes;
+	}
+
+	public static boolean isInstantiable(Class<?> aClass) throws IllegalAccessException, InvocationTargetException {
+		boolean canInstantiate = true;
+		for (Method declaredMethod : aClass.getDeclaredMethods()) {
+			if (declaredMethod.isAnnotationPresent(ConditionalUse.class)) {
+				if (Modifier.isStatic(declaredMethod.getModifiers())) {
+					if (declaredMethod.getParameterCount() == 0 && declaredMethod.getReturnType() == boolean.class) {
+						if (!declaredMethod.canAccess(null))
+							throw new IllegalStateException("Method " + Utils.formatMethodShort(declaredMethod) + " is not public");
+						canInstantiate = (boolean) declaredMethod.invoke(null);
+					} else {
+						LOGGER.warn("Method {}#{} is annotated @ConditionalUse but does not have the correct signature (return boolean, no parameters)", aClass.getName(), declaredMethod.getName());
+					}
+				} else {
+					LOGGER.warn("Method {}#{} is annotated @ConditionalUse but is not static", aClass.getName(), declaredMethod.getName());
+				}
+
+				break;
+			}
+		}
+
+		return canInstantiate;
+	}
+
+	public static boolean hasFirstParameter(Method method, Class<?> type) {
+		return method.getParameterCount() > 0 && type.isAssignableFrom(method.getParameterTypes()[0]);
+	}
+
+	public static boolean isOptional(Parameter parameter) {
+		return optionalSet.contains(parameter);
+	}
+
+	public static void scanOptionals(Set<Class<?>> classes) {
+		if (classes.isEmpty())
+			return;
+
+		final ScanResult result = new ClassGraph()
+				.acceptClasses(classes.stream().map(Class::getName).toArray(String[]::new))
+				.enableMethodInfo()
+				.enableAnnotationInfo()
+				.scan();
+
+		final ClassInfoList nullableInfos = result.getClassesWithMethodParameterAnnotation("org.jetbrains.annotations.Nullable")
+				.union(result.getClassesWithMethodParameterAnnotation("javax.annotation.Nullable"))
+				.union(result.getClassesWithMethodParameterAnnotation("com.freya02.botcommands.api.annotations.Optional"));
+
+		for (ClassInfo classInfo : nullableInfos) {
+			for (MethodInfo info : classInfo.getDeclaredMethodInfo()) {
+				if (info.isConstructor())
+					continue;
+
+				final Method method = info.loadClassAndGetMethod();
+
+				MethodParameterInfo[] infoParameterInfo = info.getParameterInfo();
+				for (int i = 0, infoParameterInfoLength = infoParameterInfo.length; i < infoParameterInfoLength; i++) {
+					MethodParameterInfo parameterInfo = infoParameterInfo[i];
+
+					if (!parameterInfo.hasAnnotation("org.jetbrains.annotations.Nullable")
+							&& !parameterInfo.hasAnnotation("com.freya02.botcommands.api.annotations.Optional")
+							&& !parameterInfo.hasAnnotation("javax.annotation.Nullable")) continue;
+
+					optionalSet.add(method.getParameters()[i]);
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/com/freya02/botcommands/internal/utils/Utils.java
+++ b/src/main/java/com/freya02/botcommands/internal/utils/Utils.java
@@ -1,8 +1,8 @@
 package com.freya02.botcommands.internal.utils;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.Logging;
 import com.freya02.botcommands.api.components.ComponentManager;
-import com.freya02.botcommands.internal.Logging;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/freya02/botcommands/internal/utils/Utils.java
+++ b/src/main/java/com/freya02/botcommands/internal/utils/Utils.java
@@ -3,6 +3,7 @@ package com.freya02.botcommands.internal.utils;
 import com.freya02.botcommands.api.BContext;
 import com.freya02.botcommands.api.components.ComponentManager;
 import com.freya02.botcommands.internal.Logging;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -57,6 +58,18 @@ public final class Utils {
 		}
 
 		return e;
+	}
+
+	public static ErrorResponseException getErrorResponseException(Throwable e) {
+		do {
+			if (e instanceof ErrorResponseException ex) {
+				return ex;
+			}
+
+			e = e.getCause();
+		} while (e != null);
+
+		return null;
 	}
 
 	public static String randomId(int n) {

--- a/src/main/java/com/freya02/botcommands/internal/utils/Utils.java
+++ b/src/main/java/com/freya02/botcommands/internal/utils/Utils.java
@@ -1,29 +1,16 @@
 package com.freya02.botcommands.internal.utils;
 
 import com.freya02.botcommands.api.BContext;
-import com.freya02.botcommands.api.annotations.ConditionalUse;
 import com.freya02.botcommands.api.components.ComponentManager;
 import com.freya02.botcommands.internal.Logging;
-import io.github.classgraph.*;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
 import java.io.CharArrayWriter;
-import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
@@ -32,52 +19,6 @@ public final class Utils {
 	private static final char[] chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?_^[]{}|".toCharArray();
 
 	private static final Logger LOGGER = Logging.getLogger();
-	private static final Set<Parameter> optionalSet = new HashSet<>();
-
-	@NotNull
-	public static Set<Class<?>> getPackageClasses(@NotNull String packageName, int maxDepth) throws IOException {
-		final Set<Class<?>> classes = new HashSet<>();
-		final String packagePath = packageName.replace('.', File.separatorChar);
-
-		final String classPath = System.getProperty("java.class.path");
-		for (String strPath : classPath.split(";")) {
-			final Path jarPath = Path.of(strPath);
-
-			final Path walkRoot;
-			final boolean isJar = strPath.endsWith("jar");
-			if (isJar) {
-				final FileSystem zfs = FileSystems.newFileSystem(jarPath, (ClassLoader) null);
-				walkRoot = zfs.getPath(packagePath);
-			} else {
-				walkRoot = jarPath.resolve(packagePath);
-			}
-
-			if (Files.notExists(walkRoot)) {
-				continue;
-			}
-
-			Files.walk(walkRoot, maxDepth)
-					.filter(Files::isRegularFile)
-					.filter(p -> IOUtils.getFileExtension(p).equals("class"))
-					.forEach(p -> {
-						// Change from a/b/c/d to c/d
-						final String relativePath = walkRoot.relativize(p).toString().replace('\\',  '.');
-
-						//Remove .class suffix and add package prefix
-						final String result = packageName + "." + relativePath.substring(0, relativePath.length() - 6);
-
-						try {
-							classes.add(Class.forName(result, false, Utils.class.getClassLoader()));
-						} catch (ClassNotFoundException e) {
-							LOGGER.error("Unable to load class {}", result);
-						}
-					});
-
-			break;
-		}
-
-		return classes;
-	}
 
 	@Contract("null, _ -> fail")
 	@NotNull
@@ -104,32 +45,6 @@ public final class Utils {
 		e.printStackTrace(printWriter);
 
 		LOGGER.error(out.toString());
-	}
-
-	public static boolean isInstantiable(Class<?> aClass) throws IllegalAccessException, InvocationTargetException {
-		boolean canInstantiate = true;
-		for (Method declaredMethod : aClass.getDeclaredMethods()) {
-			if (declaredMethod.isAnnotationPresent(ConditionalUse.class)) {
-				if (Modifier.isStatic(declaredMethod.getModifiers())) {
-					if (declaredMethod.getParameterCount() == 0 && declaredMethod.getReturnType() == boolean.class) {
-						if (!declaredMethod.canAccess(null))
-							throw new IllegalStateException("Method " + Utils.formatMethodShort(declaredMethod) + " is not public");
-						canInstantiate = (boolean) declaredMethod.invoke(null);
-					} else {
-						LOGGER.warn("Method {}#{} is annotated @ConditionalUse but does not have the correct signature (return boolean, no parameters)", aClass.getName(), declaredMethod.getName());
-					}
-				} else {
-					LOGGER.warn("Method {}#{} is annotated @ConditionalUse but is not static", aClass.getName(), declaredMethod.getName());
-				}
-				break;
-			}
-		}
-
-		return canInstantiate;
-	}
-
-	public static boolean hasFirstParameter(Method method, Class<?> type) {
-		return method.getParameterCount() > 0 && type.isAssignableFrom(method.getParameterTypes()[0]);
 	}
 
 	/**
@@ -193,51 +108,13 @@ public final class Utils {
 		}
 	}
 
-	public static String formatMethodShort(Method method) {
+	@NotNull
+	public static String formatMethodShort(@NotNull Method method) {
 		return method.getDeclaringClass().getSimpleName()
 				+ "#"
 				+ method.getName()
 				+ Arrays.stream(method.getParameterTypes())
 				.map(Class::getSimpleName)
 				.collect(Collectors.joining(", ", "(", ")"));
-	}
-
-	public static boolean isOptional(Parameter parameter) {
-		return optionalSet.contains(parameter);
-	}
-
-	public static void scanOptionals(Set<Class<?>> classes) {
-		if (classes.isEmpty())
-			return;
-
-		final ScanResult result = new ClassGraph()
-				.acceptClasses(classes.stream().map(Class::getName).toArray(String[]::new))
-				.enableMethodInfo()
-				.enableAnnotationInfo()
-				.scan();
-
-		final ClassInfoList nullableInfos = result.getClassesWithMethodParameterAnnotation("org.jetbrains.annotations.Nullable")
-				.union(result.getClassesWithMethodParameterAnnotation("javax.annotation.Nullable"))
-				.union(result.getClassesWithMethodParameterAnnotation("com.freya02.botcommands.api.annotations.Optional"));
-
-		for (ClassInfo classInfo : nullableInfos) {
-			for (MethodInfo info : classInfo.getDeclaredMethodInfo()) {
-				if (info.isConstructor())
-					continue;
-
-				final Method method = info.loadClassAndGetMethod();
-
-				MethodParameterInfo[] infoParameterInfo = info.getParameterInfo();
-				for (int i = 0, infoParameterInfoLength = infoParameterInfo.length; i < infoParameterInfoLength; i++) {
-					MethodParameterInfo parameterInfo = infoParameterInfo[i];
-
-					if (!parameterInfo.hasAnnotation("org.jetbrains.annotations.Nullable")
-							&& !parameterInfo.hasAnnotation("com.freya02.botcommands.api.annotations.Optional")
-							&& !parameterInfo.hasAnnotation("javax.annotation.Nullable")) continue;
-
-					optionalSet.add(method.getParameters()[i]);
-				}
-			}
-		}
 	}
 }


### PR DESCRIPTION
# Changed
* Updated to a JDA 5 fork (with autocomplete, context menus, min/max and channel types
* Searching for classes in the VM's classpath instead of supplying a `jarPath`
* Application commands update should be async, but still requires all shards to be ready
* Updated dependencies
* Only ship API docs
* Moved `DefaultMessages` and `Logging` to API package
* Replaced `Consumer<ButtonEvent>` and `Consumer<SelectEvent>` by `ButtonConsumer` and `SelectConsumer`
* Fixed application command updating issues due to JSON content arrangement and *possible* race conditions
* Set a 10 minutes cooldown between messages sent to bot owners for exceptions

# Added
* Auto completion for slash commands (& state aware, which means you can ask for previously sent arguments as to make a better decision)
* Min / Max for slash command options
* Channel types for slash command options (inferred or with annotation)
* Building buttons with `ButtonContent` using string *and* emojis
