### PR TITLE
Add dynamic help examples

### DIFF
--- a/src/main/java/com/freya02/botcommands/api/parameters/QuotableRegexParameterResolver.java
+++ b/src/main/java/com/freya02/botcommands/api/parameters/QuotableRegexParameterResolver.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
  * Interface which indicates this class can resolve parameters for regex commands.
  * <br><b>Must be used with {@link RegexParameterResolver}.</b>
  */
-public interface QuotableRegexParameterResolver {
+public interface QuotableRegexParameterResolver<T extends ParameterResolver<T, R> & QuotableRegexParameterResolver<T, R>, R> extends RegexParameterResolver<T, R> {
 	/**
 	 * Returns a quoted pattern of the parameter resolver
 	 *
@@ -18,4 +18,10 @@ public interface QuotableRegexParameterResolver {
 	 */
 	@NotNull
 	Pattern getQuotedPattern();
+
+	@NotNull
+	@Override
+	default Pattern getPreferredPattern() {
+		return getQuotedPattern();
+	}
 }

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/BooleanResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/BooleanResolver.java
@@ -48,6 +48,12 @@ public class BooleanResolver
 		return "true";
 	}
 
+	@NotNull
+	@Override
+	public String getHelpExample(boolean isID) {
+		return "true";
+	}
+
 	@Override
 	@NotNull
 	public OptionType getOptionType() {

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/BooleanResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/BooleanResolver.java
@@ -9,6 +9,7 @@ import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import com.freya02.botcommands.internal.commands.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation;
 import com.freya02.botcommands.internal.components.ComponentDescriptor;
+import kotlin.reflect.KParameter;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload;
@@ -50,7 +51,7 @@ public class BooleanResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
 		return "true";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/BooleanResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/BooleanResolver.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.parameters.resolvers;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.core.service.annotations.Resolver;
 import com.freya02.botcommands.api.parameters.ComponentParameterResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
@@ -51,7 +52,7 @@ public class BooleanResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, @NotNull BaseCommandEvent event, boolean isID) {
 		return "true";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/DoubleResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/DoubleResolver.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.parameters.resolvers;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.core.service.annotations.Resolver;
 import com.freya02.botcommands.api.parameters.ComponentParameterResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
@@ -55,7 +56,7 @@ public class DoubleResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, @NotNull BaseCommandEvent event, boolean isID) {
 		return "3.14159";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/DoubleResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/DoubleResolver.java
@@ -52,6 +52,12 @@ public class DoubleResolver
 		return "1234.42";
 	}
 
+	@NotNull
+	@Override
+	public String getHelpExample(boolean isID) {
+		return "3.14159";
+	}
+
 	@Override
 	@NotNull
 	public OptionType getOptionType() {

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/DoubleResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/DoubleResolver.java
@@ -9,6 +9,7 @@ import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import com.freya02.botcommands.internal.commands.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation;
 import com.freya02.botcommands.internal.components.ComponentDescriptor;
+import kotlin.reflect.KParameter;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload;
@@ -54,7 +55,7 @@ public class DoubleResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
 		return "3.14159";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/EmojiResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/EmojiResolver.java
@@ -10,6 +10,7 @@ import com.freya02.botcommands.api.utils.EmojiUtils;
 import com.freya02.botcommands.internal.commands.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation;
 import com.freya02.botcommands.internal.components.ComponentDescriptor;
+import kotlin.reflect.KParameter;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
@@ -55,7 +56,7 @@ public class EmojiResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
 		return ":joy:";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/EmojiResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/EmojiResolver.java
@@ -53,6 +53,12 @@ public class EmojiResolver
 		return "<:name:1234>";
 	}
 
+	@NotNull
+	@Override
+	public String getHelpExample(boolean isID) {
+		return ":joy:";
+	}
+
 	@Override
 	@NotNull
 	public OptionType getOptionType() {

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/EmojiResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/EmojiResolver.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.parameters.resolvers;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.core.service.annotations.Resolver;
 import com.freya02.botcommands.api.parameters.ComponentParameterResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
@@ -56,7 +57,7 @@ public class EmojiResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, @NotNull BaseCommandEvent event, boolean isID) {
 		return ":joy:";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/GuildResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/GuildResolver.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.parameters.resolvers;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.core.service.annotations.Resolver;
 import com.freya02.botcommands.api.parameters.ComponentParameterResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
@@ -53,8 +54,8 @@ public class GuildResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
-		return "guild-id";
+	public String getHelpExample(@NotNull KParameter parameter, @NotNull BaseCommandEvent event, boolean isID) {
+		return event.getGuild().getId();
 	}
 
 	@Override

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/GuildResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/GuildResolver.java
@@ -50,6 +50,12 @@ public class GuildResolver
 		return "1234";
 	}
 
