### PR TITLE
Transfer V3 wiki to main repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,12 @@
 [//]: # (most of it is from https://kotlinlang.org/docs/jvm-api-guidelines-introduction.html)
 
+### Commits
+Wiki commits must be with `Wiki: Commit text`
+Examples commits must be with `Examples: Commit text`
+
+If these commits are in a PR, the commits can omit this format, 
+but the PR's merge commit must contain the prefix.
+
 ### Documentation
 - Document `@return` on boolean annotations or non-trivial returns (such as `the time in [timeUnit]`)
 - Document default values (e.g., for configs)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![](https://img.shields.io/badge/JDA%20Version-5.0.0--beta.17+-important)](https://github.com/discord-jda/JDA/releases)
 [![image](https://discord.com/api/guilds/848502702731165738/embed.png?style=shield)](https://discord.gg/frpCcQfvTz)
 [![image](https://img.shields.io/badge/Javadocs-Overview-blue)](https://freya022.github.io/BotCommands/docs/allclasses-index.html)
-[![image](https://img.shields.io/badge/Wiki-Home-blue)](https://freya022.github.io/BotCommands-Wiki/3.X)
+[![image](https://img.shields.io/badge/Wiki-Home-blue)](https://freya022.github.io/BotCommands/3.X)
 
 # BotCommands
 A Kotlin-first (and Java) framework that makes creating Discord bots a piece of cake,
@@ -60,12 +60,12 @@ OOP, [JDA](https://github.com/discord-jda/JDA) and Dependency Injection basics b
 ### Prerequisites
 * An [OpenJDK 17+](https://adoptium.net/temurin/releases/?version=17) installation
 * A competent IDE (I recommend IntelliJ IDEA, you can't go wrong with it in Java & Kotlin, + Live Templates)
-* (Recommended, only Java) Enable method parameters names, please refer to the [wiki page](https://freya022.github.io/BotCommands-Wiki/3.X/using-commands/Inferred-option-names/)
+* (Recommended, only Java) Enable method parameters names, please refer to the [wiki page](https://freya022.github.io/BotCommands/3.X/using-commands/Inferred-option-names/)
 * (Recommended) Use [HotswapAgent](https://github.com/HotswapProjects/HotswapAgent) in development, to avoid restarting too often
 * (Recommended) Use [stacktrace-decoroutinator](https://github.com/Anamorphosee/stacktrace-decoroutinator), to get clearer stack traces in suspending code
   * Each bot template has it enabled in their main class
 
-You can then head over to [the wiki](https://freya022.github.io/BotCommands-Wiki/3.X/setup/getting-started/) 
+You can then head over to [the wiki](https://freya022.github.io/BotCommands/3.X/setup/getting-started/) 
 to get started using a bot template.
 
 [//]: # (TODO keep an eye out for this wiki link)
@@ -184,7 +184,7 @@ You can find a number of feature demonstrations in the [examples subproject](exa
 
 ## Debugging tips
 
-- Enable the debug/trace logs in your logback.xml file, for a logging tutorial you can look at [the wiki's logging page](https://freya022.github.io/BotCommands-Wiki/3.X/setup/logging/)
+- Enable the debug/trace logs in your logback.xml file, for a logging tutorial you can look at [the wiki's logging page](https://freya022.github.io/BotCommands/3.X/setup/logging/)
 - Look at the switches in `BDebugConfig`
 
 ## Live templates

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,7 +29,7 @@ You can then just run the `Main` class.
 
 ### Starting your own bot
 If you are seeking for a bot you can set up yourself, 
-you can look at the bot templates on [the wiki](https://freya022.github.io/BotCommands-Wiki/3.X/setup/getting-started/#using-the-bot-template).
+you can look at the bot templates on [the wiki](https://freya022.github.io/BotCommands/3.X/setup/getting-started/#using-the-bot-template).
 
 ## Examples
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/SlashOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/SlashOption.kt
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable
  * Sets a parameter as a slash command option from Discord.
  *
  * Option names can be inferred from the parameter's name,
- * see the [Wiki about inferred option names](https://freya022.github.io/BotCommands-Wiki/3.X/using-commands/Inferred-option-names/)
+ * see the [Wiki about inferred option names](https://freya022.github.io/BotCommands/3.X/using-commands/Inferred-option-names/)
  * for more details.
  *
  * Choices can be added by either [their parameter resolver][SlashParameterResolver.getPredefinedChoices],
@@ -51,7 +51,7 @@ annotation class SlashOption(
      * This can be localized, see [LocalizationFunction] on how options are mapped.
      *
      * This is optional if the parameter name is found,
-     * see [the wiki](https://freya022.github.io/BotCommands-Wiki/3.X/using-commands/Inferred-option-names/) for more details.
+     * see [the wiki](https://freya022.github.io/BotCommands/3.X/using-commands/Inferred-option-names/) for more details.
      */
     //TODO keep an eye out for this wiki link
     val name: String = "",

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/TextOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/TextOption.kt
@@ -19,7 +19,7 @@ annotation class TextOption(
      * The name of this option displayed on the help content.
      *
      * This is optional if the parameter name is available,
-     * see [the wiki](https://freya022.github.io/BotCommands-Wiki/using-commands/Inferred-option-names/) for more details.
+     * see [the wiki](https://freya022.github.io/BotCommands/using-commands/Inferred-option-names/) for more details.
      */
     //TODO keep an eye out for this wiki link
     val name: String = "",

--- a/wiki/docs/index.md
+++ b/wiki/docs/index.md
@@ -2,4 +2,4 @@
 
 Have a look around the different categories on how to use this framework
 
-*If you don't find a wiki page you need, you should check out the [examples](https://github.com/freya022/BotCommands/tree/2.X/examples)*
+*If you don't find a wiki page you need, you should check out the [examples](https://github.com/freya022/BotCommands/tree/3.X/examples)*

--- a/wiki/docs/setup/getting-started.md
+++ b/wiki/docs/setup/getting-started.md
@@ -1,0 +1,140 @@
+This tutorial assumes you know how to use your IDE (preferably IntelliJ IDEA), using Maven or Gradle,
+and how to install PostgreSQL.
+
+## Using the bot template
+
+The framework provides Kotlin and Java templates for a quick start,
+while the template uses Maven, it can be substituted with Gradle.
+
+### Getting the template
+You can make a repository from the 
+([Kotlin](https://github.com/freya022/BotCommands-Template-Kotlin) / [Java](https://github.com/freya022/BotCommands-Template-Java))
+template on GitHub, or clone them.
+
+### Preparing your project
+You can then configure your build file:
+=== "Maven"
+
+    1. In the pom.xml, change the `groupId` to your base package name, such as `io.github.[your username]`, in lowercase.
+    2. Replace the `artifactId` and `finalName` (in the `maven-shade-plugin`), with your project's name.
+
+=== "Gradle"
+
+    1. Create a new Gradle project, then copy all files, except `pom.xml`.
+
+    2. Update your build script:
+
+    ```kotlin title="build.gradle.kts"
+    import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+    
+    plugins {
+        java
+        application
+        id("com.github.johnrengelman.shadow") version "7.1.2"
+    }
+    
+    application.mainClass.set("io.github.[username].bot.Main")    //TODO change here
+    group = "io.github.name"                                //TODO change here
+    version = "1.0-SNAPSHOT"
+    
+    tasks.withType<ShadowJar> {
+        archiveFileName.set("ProjectName.jar")        //TODO change here
+    }
+    
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+    
+    dependencies {
+        //Logging
+        implementation("org.slf4j:slf4j-api:[VERSION]") //See https://mvnrepository.com/artifact/org.slf4j/slf4j-api/latest
+        implementation("ch.qos.logback:logback-classic:[VERSION]") //See https://mvnrepository.com/artifact/ch.qos.logback/logback-classic/latest
+
+        //JDA
+        implementation("net.dv8tion:JDA:[VERSION]") //See https://mvnrepository.com/artifact/net.dv8tion/JDA/latest
+        implementation("io.github.freya022:BotCommands:[VERSION]") //See https://mvnrepository.com/artifact/io.github.freya022/BotCommands/latest
+    }
+    
+    tasks.withType<JavaCompile> {
+        options.encoding = "UTF-8"
+        options.isIncremental = true
+    
+        //BC supports Java 17 and above
+        options.release.set(17)
+    }
+    ```
+
+You can then update the package of the template, so it matches your group ID.
+
+!!! note
+
+    Don't forget to update the main class in your build script, as well as the main package in the `Main` class.
+
+### Running the bot
+
+!!! warning
+
+    The framework (optionally) uses a database for its components (and so other features depending on components),
+    you are required to use PostgreSQL, and so the template is already configured for it,
+    including a connection pool (HikariCP), and a database migrator (Flyway).
+
+[//]: # (TODO update depending on SQLite compatibility)
+
+#### Configuring the bot
+
+=== "Dev config"
+
+    1. Copy the `config-template` folder as `dev-config`, 
+    and edit the `config.json` with your bot token, prefixes, owner ID and the database details.
+    2. Delete `logback.xml`.
+
+    ??? info "How your project folder should look like"
+
+        ```
+        IntelliJ-Projects/
+        └── ProjectName/
+            ├── dev-config/
+            │   ├── config.json
+            │   └── logback-test.xml
+            ├── src/
+            │   └── ..
+            └── pom.xml/build.gradle.kts
+        ```
+
+=== "Prod config"
+
+    1. Copy the `config-template` folder as `config`, 
+    and edit the `config.json` with your bot token, prefixes, owner ID and the database details.
+    2. Delete `logback-test.xml`.
+
+    ??? info "How your deployed bot's folder should look like"
+    
+        ```
+        ProjectName/
+        ├── config/
+        │   ├── config.json
+        │   └── logback.xml
+        └── ProjectName.jar
+        ```
+
+#### Making the JAR
+
+During development, simply run the main class in your IDE.
+
+For your production environment, making a JAR is as simple as opening "Run Anything"
+by pressing ++ctrl++ twice in IntelliJ, then running:
+
+=== "Maven"
+
+    ```
+    mvn package
+    ```
+
+=== "Gradle"
+
+    ```
+    gradle shadowJar
+    ```
+
+This will generate an executable jar, which you should be running using `#!sh java -jar YourBotName.jar`.

--- a/wiki/docs/setup/logging.md
+++ b/wiki/docs/setup/logging.md
@@ -1,0 +1,33 @@
+In case you are **not** using the bot template, you can add a logger with the following dependencies:
+
+- [slf4j-api](https://mvnrepository.com/artifact/org.slf4j/slf4j-api/latest)
+- [logback-classic](https://mvnrepository.com/artifact/ch.qos.logback/logback-classic/latest)
+
+You can then create a `logback.xml` file, which you can put in the root of your resources (`src/main/resources`),
+or in another place (such as in a config directory), and load them as such:
+
+=== "Kotlin"
+
+    ```kotlin
+    System.setProperty(ClassicConstants.CONFIG_FILE_PROPERTY, PATH_TO_LOGBACK.absolutePathString())
+    ```
+
+=== "Java"
+
+    ```java
+    System.setProperty(ClassicConstants.CONFIG_FILE_PROPERTY, PATH_TO_LOGBACK.toAbsolutePath().toString());
+    ```
+
+Here are the logback configs used in the bot templates:
+
+=== "Dev config"
+
+    ```xml title="logback-test.xml"
+    --8<-- "https://github.com/freya022/BotCommands-Template-Kotlin/raw/3.X/config-template/logback-test.xml"
+    ```
+
+=== "Prod config"
+
+    ```xml title="logback.xml"
+    --8<-- "https://github.com/freya022/BotCommands-Template-Kotlin/raw/3.X/config-template/logback.xml"
+    ```

--- a/wiki/docs/using-commands/updating-application-commands/Slash-commands---Updating-option-choices.md
+++ b/wiki/docs/using-commands/updating-application-commands/Slash-commands---Updating-option-choices.md
@@ -1,6 +1,6 @@
 # Slash commands - Updating option choices
 
-See [here](../using-slash-commands/Slash-commands.md#examples) 
+See [here](../using-slash-commands/writing-slash-commands.md#examples) 
 the example on how to add predefined choices to your slash commands
 
 You can also change the `GuildApplicationSettings#getOptionChoices` to provide dynamic values, 

--- a/wiki/docs/using-commands/using-slash-commands/writing-slash-commands.md
+++ b/wiki/docs/using-commands/using-slash-commands/writing-slash-commands.md
@@ -1,0 +1,361 @@
+# Writing slash commands
+
+Slash commands are the new way of defining commands, even though there are limitations with them, 
+we do have some advantages such as being easier to fill in, choices and auto-completion.
+
+## Defining the command method
+
+Whether you're using annotated or DSL commands, you will have to write a method, 
+which holds the user inputs as parameters.
+
+The method must be public, non-static, with the first parameter being `GlobalSlashEvent` for global commands
+or `GuildSlashEvent` for guild commands, or guild-only global commands (default).
+
+Lastly, any class containing commands will need to be annotated with `#!java @Command`.
+
+The command methods support coroutines, as well as nullable options, and optionals.
+
+??? example "A method with everything mentioned above"
+    === "Kotlin"
+        ```kotlin
+        suspend fun example(event: GuildSlashEvent, string: String, user: User?, integer: Int = 42) {}    
+        ```
+
+    === "Java"
+        ```java
+        public void example(@NotNull GuildSlashEvent event, @NotNull String string, @Nullable User user) {}
+        ```
+
+## Annotated commands
+
+Annotated commands are easy to create, but generally are hard to read, cannot be made dynamically,
+and require usage of other methods for other features, such as retrieving choices.
+
+The command method must be annotated with `#!java @JDASlashCommand`,
+where you can set the scope, name, description, etc..., 
+while the declaring class must extend `ApplicationCommand`.
+
+!!! question "Why do I need to extend `ApplicationCommand`?"
+    As a limitation of annotated commands, 
+    you are required to extend this class as it allows the framework to ask your commands for stuff,
+    like what guilds a command should be pushed to, getting a value generator for one of their options,
+    and also getting choices.
+
+[//]: # (TODO add tip with live template)
+
+!!! example
+    === "Kotlin"
+        ```kotlin
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashPing.kt:ping-kotlin"
+        ```
+
+    === "Java"
+        ```java
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashPingJava.java:ping-java"
+        ```
+
+### Adding options
+
+Options can simply be added with a parameter annotated with `#!java @SlashOption`.
+
+All supported types are documented under `ParameterResolver`, and [other types can be added](#adding-option-resolvers).
+
+!!! example
+    === "Kotlin"
+        ```kotlin
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashSay.kt:say-kotlin"
+        ```
+
+    === "Java"
+        ```java
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashSayJava.java:say-java"
+        ```
+
+!!! tip "Inferred option names"
+    Display names of options can be set on the annotation,
+    but can also be deduced from the parameter name, this is natively supported in Kotlin,
+    but for Java, you will need to [enable parameter names](../Inferred-option-names.md) on the Java compiler.
+
+#### Using choices
+
+You must override `getOptionChoices` in order to return a list of choices, 
+be careful to check against the command path as well as the option's display name.
+
+!!! example
+    === "Kotlin"
+        ```kotlin
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashConvert.kt:convert-kotlin"
+        ```
+
+    === "Java"
+        ```java
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashConvertJava.java:convert-java"
+        ```
+
+As you can see, despite the short choice list, 
+the method is quite lengthy and causes duplications with multiple commands.
+This issue is solved with [predefined choices](#using-predefined-choices).
+
+### Generated values
+
+Generated values are a command parameter which gets their values computed by a lambda everytime a command is run, 
+given by `ApplicationCommand#getGeneratedValueSupplier`, which you must override, 
+similarly to adding choices.
+
+As always, make sure to check against the command path as well as the option's display name.
+
+!!! example
+    === "Kotlin"
+        ```kotlin
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashCreateTime.kt:create_time-kotlin"
+        ```
+
+    === "Java"
+        ```java
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashCreateTimeJava.java:create_time-java"
+        ```
+
+## DSL commands (Kotlin)
+
+DSL commands were added in V3 to help create commands dynamically, 
+whether it's to let the user filter commands themselves, or adding subcommands/options in a loop; 
+you can almost do anything you want while keeping the simplicity of your command method.
+
+Application commands can be added with a public method annotated with `#!java @AppDeclaration`,
+where the first parameter is a `GlobalApplicationCommandManager` (for global / guild-only global) commands, 
+or `GuildApplicationCommandManager` for guild commands.
+
+You can then simply use the `slashCommand` method, give it the command name, the command method, 
+and then configure your command.
+
+!!! tip
+    You are allowed to not add any command at all, for example, 
+    if the `guild` in `GuildApplicationCommandManager` isn't a guild you want the command to appear in.
+
+[//]: # (TODO add tip with live template)
+
+!!! example
+    ```kotlin
+    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashPing.kt:ping-kotlin_dsl"
+    ```
+
+### Adding options
+
+Options can simply be added with a parameter and declaring it using `option` in your command builder,
+where the `declaredName` is the name of your parameter, the block will let you change the description, choices, etc.
+
+All supported types are documented under `ParameterResolver`, and [other types can be added](#adding-option-resolvers).
+
+!!! example
+    ```kotlin
+    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashSay.kt:say-kotlin_dsl"
+    ```
+
+!!! tip
+    You can override the option name by setting `optionName` in the option declaration:
+    ```kotlin
+    option("content", optionName = "sentence") {
+        ...
+    }
+    ```
+
+#### Using choices
+
+Adding choices is very straight forward, you only have to give a list of choices to the `choice` property.
+
+!!! example
+    ```kotlin
+    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashConvert.kt:convert-kotlin_dsl"
+    ```
+
+As you can see, despite the short choice list, this causes duplications with multiple commands.
+This issue is solved with [predefined choices](#using-predefined-choices).
+
+### Generated values
+
+Generated values are a command parameter that gets their values computed by the given block everytime the command run.
+
+Contrary to the annotated commands, no checks are required, as this is tied to the currently built command.
+
+!!! example
+    ```kotlin
+    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashCreateTime.kt:create_time-kotlin_dsl"
+    ```
+
+## Default description
+
+You can avoid setting the (non-localized) descriptions of your commands and options 
+by putting them in a localization file, using the root locale (i.e., no locale suffix),
+and have your localization bundle registered with `BApplicationConfigBuilder#addLocalizations`.
+
+??? info "The same commands as before, but without the descriptions"
+    === "Kotlin"
+        ```kotlin
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashSayDefaultDescription.kt:say_default_description-kotlin"
+        ```
+
+    === "Kotlin (DSL)"
+        ```kotlin
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashSayDefaultDescription.kt:say_default_description-kotlin_dsl"
+        ```
+
+    === "Java"
+        ```java
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashSayDefaultDescriptionJava.java:say_default_description-java"
+        ```
+
+!!! example "Adding the root localization bundle"
+    For the given resource bundle:
+    ```json title="src/main/resources/bc_localization/Commands.json"
+    {
+    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/resources/bc_localization/Commands.json:default_description-json"
+    }
+    ```
+
+    You can add the bundle by simply calling `BApplicationConfigBuilder#addLocalizations("Commands")`.
+
+## Using predefined choices
+
+If your choices stay the same for every command,
+you can improve re-usability and avoid extra code by using choices on the resolver's level,
+that is, the resolver will return the choices used for every option of their type.
+
+All you now need to do is enable `usePredefinedChoices` on your option.
+
+!!! example
+    Here, the resolver for `TimeUnit` is already defined and will be explained in [Adding option resolvers](#adding-option-resolvers).
+
+    === "Kotlin"
+        ```kotlin
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashConvertSimplified.kt:convert_simplified-kotlin"
+        ```
+
+    === "Kotlin (DSL)"
+        ```kotlin
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashConvertSimplified.kt:convert_simplified-kotlin_dsl"
+        ```
+
+    === "Java"
+        ```java
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashConvertSimplifiedJava.java:convert_simplified-java"
+        ```
+
+## Adding option resolvers
+
+Option resolvers help you support other types for your command options, such as `TimeUnit`, or any object of your own.
+
+Slash command option resolvers specify which option type will be used on Discord, 
+and will handle the conversion from the Discord value to the corresponding object.
+
+The class implementing the resolver, or the function returning a resolver, must be annotated with `#!java @Resolver`.
+
+!!! note
+    `#!java @Resolver` is one of the annotations that are considered as a service annotation.
+    This means that it behaves exactly the same as if you had used `@BService`, 
+    except here the annotation is more meaningful.
+
+[//]: # (TODO Add link to DI section in note)
+
+### Implementation
+
+For that, you need a class annotated with `#!java @Resolver` extending `ClassParameterResolver`, 
+and implementing `SlashParameterResolver`.
+
+The first type parameter is the type of your resolver implementation, and the second type is what the resolver returns.
+
+!!! example "A `TimeUnit` resolver"
+    === "Kotlin"
+        ```kotlin
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/resolvers/TimeUnitResolver.kt:time_unit_resolver-detailed-kotlin"
+        ```
+
+    === "Java"
+        ```java
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/resolvers/TimeUnitResolverJava.java:time_unit_resolver-detailed-java"
+        ```
+    
+    As you can see, this defines the slash command's option to be a string, 
+    and provides predefined choices, letting you easily use them in your commands.
+
+### Built-in resolver generators
+
+The framework also provides functions in `Resolvers` to do most of the work for some types,
+all you need to do is declare a service factory with `#!java @Resolver` and use the provided methods.
+
+!!! note
+    Currently there is only a factory for enum resolvers, but others might be added in the future.
+
+!!! example "How to easily make a resolver for an enum type"
+    === "Kotlin"
+        ```kotlin
+        object TimeUnitResolverSimplified {
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/resolvers/TimeUnitResolver.kt:time_unit_resolver-simplified-kotlin"
+        ```
+        As this functions as a service factory, the method needs to be in an `object` or have a no-arg constructor.
+
+    === "Java"
+        ```java
+        public class TimeUnitResolverSimplifiedJava {
+        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/resolvers/TimeUnitResolverSimplifiedJava.java:time_unit_resolver-simplified-java"
+        ```
+        As this functions as a service factory, the method needs to be static.
+
+## Advanced usage
+
+The Kotlin DSL also lets you do more, for example, using loops to generate commands, or even options. 
+It also allows you to create more complex options, such as having multiple options in one parameter.
+
+!!! info "Distinction between parameters and options"
+    Method parameters are what you expect, simply a value in your method,
+    but for the framework, parameters might be a complex object (composed of multiple options),
+    or simply a single option, whether it's an injected service, a Discord option or a generated value.
+
+    i.e., A parameter might be a single or multiple options, but an option is always a single value.
+
+### Composite parameters
+
+These are parameters composed of multiple options, of any type,
+which gets merged into one parameter by using an aggregator.
+
+!!! tip
+    This is how varargs are implemented, they are simply a loop that generate N options, where X options are optional.
+
+!!! example "Creating an aggregated parameter"
+    Here is how you can use aggregated parameters to create an message delete timeframe, out of a `Long` and a `TimeUnit`.
+
+    ```kotlin title="The aggregated object"
+    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashBan.kt:aggregated_object-kotlin"
+    ```
+
+    ```kotlin title="The aggregated parameter declaration"
+    @Command
+    class SlashBan {
+        @AppDeclaration
+        fun onDeclare(manager: GlobalApplicationCommandManager) {
+            manager.slashCommand("ban", function = SlashBan::onSlashBan) {
+                ...
+
+    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashBan.kt:declare_aggregate-kotlin_dsl"
+            }
+        }
+    }
+    ```
+
+    The aggregating function can be a reference to the object's constructor,
+    or a function taking the options and returning an object of the corresponding type. 
+
+### Kotlin's inline classes
+
+Input options as well as varargs can be encapsulated in an [inline class](https://kotlinlang.org/docs/inline-classes.html),
+allowing you to define simple computable properties and functions for types where defining an extension makes no sense.
+(Like adding an extension, that's specific to only one command, on a `String`)
+
+!!! example "Using inline classes"
+
+    ```kotlin
+    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashInlineWords.kt:inline_sentence-kotlin"
+    ```
+
+## Examples
+
+You can take a look at more examples [here](https://github.com/freya022/BotCommands/tree/3.X/examples#examples).

--- a/wiki/docs/using-commands/using-slash-commands/writing-slash-commands.md
+++ b/wiki/docs/using-commands/using-slash-commands/writing-slash-commands.md
@@ -46,12 +46,12 @@ while the declaring class must extend `ApplicationCommand`.
 !!! example
     === "Kotlin"
         ```kotlin
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashPing.kt:ping-kotlin"
+        --8<-- "wiki/commands/slash/SlashPing.kt:ping-kotlin"
         ```
 
     === "Java"
         ```java
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashPingJava.java:ping-java"
+        --8<-- "wiki/commands/slash/SlashPingJava.java:ping-java"
         ```
 
 ### Adding options
@@ -63,12 +63,12 @@ All supported types are documented under `ParameterResolver`, and [other types c
 !!! example
     === "Kotlin"
         ```kotlin
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashSay.kt:say-kotlin"
+        --8<-- "wiki/commands/slash/SlashSay.kt:say-kotlin"
         ```
 
     === "Java"
         ```java
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashSayJava.java:say-java"
+        --8<-- "wiki/commands/slash/SlashSayJava.java:say-java"
         ```
 
 !!! tip "Inferred option names"
@@ -84,12 +84,12 @@ be careful to check against the command path as well as the option's display nam
 !!! example
     === "Kotlin"
         ```kotlin
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashConvert.kt:convert-kotlin"
+        --8<-- "wiki/commands/slash/SlashConvert.kt:convert-kotlin"
         ```
 
     === "Java"
         ```java
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashConvertJava.java:convert-java"
+        --8<-- "wiki/commands/slash/SlashConvertJava.java:convert-java"
         ```
 
 As you can see, despite the short choice list, 
@@ -107,12 +107,12 @@ As always, make sure to check against the command path as well as the option's d
 !!! example
     === "Kotlin"
         ```kotlin
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashCreateTime.kt:create_time-kotlin"
+        --8<-- "wiki/commands/slash/SlashCreateTime.kt:create_time-kotlin"
         ```
 
     === "Java"
         ```java
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashCreateTimeJava.java:create_time-java"
+        --8<-- "wiki/commands/slash/SlashCreateTimeJava.java:create_time-java"
         ```
 
 ## DSL commands (Kotlin)
@@ -136,7 +136,7 @@ and then configure your command.
 
 !!! example
     ```kotlin
-    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashPing.kt:ping-kotlin_dsl"
+    --8<-- "wiki/commands/slash/SlashPing.kt:ping-kotlin_dsl"
     ```
 
 ### Adding options
@@ -148,7 +148,7 @@ All supported types are documented under `ParameterResolver`, and [other types c
 
 !!! example
     ```kotlin
-    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashSay.kt:say-kotlin_dsl"
+    --8<-- "wiki/commands/slash/SlashSay.kt:say-kotlin_dsl"
     ```
 
 !!! tip
@@ -165,7 +165,7 @@ Adding choices is very straight forward, you only have to give a list of choices
 
 !!! example
     ```kotlin
-    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashConvert.kt:convert-kotlin_dsl"
+    --8<-- "wiki/commands/slash/SlashConvert.kt:convert-kotlin_dsl"
     ```
 
 As you can see, despite the short choice list, this causes duplications with multiple commands.
@@ -179,7 +179,7 @@ Contrary to the annotated commands, no checks are required, as this is tied to t
 
 !!! example
     ```kotlin
-    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashCreateTime.kt:create_time-kotlin_dsl"
+    --8<-- "wiki/commands/slash/SlashCreateTime.kt:create_time-kotlin_dsl"
     ```
 
 ## Default description
@@ -191,24 +191,24 @@ and have your localization bundle registered with `BApplicationConfigBuilder#add
 ??? info "The same commands as before, but without the descriptions"
     === "Kotlin"
         ```kotlin
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashSayDefaultDescription.kt:say_default_description-kotlin"
+        --8<-- "wiki/commands/slash/SlashSayDefaultDescription.kt:say_default_description-kotlin"
         ```
 
     === "Kotlin (DSL)"
         ```kotlin
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashSayDefaultDescription.kt:say_default_description-kotlin_dsl"
+        --8<-- "wiki/commands/slash/SlashSayDefaultDescription.kt:say_default_description-kotlin_dsl"
         ```
 
     === "Java"
         ```java
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashSayDefaultDescriptionJava.java:say_default_description-java"
+        --8<-- "wiki/commands/slash/SlashSayDefaultDescriptionJava.java:say_default_description-java"
         ```
 
 !!! example "Adding the root localization bundle"
     For the given resource bundle:
     ```json title="src/main/resources/bc_localization/Commands.json"
     {
-    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/resources/bc_localization/Commands.json:default_description-json"
+    --8<-- "bc_localization/Commands.json:default_description-json"
     }
     ```
 
@@ -227,17 +227,17 @@ All you now need to do is enable `usePredefinedChoices` on your option.
 
     === "Kotlin"
         ```kotlin
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashConvertSimplified.kt:convert_simplified-kotlin"
+        --8<-- "wiki/commands/slash/SlashConvertSimplified.kt:convert_simplified-kotlin"
         ```
 
     === "Kotlin (DSL)"
         ```kotlin
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashConvertSimplified.kt:convert_simplified-kotlin_dsl"
+        --8<-- "wiki/commands/slash/SlashConvertSimplified.kt:convert_simplified-kotlin_dsl"
         ```
 
     === "Java"
         ```java
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/commands/slash/SlashConvertSimplifiedJava.java:convert_simplified-java"
+        --8<-- "wiki/commands/slash/SlashConvertSimplifiedJava.java:convert_simplified-java"
         ```
 
 ## Adding option resolvers
@@ -266,12 +266,12 @@ The first type parameter is the type of your resolver implementation, and the se
 !!! example "A `TimeUnit` resolver"
     === "Kotlin"
         ```kotlin
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/resolvers/TimeUnitResolver.kt:time_unit_resolver-detailed-kotlin"
+        --8<-- "wiki/resolvers/TimeUnitResolver.kt:time_unit_resolver-detailed-kotlin"
         ```
 
     === "Java"
         ```java
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/resolvers/TimeUnitResolverJava.java:time_unit_resolver-detailed-java"
+        --8<-- "wiki/resolvers/TimeUnitResolverJava.java:time_unit_resolver-detailed-java"
         ```
     
     As you can see, this defines the slash command's option to be a string, 
@@ -289,14 +289,14 @@ all you need to do is declare a service factory with `#!java @Resolver` and use 
     === "Kotlin"
         ```kotlin
         object TimeUnitResolverSimplified {
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/resolvers/TimeUnitResolver.kt:time_unit_resolver-simplified-kotlin"
+        --8<-- "wiki/resolvers/TimeUnitResolver.kt:time_unit_resolver-simplified-kotlin"
         ```
         As this functions as a service factory, the method needs to be in an `object` or have a no-arg constructor.
 
     === "Java"
         ```java
         public class TimeUnitResolverSimplifiedJava {
-        --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/java/io/github/freya022/bot/resolvers/TimeUnitResolverSimplifiedJava.java:time_unit_resolver-simplified-java"
+        --8<-- "wiki/resolvers/TimeUnitResolverSimplifiedJava.java:time_unit_resolver-simplified-java"
         ```
         As this functions as a service factory, the method needs to be static.
 
@@ -324,7 +324,7 @@ which gets merged into one parameter by using an aggregator.
     Here is how you can use aggregated parameters to create an message delete timeframe, out of a `Long` and a `TimeUnit`.
 
     ```kotlin title="The aggregated object"
-    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashBan.kt:aggregated_object-kotlin"
+    --8<-- "wiki/commands/slash/SlashBan.kt:aggregated_object-kotlin"
     ```
 
     ```kotlin title="The aggregated parameter declaration"
@@ -335,7 +335,7 @@ which gets merged into one parameter by using an aggregator.
             manager.slashCommand("ban", function = SlashBan::onSlashBan) {
                 ...
 
-    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashBan.kt:declare_aggregate-kotlin_dsl"
+    --8<-- "wiki/commands/slash/SlashBan.kt:declare_aggregate-kotlin_dsl"
             }
         }
     }
@@ -353,7 +353,7 @@ allowing you to define simple computable properties and functions for types wher
 !!! example "Using inline classes"
 
     ```kotlin
-    --8<-- "https://github.com/freya022/BotCommands/raw/3.X/examples/src/main/kotlin/io/github/freya022/bot/commands/slash/SlashInlineWords.kt:inline_sentence-kotlin"
+    --8<-- "wiki/commands/slash/SlashInlineWords.kt:inline_sentence-kotlin"
     ```
 
 ## Examples

--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -37,7 +37,7 @@ site_url: 'https://freya022.github.io/BotCommands'
 
 repo_name: BotCommands
 repo_url: https://github.com/freya022/BotCommands/tree/3.X
-edit_uri: ../../edit/3.X/wiki/docs # This URI is relative to repo_url TODO check
+edit_uri: ../../edit/3.X/wiki/docs # This URI is relative to repo_url
 extra:
   version:
     provider: mike

--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -69,8 +69,8 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 nav:
   - Home: index.md

--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -1,13 +1,15 @@
 # yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
 
-# Heavily inspired from: https://github.com/DV8FromTheWorld/JDA-Website/blob/master/mkdocs.yml
+# Base file from: https://github.com/discord-jda/JDA-Website/blob/8a3a36f0f95e29f14f0e04a75c219c4e4352ecf7/mkdocs.yml
 theme:
   features:
     - navigation.instant # Faster loading
     - navigation.tabs # Top level horizontal tabs
     - toc.integrate # Integrated Table Of Contents (shows #, ##... sections)
     - content.code.annotate # Annotations on lines of codeicon:
+    - content.code.copy
     - content.action.edit
+    - content.tabs.link
   name: material
   logo: assets/logo-transparent.svg
   favicon: assets/logo-round.svg
@@ -31,19 +33,19 @@ plugins:
   - mike
 
 site_name: BotCommands Wiki
-site_url: 'https://freya022.github.io/BotCommands/'
+site_url: 'https://freya022.github.io/BotCommands'
 
 repo_name: BotCommands
-repo_url: https://github.com/freya022/BotCommands/tree/2.X
-edit_uri: ../../edit/2.X/wiki/docs # This URI is relative to repo_url
+repo_url: https://github.com/freya022/BotCommands/tree/3.X
+edit_uri: ../../edit/3.X/wiki/docs # This URI is relative to repo_url TODO check
 extra:
   version:
     provider: mike
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/freya022/BotCommands/tree/2.X
+      link: https://github.com/freya022/BotCommands/tree/3.X
     - icon: fontawesome/solid/book
-      link: https://github.com/freya022/BotCommands/tree/2.X/wiki
+      link: https://github.com/freya022/BotCommands/tree/3.X/wiki
     - icon: fontawesome/brands/discord
       link: https://discord.gg/frpCcQfvTz
 
@@ -53,41 +55,48 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.highlight
   - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.keys
   - footnotes
   - def_list
   - pymdownx.tasklist:
       custom_checkbox: true
+  - pymdownx.snippets:
+      url_download: true
+      check_paths: true
   - toc:
       permalink: true
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
 
 nav:
   - Home: index.md
+  - Setup:
+      - Getting started: setup/getting-started.md
+      - Logging: setup/logging.md
   - Using commands:
-      - Writing prefixed commands: using-commands/Prefixed-commands.md
+#      - Writing prefixed commands: using-commands/Prefixed-commands.md
       - Using slash commands:
-        - Writing slash commands: using-commands/using-slash-commands/Slash-commands.md
-        - Updating application commands: using-commands/using-slash-commands/Updating-slash-commands.md
-        - Managing guild application commands: using-commands/using-slash-commands/Managing-application-commands.md
-      - Writing context menu commands: using-commands/Context-menu-commands.md
-      - Updating application commands:
-          - Slash commands - Updating option choices: using-commands/updating-application-commands/Slash-commands---Updating-option-choices.md
-      - Using localization: using-commands/Using-localization.md
-      - Inferred option names: using-commands/Inferred-option-names.md
-  - Using components:
-      - The Components API: using-components/The-Components-API.md
-      - Buttons: using-components/Buttons.md
-      - Selection menus: using-components/Selection-menus.md
-  - Writing extensions:
-      - Creating parameter resolvers: writing-extensions/Creating-parameter-resolvers.md #TODO move to each command type's wiki as to show the different interfaces
-      - Constructor injection: writing-extensions/Constructor-injection.md
-      - Field injection: writing-extensions/Field-injection.md
-  - Misc:
-      - Conditional instancing: misc/Conditional-instancing.md
-      - Using instance suppliers: misc/Instance-suppliers.md
-      - Using the event waiter: misc/The-event-waiter.md
-  - Logging: Logging.md
+        - Writing slash commands: using-commands/using-slash-commands/writing-slash-commands.md
+#        - Updating application commands: using-commands/using-slash-commands/Updating-slash-commands.md
+#        - Managing guild application commands: using-commands/using-slash-commands/Managing-application-commands.md
+#      - Writing context menu commands: using-commands/Context-menu-commands.md
+#      - Updating application commands:
+#          - Slash commands - Updating option choices: using-commands/updating-application-commands/Slash-commands---Updating-option-choices.md
+#      - Using localization: using-commands/Using-localization.md
+#      - Inferred option names: using-commands/Inferred-option-names.md
+#  - Using components:
+#      - The Components API: using-components/The-Components-API.md
+#      - Buttons: using-components/Buttons.md
+#      - Selection menus: using-components/Selection-menus.md
+#  - Writing extensions:
+#      - Creating parameter resolvers: writing-extensions/Creating-parameter-resolvers.md #TODO move to each command type's wiki as to show the different interfaces
+#      - Constructor injection: writing-extensions/Constructor-injection.md
+#      - Field injection: writing-extensions/Field-injection.md
+#  - Misc:
+#      - Conditional instancing: misc/Conditional-instancing.md
+#      - Using instance suppliers: misc/Instance-suppliers.md
+#      - Using the event waiter: misc/The-event-waiter.md

--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -62,6 +62,12 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.snippets:
+      base_path:
+       - "../examples/src/main/java/io/github/freya022"
+       - "../examples/src/main/kotlin/io/github/freya022"
+       - "../examples/src/main/resources"
+       - "."
+       - ".."
       url_download: true
       check_paths: true
   - toc:


### PR DESCRIPTION
Using URLs as code snippets is horribly slow and makes the writing of the wiki a pain.

The website being in the main repository also means that a separate repository is no longer needed for both the docs and the wiki

The examples and the wiki being in the same repository also means the wiki's content is versioned with the examples themselves