### PR TITLE
Replace query logging by using a `Logger` instead

### DIFF
--- a/sql/CreateDatabase.sql
+++ b/sql/CreateDatabase.sql
@@ -1,7 +1,6 @@
 ------------ Base framework
 
 drop table if exists bc_version cascade;
-drop table if exists bc_statement_result cascade;
 
 create table bc_version
 (
@@ -11,14 +10,6 @@ create table bc_version
 
 insert into bc_version
 values (true, '3.0.0-alpha.1'); -- Change in Database.kt too
-
-create table bc_statement_result
-(
-    id         serial   not null primary key,
-    query      text     not null,
-    success    smallint not null,
-    time_nanos bigint   not null
-);
 
 ------------ Components
 

--- a/src/main/kotlin/com/freya02/botcommands/api/core/config/BConfig.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/core/config/BConfig.kt
@@ -71,6 +71,10 @@ class BConfig internal constructor() {
     fun hasConnectionProvider() = ::connectionProvider.toDelegate<LockableVar<*>>().hasValue()
 
     /**
+     * Determines whether the SQL queries should be logged
+     */
+    var logQueries: Boolean = true
+    /**
      * Determines if the SQL query logger will replace query parameters by their value.
      */
     var logQueryParameters: Boolean = true

--- a/src/main/kotlin/com/freya02/botcommands/api/core/config/BConfig.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/core/config/BConfig.kt
@@ -71,6 +71,11 @@ class BConfig internal constructor() {
     fun hasConnectionProvider() = ::connectionProvider.toDelegate<LockableVar<*>>().hasValue()
 
     /**
+     * Determines if the SQL query logger will replace query parameters by their value.
+     */
+    var logQueryParameters: Boolean = true
+
+    /**
      * Adds owners, they can access the commands annotated with [RequireOwner]
      *
      * @param ownerIds Owners Long IDs to add

--- a/src/main/kotlin/com/freya02/botcommands/internal/core/db/Database.kt
+++ b/src/main/kotlin/com/freya02/botcommands/internal/core/db/Database.kt
@@ -10,7 +10,7 @@ import org.intellij.lang.annotations.Language
 import java.sql.Connection
 
 @ConditionalService
-class Database internal constructor(private val config: BConfig) {
+class Database internal constructor(internal val config: BConfig) {
     init {
         config.connectionProvider.get().use { conn ->
             conn.prepareStatement("select version from bc_version").use {

--- a/src/main/kotlin/com/freya02/botcommands/internal/core/db/KPreparedStatement.kt
+++ b/src/main/kotlin/com/freya02/botcommands/internal/core/db/KPreparedStatement.kt
@@ -53,6 +53,10 @@ class KPreparedStatement(val database: Database, val preparedStatement: Prepared
 
         return preparedStatement.toString().substring(index + indexMarker.length)
             .lines()
+            .map {
+                val endIndex = Regex("--(?!.*')").find(it)?.range?.start ?: it.length
+                it.substring(0, endIndex)
+            }
             .joinToString(" ") { it.trim() }
     }
 

--- a/src/main/kotlin/com/freya02/botcommands/internal/core/db/KPreparedStatement.kt
+++ b/src/main/kotlin/com/freya02/botcommands/internal/core/db/KPreparedStatement.kt
@@ -61,7 +61,7 @@ class KPreparedStatement(val database: Database, val preparedStatement: Prepared
         return preparedStatement.toString().substring(index + indexMarker.length)
             .lines()
             .map {
-                val endIndex = Regex("--(?!.*')").find(it)?.range?.start ?: it.length
+                val endIndex = commentRegex.find(it)?.range?.start ?: it.length
                 it.substring(0, endIndex)
             }
             .joinToString(" ") { it.trim() }
@@ -73,5 +73,7 @@ class KPreparedStatement(val database: Database, val preparedStatement: Prepared
 
     companion object {
         private val logger = KotlinLogging.logger { }
+
+        private val commentRegex = Regex("--(?!.*')")
     }
 }


### PR DESCRIPTION
* Can include primitive query parameters
* Can be disabled