+	@NotNull
+	@Override
+	public String getHelpExample(boolean isID) {
+		return "guild-id";
+	}
+
 	@Override
 	@NotNull
 	public OptionType getOptionType() {

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/GuildResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/GuildResolver.java
@@ -9,6 +9,7 @@ import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import com.freya02.botcommands.internal.commands.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation;
 import com.freya02.botcommands.internal.components.ComponentDescriptor;
+import kotlin.reflect.KParameter;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
@@ -52,7 +53,7 @@ public class GuildResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
 		return "guild-id";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/IntegerResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/IntegerResolver.java
@@ -52,6 +52,12 @@ public class IntegerResolver
 		return "1234";
 	}
 
+	@NotNull
+	@Override
+	public String getHelpExample(boolean isID) {
+		return "42";
+	}
+
 	@Override
 	@NotNull
 	public OptionType getOptionType() {

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/IntegerResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/IntegerResolver.java
@@ -9,6 +9,7 @@ import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import com.freya02.botcommands.internal.commands.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation;
 import com.freya02.botcommands.internal.components.ComponentDescriptor;
+import kotlin.reflect.KParameter;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload;
@@ -54,7 +55,7 @@ public class IntegerResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
 		return "42";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/IntegerResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/IntegerResolver.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.parameters.resolvers;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.core.service.annotations.Resolver;
 import com.freya02.botcommands.api.parameters.ComponentParameterResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
@@ -55,7 +56,7 @@ public class IntegerResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, @NotNull BaseCommandEvent event, boolean isID) {
 		return "42";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/LongResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/LongResolver.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.parameters.resolvers;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.core.service.annotations.Resolver;
 import com.freya02.botcommands.api.parameters.ComponentParameterResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
@@ -55,7 +56,7 @@ public class LongResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, @NotNull BaseCommandEvent event, boolean isID) {
 		return isID ? "222046562543468545" : "42";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/LongResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/LongResolver.java
@@ -52,6 +52,12 @@ public class LongResolver
 		return "1234";
 	}
 
+	@NotNull
+	@Override
+	public String getHelpExample(boolean isID) {
+		return isID ? "222046562543468545" : "42";
+	}
+
 	@Override
 	@NotNull
 	public OptionType getOptionType() {

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/LongResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/LongResolver.java
@@ -9,6 +9,7 @@ import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import com.freya02.botcommands.internal.commands.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation;
 import com.freya02.botcommands.internal.components.ComponentDescriptor;
+import kotlin.reflect.KParameter;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload;
@@ -54,7 +55,7 @@ public class LongResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
 		return isID ? "222046562543468545" : "42";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/RoleResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/RoleResolver.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.parameters.resolvers;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.core.service.annotations.Resolver;
 import com.freya02.botcommands.api.parameters.ComponentParameterResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
@@ -57,8 +58,11 @@ public class RoleResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
-		return "role-id/mention";
+	public String getHelpExample(@NotNull KParameter parameter, @NotNull BaseCommandEvent event, boolean isID) {
+		return event.getMember().getRoles().stream().findAny()
+				.or(() -> event.getGuild().getRoleCache().streamUnordered().findAny())
+				.map(Role::getAsMention)
+				.orElse("role-id/mention");
 	}
 
 	@Override

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/RoleResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/RoleResolver.java
@@ -9,6 +9,7 @@ import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import com.freya02.botcommands.internal.commands.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation;
 import com.freya02.botcommands.internal.components.ComponentDescriptor;
+import kotlin.reflect.KParameter;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -56,7 +57,7 @@ public class RoleResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
 		return "role-id/mention";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/RoleResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/RoleResolver.java
@@ -54,6 +54,12 @@ public class RoleResolver
 		return "<@&1234>";
 	}
 
+	@NotNull
+	@Override
+	public String getHelpExample(boolean isID) {
+		return "role-id/mention";
+	}
+
 	@Override
 	@NotNull
 	public OptionType getOptionType() {

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/StringResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/StringResolver.java
@@ -7,6 +7,7 @@ import com.freya02.botcommands.internal.commands.application.slash.SlashCommandI
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation;
 import com.freya02.botcommands.internal.components.ComponentDescriptor;
 import com.freya02.botcommands.internal.modals.ModalHandlerInfo;
+import kotlin.reflect.KParameter;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -58,7 +59,7 @@ public class StringResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
 		return "foo bar";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/StringResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/StringResolver.java
@@ -23,8 +23,7 @@ import java.util.regex.Pattern;
 @Resolver
 public class StringResolver
 		extends ParameterResolver<StringResolver, String>
-		implements RegexParameterResolver<StringResolver, String>,
-		           QuotableRegexParameterResolver,
+		implements QuotableRegexParameterResolver<StringResolver, String>,
 		           SlashParameterResolver<StringResolver, String>,
 		           ComponentParameterResolver<StringResolver, String>,
 		           ModalParameterResolver<StringResolver, String> {

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/StringResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/StringResolver.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.parameters.resolvers;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.core.service.annotations.Resolver;
 import com.freya02.botcommands.api.parameters.*;
 import com.freya02.botcommands.internal.commands.application.slash.SlashCommandInfo;
@@ -58,7 +59,7 @@ public class StringResolver
 
 	@NotNull
 	@Override
-	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, @NotNull BaseCommandEvent event, boolean isID) {
 		return "foo bar";
 	}
 

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/StringResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/StringResolver.java
@@ -56,6 +56,12 @@ public class StringResolver
 		return "foobar";
 	}
 
+	@NotNull
+	@Override
+	public String getHelpExample(boolean isID) {
+		return "foo bar";
+	}
+
 	@Override
 	@NotNull
 	public OptionType getOptionType() {

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/channels/AbstractChannelResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/channels/AbstractChannelResolver.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.parameters.resolvers.channels;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.parameters.ComponentParameterResolver;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
 import com.freya02.botcommands.api.parameters.RegexParameterResolver;
@@ -72,8 +73,8 @@ public abstract class AbstractChannelResolver<T extends GuildChannel>
 
 	@NotNull
 	@Override
-	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
-		return "channel-id/mention";
+	public String getHelpExample(@NotNull KParameter parameter, @NotNull BaseCommandEvent event, boolean isID) {
+		return event.getChannel().getAsMention();
 	}
 
 	@Override

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/channels/AbstractChannelResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/channels/AbstractChannelResolver.java
@@ -69,6 +69,12 @@ public abstract class AbstractChannelResolver<T extends GuildChannel>
 		return "<#1234>";
 	}
 
+	@NotNull
+	@Override
+	public String getHelpExample(boolean isID) {
+		return "channel-id/mention";
+	}
+
 	@Override
 	@NotNull
 	public OptionType getOptionType() {

--- a/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/channels/AbstractChannelResolver.java
+++ b/src/main/java/com/freya02/botcommands/internal/parameters/resolvers/channels/AbstractChannelResolver.java
@@ -8,6 +8,7 @@ import com.freya02.botcommands.api.parameters.SlashParameterResolver;
 import com.freya02.botcommands.internal.commands.application.slash.SlashCommandInfo;
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation;
 import com.freya02.botcommands.internal.components.ComponentDescriptor;
+import kotlin.reflect.KParameter;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
@@ -71,7 +72,7 @@ public abstract class AbstractChannelResolver<T extends GuildChannel>
 
 	@NotNull
 	@Override
-	public String getHelpExample(boolean isID) {
+	public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
 		return "channel-id/mention";
 	}
 

--- a/src/main/kotlin/com/freya02/botcommands/api/parameters/ComponentParameterResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/parameters/ComponentParameterResolver.kt
@@ -7,7 +7,8 @@ import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteract
 /**
  * Interface which indicates this class can resolve parameters for buttons commands
  */
-interface ComponentParameterResolver<T : ParameterResolver<T, R>, R> {
+interface ComponentParameterResolver<T, R> where T : ParameterResolver<T, R>,
+                                                 T : ComponentParameterResolver<T, R> {
     /**
      * Returns a resolved object from this component interaction
      *

--- a/src/main/kotlin/com/freya02/botcommands/api/parameters/ICustomResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/parameters/ICustomResolver.kt
@@ -4,7 +4,8 @@ import com.freya02.botcommands.api.BContext
 import com.freya02.botcommands.internal.IExecutableInteractionInfo
 import net.dv8tion.jda.api.events.Event
 
-interface ICustomResolver<T : ParameterResolver<T, R>, R> {
+interface ICustomResolver<T, R> where T : ParameterResolver<T, R>,
+                                      T : ICustomResolver<T, R> {
     fun resolve(context: BContext, executableInteractionInfo: IExecutableInteractionInfo, event: Event): R? =
         throw UnsupportedOperationException("${this.javaClass.simpleName} must implement the 'resolve' or 'resolveSuspend' method")
 

--- a/src/main/kotlin/com/freya02/botcommands/api/parameters/MessageContextParameterResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/parameters/MessageContextParameterResolver.kt
@@ -4,7 +4,8 @@ import com.freya02.botcommands.api.BContext
 import com.freya02.botcommands.internal.commands.application.context.message.MessageCommandInfo
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 
-interface MessageContextParameterResolver<T : ParameterResolver<T, R>, R> {
+interface MessageContextParameterResolver<T, R> where T : ParameterResolver<T, R>,
+                                                      T : MessageContextParameterResolver<T, R> {
     /**
      * Returns a resolved object from this message context interaction
      *

--- a/src/main/kotlin/com/freya02/botcommands/api/parameters/ModalParameterResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/parameters/ModalParameterResolver.kt
@@ -5,7 +5,8 @@ import com.freya02.botcommands.internal.modals.ModalHandlerInfo
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.interactions.modals.ModalMapping
 
-interface ModalParameterResolver<T : ParameterResolver<T, R>, R> {
+interface ModalParameterResolver<T, R> where T : ParameterResolver<T, R>,
+                                             T : ModalParameterResolver<T, R> {
     /**
      * Returns a resolved object for this [ModalMapping]
      *

--- a/src/main/kotlin/com/freya02/botcommands/api/parameters/RegexParameterResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/parameters/RegexParameterResolver.kt
@@ -5,6 +5,7 @@ import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation
 import com.freya02.botcommands.internal.utils.throwUser
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import java.util.regex.Pattern
+import kotlin.reflect.KParameter
 
 /**
  * Interface which indicates this class can resolve parameters for regex commands
@@ -71,5 +72,5 @@ interface RegexParameterResolver<T : ParameterResolver<T, R>, R> {
             else -> pattern
         }
 
-    fun getHelpExample(isID: Boolean): String
+    fun getHelpExample(parameter: KParameter, isID: Boolean): String
 }

--- a/src/main/kotlin/com/freya02/botcommands/api/parameters/RegexParameterResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/parameters/RegexParameterResolver.kt
@@ -15,7 +15,7 @@ interface RegexParameterResolver<T : ParameterResolver<T, R>, R> {
      *
      * @param context   The [BContext] of this bot
      * @param variation The text command variation of the command being executed
-     * @param event     The event of this received message
+     * @param event     The event of the received message
      * @param args      The text arguments of this command, extracted with [pattern]
      *
      * @return The resolved option mapping
@@ -70,4 +70,6 @@ interface RegexParameterResolver<T : ParameterResolver<T, R>, R> {
             is QuotableRegexParameterResolver -> this.quotedPattern
             else -> pattern
         }
+
+    fun getHelpExample(isID: Boolean): String
 }

--- a/src/main/kotlin/com/freya02/botcommands/api/parameters/RegexParameterResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/parameters/RegexParameterResolver.kt
@@ -2,6 +2,7 @@ package com.freya02.botcommands.api.parameters
 
 import com.freya02.botcommands.api.BContext
 import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent
+import com.freya02.botcommands.api.commands.prefixed.annotations.ID
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation
 import com.freya02.botcommands.internal.utils.throwUser
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
@@ -71,5 +72,14 @@ interface RegexParameterResolver<T, R> where T : ParameterResolver<T, R>,
     val preferredPattern: Pattern
         get() = pattern
 
+    /**
+     * Returns a help example for this parameter.
+     *
+     * **Tip:** You may use the event as a way to get sample data (such as getting the member, channel, roles, etc...).
+     *
+     * @param parameter the [parameter][KParameter] of the command being shown in the help content
+     * @param event the event of the command that triggered help content to be displayed
+     * @param isID whether this option was [marked as being an ID][ID]
+     */
     fun getHelpExample(parameter: KParameter, event: BaseCommandEvent, isID: Boolean): String
 }

--- a/src/main/kotlin/com/freya02/botcommands/api/parameters/RegexParameterResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/parameters/RegexParameterResolver.kt
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.api.parameters
 
 import com.freya02.botcommands.api.BContext
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation
 import com.freya02.botcommands.internal.utils.throwUser
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
@@ -70,5 +71,5 @@ interface RegexParameterResolver<T, R> where T : ParameterResolver<T, R>,
     val preferredPattern: Pattern
         get() = pattern
 
-    fun getHelpExample(parameter: KParameter, isID: Boolean): String
+    fun getHelpExample(parameter: KParameter, event: BaseCommandEvent, isID: Boolean): String
 }

--- a/src/main/kotlin/com/freya02/botcommands/api/parameters/RegexParameterResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/parameters/RegexParameterResolver.kt
@@ -10,7 +10,8 @@ import kotlin.reflect.KParameter
 /**
  * Interface which indicates this class can resolve parameters for regex commands
  */
-interface RegexParameterResolver<T : ParameterResolver<T, R>, R> {
+interface RegexParameterResolver<T, R> where T : ParameterResolver<T, R>,
+                                             T : RegexParameterResolver<T, R> {
     /**
      * Returns a resolved object from this text command interaction
      *
@@ -67,10 +68,7 @@ interface RegexParameterResolver<T : ParameterResolver<T, R>, R> {
     val testExample: String
 
     val preferredPattern: Pattern
-        get() = when (this) {
-            is QuotableRegexParameterResolver -> this.quotedPattern
-            else -> pattern
-        }
+        get() = pattern
 
     fun getHelpExample(parameter: KParameter, isID: Boolean): String
 }

--- a/src/main/kotlin/com/freya02/botcommands/api/parameters/SlashParameterResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/parameters/SlashParameterResolver.kt
@@ -16,7 +16,8 @@ import net.dv8tion.jda.api.interactions.commands.OptionType
 /**
  * Interface which indicates this class can resolve parameters for application commands
  */
-interface SlashParameterResolver<T : ParameterResolver<T, R>, R> {
+interface SlashParameterResolver<T, R> where T : ParameterResolver<T, R>,
+                                             T : SlashParameterResolver<T, R> {
     /**
      * Returns the supported [OptionType] for this slash command parameter
      *

--- a/src/main/kotlin/com/freya02/botcommands/api/parameters/UserContextParameterResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/api/parameters/UserContextParameterResolver.kt
@@ -4,7 +4,8 @@ import com.freya02.botcommands.api.BContext
 import com.freya02.botcommands.internal.commands.application.context.user.UserCommandInfo
 import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEvent
 
-interface UserContextParameterResolver<T : ParameterResolver<T, R>, R> {
+interface UserContextParameterResolver<T, R> where T : ParameterResolver<T, R>,
+                                                   T : UserContextParameterResolver<T, R> {
     /**
      * Returns a resolved object from this user context interaction
      *

--- a/src/main/kotlin/com/freya02/botcommands/internal/commands/prefixed/TextUtils.kt
+++ b/src/main/kotlin/com/freya02/botcommands/internal/commands/prefixed/TextUtils.kt
@@ -78,7 +78,7 @@ object TextUtils {
     }
 
     private fun getArgExample(needsQuote: Boolean, commandOption: TextCommandOption): String {
-        val example = commandOption.helpExample ?: commandOption.resolver.getHelpExample(commandOption.isId)
+        val example = commandOption.helpExample ?: commandOption.resolver.getHelpExample(commandOption.kParameter, commandOption.isId)
 
         return when {
             needsQuote && commandOption.resolver is QuotableRegexParameterResolver -> "\"$example\""

--- a/src/main/kotlin/com/freya02/botcommands/internal/commands/prefixed/TextUtils.kt
+++ b/src/main/kotlin/com/freya02/botcommands/internal/commands/prefixed/TextUtils.kt
@@ -42,7 +42,7 @@ object TextUtils {
                     val boxedType = commandOption.type.jvmErasure
 
                     val argName = getArgName(needsQuote, commandOption, boxedType)
-                    val argExample = getArgExample(needsQuote, commandOption)
+                    val argExample = getArgExample(needsQuote, commandOption, event)
 
                     val isOptional = commandOption.isOptionalOrNullable
                     syntax.append(if (isOptional) '[' else '`').append(argName).append(if (isOptional) ']' else '`').append(' ')
@@ -77,8 +77,9 @@ object TextUtils {
         return builder
     }
 
-    private fun getArgExample(needsQuote: Boolean, commandOption: TextCommandOption): String {
-        val example = commandOption.helpExample ?: commandOption.resolver.getHelpExample(commandOption.kParameter, commandOption.isId)
+    private fun getArgExample(needsQuote: Boolean, commandOption: TextCommandOption, event: BaseCommandEvent): String {
+        val example = commandOption.helpExample
+            ?: commandOption.resolver.getHelpExample(commandOption.kParameter, event, commandOption.isId)
 
         return when {
             needsQuote && commandOption.resolver is QuotableRegexParameterResolver -> "\"$example\""

--- a/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/MemberResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/MemberResolver.kt
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import java.util.regex.Pattern
+import kotlin.reflect.KParameter
 
 @Resolver
 class MemberResolver : ParameterResolver<MemberResolver, Member>(Member::class),
@@ -32,7 +33,7 @@ class MemberResolver : ParameterResolver<MemberResolver, Member>(Member::class),
     override val pattern: Pattern = Pattern.compile("(?:<@!?)?(\\d+)>?")
     override val testExample: String = "<@1234>"
 
-    override fun getHelpExample(isID: Boolean): String {
+    override fun getHelpExample(parameter: KParameter, isID: Boolean): String {
         return "member-id/mention"
     }
 

--- a/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/MemberResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/MemberResolver.kt
@@ -32,6 +32,10 @@ class MemberResolver : ParameterResolver<MemberResolver, Member>(Member::class),
     override val pattern: Pattern = Pattern.compile("(?:<@!?)?(\\d+)>?")
     override val testExample: String = "<@1234>"
 
+    override fun getHelpExample(isID: Boolean): String {
+        return "member-id/mention"
+    }
+
     override val optionType: OptionType = OptionType.USER
 
     override suspend fun resolveSuspend(

--- a/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/MemberResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/MemberResolver.kt
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.parameters.resolvers
 
 import com.freya02.botcommands.api.BContext
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent
 import com.freya02.botcommands.api.core.service.annotations.Resolver
 import com.freya02.botcommands.api.core.utils.onErrorResponse
 import com.freya02.botcommands.api.core.utils.onErrorResponseException
@@ -33,8 +34,8 @@ class MemberResolver : ParameterResolver<MemberResolver, Member>(Member::class),
     override val pattern: Pattern = Pattern.compile("(?:<@!?)?(\\d+)>?")
     override val testExample: String = "<@1234>"
 
-    override fun getHelpExample(parameter: KParameter, isID: Boolean): String {
-        return "member-id/mention"
+    override fun getHelpExample(parameter: KParameter, event: BaseCommandEvent, isID: Boolean): String {
+        return event.member.asMention
     }
 
     override val optionType: OptionType = OptionType.USER

--- a/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/UserResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/UserResolver.kt
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.internal.parameters.resolvers
 
 import com.freya02.botcommands.api.BContext
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent
 import com.freya02.botcommands.api.core.service.annotations.Resolver
 import com.freya02.botcommands.api.core.utils.onErrorResponseException
 import com.freya02.botcommands.api.parameters.*
@@ -33,8 +34,8 @@ class UserResolver : ParameterResolver<UserResolver, User>(User::class),
     override val testExample: String = "<@1234>"
     override val optionType: OptionType = OptionType.USER
 
-    override fun getHelpExample(parameter: KParameter, isID: Boolean): String {
-        return "user-id/mention"
+    override fun getHelpExample(parameter: KParameter, event: BaseCommandEvent, isID: Boolean): String {
+        return event.member.asMention
     }
 
     override suspend fun resolveSuspend(

--- a/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/UserResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/UserResolver.kt
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import java.util.regex.Pattern
+import kotlin.reflect.KParameter
 
 @Resolver
 class UserResolver : ParameterResolver<UserResolver, User>(User::class),
@@ -32,7 +33,7 @@ class UserResolver : ParameterResolver<UserResolver, User>(User::class),
     override val testExample: String = "<@1234>"
     override val optionType: OptionType = OptionType.USER
 
-    override fun getHelpExample(isID: Boolean): String {
+    override fun getHelpExample(parameter: KParameter, isID: Boolean): String {
         return "user-id/mention"
     }
 

--- a/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/UserResolver.kt
+++ b/src/main/kotlin/com/freya02/botcommands/internal/parameters/resolvers/UserResolver.kt
@@ -32,6 +32,10 @@ class UserResolver : ParameterResolver<UserResolver, User>(User::class),
     override val testExample: String = "<@1234>"
     override val optionType: OptionType = OptionType.USER
 
+    override fun getHelpExample(isID: Boolean): String {
+        return "user-id/mention"
+    }
+
     override suspend fun resolveSuspend(
         context: BContext,
         variation: TextCommandVariation,

--- a/src/test/java/com/freya02/botcommands/othertests/CommandPatternTest.java
+++ b/src/test/java/com/freya02/botcommands/othertests/CommandPatternTest.java
@@ -7,6 +7,7 @@ import com.freya02.botcommands.internal.commands.prefixed.CommandPattern;
 import com.freya02.botcommands.internal.commands.prefixed.CommandPattern.ParameterPattern;
 import com.freya02.botcommands.internal.commands.prefixed.TextCommandVariation;
 import com.freya02.botcommands.internal.parameters.resolvers.*;
+import kotlin.reflect.KParameter;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -107,7 +108,7 @@ public class CommandPatternTest {
 
         @NotNull
         @Override
-        public String getHelpExample(boolean isID) {
+        public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
             return "jda";
         }
     }

--- a/src/test/java/com/freya02/botcommands/othertests/CommandPatternTest.java
+++ b/src/test/java/com/freya02/botcommands/othertests/CommandPatternTest.java
@@ -104,5 +104,11 @@ public class CommandPatternTest {
         public @NotNull String getTestExample() {
             return "jda";
         }
+
+        @NotNull
+        @Override
+        public String getHelpExample(boolean isID) {
+            return "jda";
+        }
     }
 }

--- a/src/test/java/com/freya02/botcommands/othertests/CommandPatternTest.java
+++ b/src/test/java/com/freya02/botcommands/othertests/CommandPatternTest.java
@@ -1,6 +1,7 @@
 package com.freya02.botcommands.othertests;
 
 import com.freya02.botcommands.api.BContext;
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent;
 import com.freya02.botcommands.api.parameters.ParameterResolver;
 import com.freya02.botcommands.api.parameters.RegexParameterResolver;
 import com.freya02.botcommands.internal.commands.prefixed.CommandPattern;
@@ -108,7 +109,7 @@ public class CommandPatternTest {
 
         @NotNull
         @Override
-        public String getHelpExample(@NotNull KParameter parameter, boolean isID) {
+        public String getHelpExample(@NotNull KParameter parameter, @NotNull BaseCommandEvent event, boolean isID) {
             return "jda";
         }
     }

--- a/src/test/kotlin/com/freya02/botcommands/test_kt/commands/text/TextHelpTesting.kt
+++ b/src/test/kotlin/com/freya02/botcommands/test_kt/commands/text/TextHelpTesting.kt
@@ -1,0 +1,31 @@
+package com.freya02.botcommands.test_kt.commands.text
+
+import com.freya02.botcommands.api.commands.annotations.Command
+import com.freya02.botcommands.api.commands.prefixed.BaseCommandEvent
+import com.freya02.botcommands.api.commands.prefixed.TextCommand
+import com.freya02.botcommands.api.commands.prefixed.annotations.JDATextCommand
+import com.freya02.botcommands.api.commands.prefixed.annotations.TextOption
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.emoji.Emoji
+
+@Command
+class TextHelpTesting : TextCommand() {
+    @JDATextCommand(name = "help_testing")
+    fun onTextHelpTesting(event: BaseCommandEvent,
+                          @TextOption boolean: Boolean,
+                          @TextOption double: Double,
+                          @TextOption emoji: Emoji,
+                          @TextOption guild: Guild,
+                          @TextOption int: Int,
+                          @TextOption long: Long,
+                          @TextOption member: Member,
+                          @TextOption user: User,
+                          @TextOption role: Role,
+                          @TextOption string: String,
+    ) {
+        event.respond("testing").queue()
+    }
+}


### PR DESCRIPTION
Also makes `QuotableRegexParameterResolver` extend `RegexParameterResolver`

Default help content will now have more consistent examples with the same invocation context