### PR TITLE
Add prefix to component, modal and input IDs

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/Button.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/Button.kt
@@ -10,18 +10,19 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button as JDAButton
 
 class Button internal constructor(
     private val componentController: ComponentController,
+    override val internalId: Int,
     private val button: JDAButton
 ) : JDAButton by button, IdentifiableComponent {
     override fun withDisabled(disabled: Boolean): Button {
-        return Button(componentController, super.withDisabled(disabled))
+        return Button(componentController, internalId, super.withDisabled(disabled))
     }
 
     override fun withEmoji(emoji: Emoji?): Button {
-        return Button(componentController, super.withEmoji(emoji))
+        return Button(componentController, internalId, super.withEmoji(emoji))
     }
 
     override fun withLabel(label: String): Button {
-        return Button(componentController, super.withLabel(label))
+        return Button(componentController, internalId, super.withLabel(label))
     }
 
     override fun withId(id: String): Nothing = throw UnsupportedOperationException("This type of button cannot contain custom IDs")
@@ -29,7 +30,7 @@ class Button internal constructor(
     override fun withUrl(url: String): Nothing = throw UnsupportedOperationException("This type of button cannot contain URLs")
 
     override fun withStyle(style: ButtonStyle): Button {
-        return Button(componentController, super.withStyle(style))
+        return Button(componentController, internalId, super.withStyle(style))
     }
 
     override fun getId(): String = button.id ?: throwInternal("BC components cannot have null IDs")

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/ComponentGroup.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/ComponentGroup.kt
@@ -4,9 +4,10 @@ import io.github.freya022.botcommands.internal.components.controller.ComponentCo
 import kotlinx.coroutines.TimeoutCancellationException
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
 
-class ComponentGroup internal constructor(private val componentController: ComponentController, private val id: String) : IdentifiableComponent {
-    override fun getId(): String = id
-
+class ComponentGroup internal constructor(
+    private val componentController: ComponentController,
+    override val internalId: Int
+) : IdentifiableComponent {
     @JvmSynthetic
     override suspend fun await(): GenericComponentInteractionCreateEvent = componentController.awaitComponent(this)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/EntitySelectMenu.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/EntitySelectMenu.kt
@@ -7,10 +7,11 @@ import net.dv8tion.jda.api.interactions.components.selections.EntitySelectMenu a
 
 class EntitySelectMenu internal constructor(
     private val componentController: ComponentController,
+    override val internalId: Int,
     private val selectMenu: JDAEntitySelectMenu
 ) : JDAEntitySelectMenu by selectMenu, IdentifiableComponent {
     override fun withDisabled(disabled: Boolean): EntitySelectMenu {
-        return EntitySelectMenu(componentController, super.withDisabled(disabled))
+        return EntitySelectMenu(componentController, internalId, super.withDisabled(disabled))
     }
 
     override fun getId(): String = selectMenu.id ?: throwInternal("BC components cannot have null IDs")

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/IdentifiableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/IdentifiableComponent.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
 
 interface IdentifiableComponent {
-    fun getId(): String
+    val internalId: Int
 
     /**
      * Suspends until the component is used and all checks passed, and returns the event.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/StringSelectMenu.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/StringSelectMenu.kt
@@ -7,10 +7,11 @@ import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu a
 
 class StringSelectMenu internal constructor(
     private val componentController: ComponentController,
+    override val internalId: Int,
     private val selectMenu: JDAStringSelectMenu
 ) : JDAStringSelectMenu by selectMenu, IdentifiableComponent {
     override fun withDisabled(disabled: Boolean): StringSelectMenu {
-        return StringSelectMenu(componentController, super.withDisabled(disabled))
+        return StringSelectMenu(componentController, internalId, super.withDisabled(disabled))
     }
 
     override fun getId(): String = selectMenu.id ?: throwInternal("BC components cannot have null IDs")

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/button/AbstractButtonBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/button/AbstractButtonBuilder.kt
@@ -24,6 +24,12 @@ sealed class AbstractButtonBuilder<T : AbstractButtonBuilder<T>>(
         check(!built) { "Cannot build components more than once" }
         built = true
 
-        return Button(componentController, JDAButton.of(style, componentController.createComponent(this), label, emoji))
+        return componentController.withNewComponent(this) { internalId, componentId ->
+            Button(
+                componentController,
+                internalId,
+                JDAButton.of(style, componentId, label, emoji)
+            )
+        }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/group/ComponentGroupBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/group/ComponentGroupBuilder.kt
@@ -16,7 +16,7 @@ sealed class ComponentGroupBuilder<T : ComponentGroupBuilder<T>>(
     override val componentType: ComponentType = ComponentType.GROUP
 
     @get:JvmSynthetic
-    internal val componentIds = components.map { it.getId().toInt() }
+    internal val componentIds = components.map { it.internalId }
 
     fun build(): ComponentGroup = runBlocking { buildSuspend() }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/group/ComponentGroupBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/group/ComponentGroupBuilder.kt
@@ -23,6 +23,6 @@ sealed class ComponentGroupBuilder<T : ComponentGroupBuilder<T>>(
     @JvmSynthetic
     @PublishedApi
     internal suspend fun buildSuspend(): ComponentGroup {
-        return componentController.insertGroup(this)
+        return componentController.createGroup(this)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/select/ephemeral/EphemeralEntitySelectBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/select/ephemeral/EphemeralEntitySelectBuilder.kt
@@ -48,8 +48,9 @@ class EphemeralEntitySelectBuilder internal constructor(
         check(!built) { "Cannot build components more than once" }
         built = true
 
-        super.setId(componentController.createComponent(this))
-
-        return EntitySelectMenu(componentController, super.build())
+        componentController.withNewComponent(this) { internalId, componentId ->
+            super.setId(componentId)
+            return EntitySelectMenu(componentController, internalId, super.build())
+        }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/select/ephemeral/EphemeralStringSelectBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/select/ephemeral/EphemeralStringSelectBuilder.kt
@@ -45,8 +45,9 @@ class EphemeralStringSelectBuilder internal constructor(
         check(!built) { "Cannot build components more than once" }
         built = true
 
-        super.setId(componentController.createComponent(this))
-
-        return StringSelectMenu(componentController, super.build())
+        componentController.withNewComponent(this) { internalId, componentId ->
+            super.setId(componentId)
+            return StringSelectMenu(componentController, internalId, super.build())
+        }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/select/persistent/PersistentEntitySelectBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/select/persistent/PersistentEntitySelectBuilder.kt
@@ -46,8 +46,9 @@ class PersistentEntitySelectBuilder internal constructor(
         check(!built) { "Cannot build components more than once" }
         built = true
 
-        super.setId(componentController.createComponent(this))
-
-        return EntitySelectMenu(componentController, super.build())
+        componentController.withNewComponent(this) { internalId, componentId ->
+            super.setId(componentId)
+            return EntitySelectMenu(componentController, internalId, super.build())
+        }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/select/persistent/PersistentStringSelectBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/select/persistent/PersistentStringSelectBuilder.kt
@@ -44,8 +44,9 @@ class PersistentStringSelectBuilder internal constructor(
         check(!built) { "Cannot build components more than once" }
         built = true
 
-        super.setId(componentController.createComponent(this))
-
-        return StringSelectMenu(componentController, super.build())
+        componentController.withNewComponent(this) { internalId, componentId ->
+            super.setId(componentId)
+            return StringSelectMenu(componentController, internalId, super.build())
+        }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/data/ComponentTimeoutData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/data/ComponentTimeoutData.kt
@@ -1,3 +1,3 @@
 package io.github.freya022.botcommands.api.components.data
 
-data class ComponentTimeoutData internal constructor(val componentId: String)
+data class ComponentTimeoutData internal constructor(val componentId: Int)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/modals/Modal.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/modals/Modal.kt
@@ -8,10 +8,11 @@ import net.dv8tion.jda.api.interactions.modals.Modal as JDAModal
 class Modal internal constructor(modal: JDAModal, private val modalMaps: ModalMaps) : JDAModal by modal {
     suspend fun await(): ModalInteractionEvent {
         return suspendCancellableCoroutine { continuation ->
-            modalMaps.insertContinuation(id, continuation)
+            val internalId = ModalMaps.parseModalId(id)
+            modalMaps.insertContinuation(internalId, continuation)
 
             continuation.invokeOnCancellation {
-                modalMaps.removeContinuation(id, continuation)
+                modalMaps.removeContinuation(internalId, continuation)
             }
         }
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/modals/ModalBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/modals/ModalBuilder.kt
@@ -101,14 +101,11 @@ abstract class ModalBuilder protected constructor(
      */
     abstract fun timeout(timeout: Duration, onTimeout: suspend () -> Unit): ModalBuilder
 
-    /**
-     * An ID is already generated automatically, but you can set a custom ID if you wish to.
-     *
-     * **Tip:** A modal with the same ID as a previously sent one, will have the previously submitted values.
-     */
-    override fun setId(customId: String): ModalBuilder {
+    @Deprecated("Cannot set an ID on modals managed by the framework", level = DeprecationLevel.ERROR)
+    abstract override fun setId(customId: String): ModalBuilder
+
+    protected fun internetSetId(customId: String) {
         super.setId(customId)
-        return this
     }
 
     protected fun jdaBuild(): JDAModal {

--- a/src/main/kotlin/io/github/freya022/botcommands/api/modals/TextInputBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/modals/TextInputBuilder.kt
@@ -9,12 +9,15 @@ abstract class TextInputBuilder internal constructor(
     label: String?,
     style: TextInputStyle?
 ) : TextInput.Builder("0", label, style) {
-    /**
-     * An ID is already generated automatically, but you can set a custom ID if you wish to.
-     *
-     * **Tip:** A modal input with the same ID as a previously sent one, will have the previously submitted values.
-     */
-    override fun setId(customId: String): TextInputBuilder = this.apply { super.setId(customId) }
+    @Deprecated("Cannot set an ID on text inputs managed by the framework", level = DeprecationLevel.ERROR)
+    override fun setId(customId: String): TextInputBuilder = this.apply {
+        if (customId == "0") return@apply // Super constructor call
+        throw UnsupportedOperationException("Cannot set an ID on text inputs managed by the framework")
+    }
+
+    protected fun internetSetId(customId: String) {
+        super.setId(customId)
+    }
 
     override fun setLabel(label: String): TextInputBuilder = this.apply { super.setLabel(label) }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentController.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentController.kt
@@ -84,7 +84,7 @@ internal class ComponentController(
     suspend fun deleteComponent(component: ComponentData, throwTimeouts: Boolean) =
         deleteComponentsById(listOf(component.internalId), throwTimeouts)
 
-    suspend fun insertGroup(group: ComponentGroupBuilder<*>): ComponentGroup {
+    suspend fun createGroup(group: ComponentGroupBuilder<*>): ComponentGroup {
         return componentRepository.insertGroup(group)
             .also { id ->
                 val timeout = group.timeout ?: return@also

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentTimeoutManager.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentTimeoutManager.kt
@@ -82,8 +82,8 @@ internal class ComponentTimeoutManager(
                 }
 
                 val firstParameter: Any = when (component.componentType) {
-                    ComponentType.GROUP -> GroupTimeoutData((component as ComponentGroupData).componentsIds)
-                    ComponentType.BUTTON, ComponentType.SELECT_MENU -> ComponentTimeoutData(component.componentId.toString())
+                    ComponentType.GROUP -> GroupTimeoutData((component as ComponentGroupData).componentIds)
+                    ComponentType.BUTTON, ComponentType.SELECT_MENU -> ComponentTimeoutData(component.internalId)
                 }
 
                 val userData = componentTimeout.userData

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
@@ -73,9 +73,12 @@ internal class ComponentsListener(
         logger.trace { "Received ${event.componentType} interaction: ${event.component}" }
 
         scope.launchCatching({ handleException(event, it) }) launch@{
-            val componentId = event.componentId.toIntOrNull()
-                ?: return@launch logger.error { "Received an interaction for an external token format: '${event.componentId}', " +
-                        "please only use the framework's components or disable ${BComponentsConfigBuilder::useComponents.reference}" }
+            val componentId = event.componentId.let { id ->
+                if (!ComponentController.isCompatibleComponent(id))
+                    return@launch logger.error { "Received an interaction for an external token format: '${event.componentId}', " +
+                            "please only use the framework's components or disable ${BComponentsConfigBuilder::useComponents.reference}" }
+                ComponentController.parseComponentId(id)
+            }
             val component = componentRepository.getComponent(componentId)
                 ?: return@launch event.reply_(context.getDefaultMessages(event).componentExpiredErrorMsg, ephemeral = true).queue()
 
@@ -176,7 +179,7 @@ internal class ComponentsListener(
             }
         }
 
-        componentController.removeContinuations(component.componentId).forEach {
+        componentController.removeContinuations(component.internalId).forEach {
             (it as Continuation<GenericComponentInteractionCreateEvent>).resume(evt)
         }
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
@@ -75,8 +75,8 @@ internal class ComponentsListener(
         scope.launchCatching({ handleException(event, it) }) launch@{
             val componentId = event.componentId.let { id ->
                 if (!ComponentController.isCompatibleComponent(id))
-                    return@launch logger.error { "Received an interaction for an external token format: '${event.componentId}', " +
-                            "please only use the framework's components or disable ${BComponentsConfigBuilder::useComponents.reference}" }
+                    return@launch logger.error { "Received an interaction for an external component format: '${event.componentId}', " +
+                            "please only use ${classRef<Components>()} to make components or disable ${BComponentsConfigBuilder::useComponents.reference}" }
                 ComponentController.parseComponentId(id)
             }
             val component = componentRepository.getComponent(componentId)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentData.kt
@@ -8,7 +8,7 @@ import io.github.freya022.botcommands.internal.components.LifetimeType
 import io.github.freya022.botcommands.internal.components.handler.ComponentHandler
 
 internal sealed class ComponentData(
-    val componentId: Int,
+    val internalId: Int,
     val componentType: ComponentType,
     val lifetimeType: LifetimeType,
     val filters: List<ComponentInteractionFilter<*>>,

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentGroupData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentGroupData.kt
@@ -8,5 +8,5 @@ internal class ComponentGroupData internal constructor(
     groupId: Int,
     oneUse: Boolean,
     timeout: ComponentTimeout?,
-    internal val componentsIds: List<Int>
+    internal val componentIds: List<Int>
 ): ComponentData(groupId, ComponentType.GROUP, LifetimeType.PERSISTENT, emptyList(), oneUse, null, null, timeout, null, groupId)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/IPartialModalData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/IPartialModalData.kt
@@ -1,7 +1,9 @@
 package io.github.freya022.botcommands.internal.modals
 
+import gnu.trove.map.TLongObjectMap
+
 internal interface IPartialModalData {
     val handlerData: IModalHandlerData?
-    val inputDataMap: Map<String, InputData>
+    val inputDataMap: TLongObjectMap<InputData>
     val timeoutInfo: ModalTimeoutInfo?
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalBuilderImpl.kt
@@ -37,8 +37,10 @@ internal class ModalBuilderImpl internal constructor(
         timeoutInfo = ModalTimeoutInfo(timeout, onTimeout)
     }
 
+    @Deprecated("Cannot set an ID on modals managed by the framework", level = DeprecationLevel.ERROR)
     override fun setId(customId: String): ModalBuilderImpl = this.also {
-        super.setId(customId)
+        if (customId == "0") return@also // Super constructor call
+        throw UnsupportedOperationException("Cannot set an ID on modals managed by the framework")
     }
 
     override fun build(): Modal {
@@ -56,7 +58,7 @@ internal class ModalBuilderImpl internal constructor(
                 inputDataMap.put(internalId, data)
             }
 
-        id = modalMaps.insertModal(PartialModalData(handlerData, inputDataMap, timeoutInfo), id)
+        internetSetId(modalMaps.insertModal(PartialModalData(handlerData, inputDataMap, timeoutInfo)))
 
         return Modal(jdaBuild(), modalMaps)
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalListener.kt
@@ -29,7 +29,7 @@ internal class ModalListener(private val context: BContextImpl, private val moda
 
         scope.launchCatching({ handleException(it, event) }) launch@{
             if (!ModalMaps.isCompatibleModal(event.modalId)) {
-                return@launch logger.error { "Received an interaction for an external modal format: ${event.modalId}, " +
+                return@launch logger.error { "Received an interaction for an external modal format: '${event.modalId}', " +
                         "please use ${classRef<Modals>()} to make modals" }
             }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalListener.kt
@@ -4,10 +4,12 @@ import dev.minn.jda.ktx.messages.reply_
 import dev.minn.jda.ktx.messages.send
 import io.github.freya022.botcommands.api.core.annotations.BEventListener
 import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.modals.Modals
 import io.github.freya022.botcommands.api.modals.annotations.ModalHandler
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.ExceptionHandler
 import io.github.freya022.botcommands.internal.utils.annotationRef
+import io.github.freya022.botcommands.internal.utils.classRef
 import io.github.freya022.botcommands.internal.utils.launchCatching
 import io.github.freya022.botcommands.internal.utils.throwUser
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -26,7 +28,12 @@ internal class ModalListener(private val context: BContextImpl, private val moda
         logger.trace { "Received modal interaction '${event.modalId}' with ${event.values.associate { it.id to it.asString }}" }
 
         scope.launchCatching({ handleException(it, event) }) launch@{
-            val modalData = modalMaps.consumeModal(event.modalId)
+            if (!ModalMaps.isCompatibleModal(event.modalId)) {
+                return@launch logger.error { "Received an interaction for an external modal format: ${event.modalId}, " +
+                        "please use ${classRef<Modals>()} to make modals" }
+            }
+
+            val modalData = modalMaps.consumeModal(ModalMaps.parseModalId(event.modalId))
             if (modalData == null) { //Probably the modal expired
                 event.reply_(context.getDefaultMessages(event).modalExpiredErrorMsg, ephemeral = true).queue()
                 return@launch

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalMaps.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalMaps.kt
@@ -1,11 +1,15 @@
 package io.github.freya022.botcommands.internal.modals
 
+import gnu.trove.map.TLongObjectMap
+import gnu.trove.map.hash.TLongObjectHashMap
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.modals.Modals
 import io.github.freya022.botcommands.internal.core.ExceptionHandler
 import io.github.freya022.botcommands.internal.utils.TimeoutExceptionAccessor
+import io.github.freya022.botcommands.internal.utils.classRef
 import io.github.freya022.botcommands.internal.utils.launchCatchingDelayed
-import io.github.freya022.botcommands.internal.utils.throwUser
+import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellableContinuation
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
@@ -17,6 +21,12 @@ import kotlin.math.log10
 import kotlin.math.pow
 
 private val logger = KotlinLogging.logger { }
+
+private const val MODAL_PREFIX = "BotCommands-Modal-"
+private const val MODAL_PREFIX_LENGTH = MODAL_PREFIX.length
+
+private const val INPUT_PREFIX = "BotCommands-ModalInput-"
+private const val INPUT_PREFIX_LENGTH = INPUT_PREFIX.length
 
 private const val MAX_ID = Long.MAX_VALUE
 //Same amount of digits except every digit is 0 but the first one is 1
@@ -30,21 +40,22 @@ internal class ModalMaps(context: BContext) {
     private val modalLock = ReentrantLock()
     private val inputLock = ReentrantLock()
 
-    private val modalMap: MutableMap<String, ModalData> = hashMapOf()
+    private val modalMap: TLongObjectMap<ModalData> = TLongObjectHashMap()
 
     //Modals input IDs are temporarily stored here while it waits for its ModalBuilder owner to be built, and it's InputData to be associated with it
-    private val inputMap: MutableMap<String, InputData> = hashMapOf()
+    private val inputMap: TLongObjectMap<InputData> = TLongObjectHashMap()
 
-    fun insertModal(partialModalData: PartialModalData, id: String): String {
-        modalLock.withLock {
-            if (id == "0") { //If not a user supplied ID
-                return insertModal(partialModalData, nextModalId())
+    fun insertModal(partialModalData: PartialModalData, userModalId: Long?): String {
+        return modalLock.withLock {
+            val internalId: Long = when {
+                userModalId != null -> userModalId
+                else -> generateId(modalMap)
             }
 
             val job = partialModalData.timeoutInfo?.let { timeoutInfo ->
                 // Run timeout user code on the modal scope again
                 timeoutScope.launchCatchingDelayed(timeoutInfo.timeout, { handleTimeoutException(it) }) {
-                    val data = modalLock.withLock { modalMap.remove(id) }
+                    val data = modalLock.withLock { modalMap.remove(internalId) }
                     if (data != null) { //If the timeout was reached without the modal being used
                         if (data.continuations.isNotEmpty()) {
                             val timeoutException = TimeoutExceptionAccessor.createModalTimeoutException()
@@ -57,69 +68,72 @@ internal class ModalMaps(context: BContext) {
                 }
             }
 
-            modalMap[id] = ModalData(partialModalData, job)
+            modalMap.put(internalId, ModalData(partialModalData, job))
+            getModalId(internalId)
         }
-
-        return id
     }
 
     private fun handleTimeoutException(e: Throwable) {
         exceptionHandler.handleException(null, e, "modal timeout handler", emptyMap())
     }
 
-    fun insertInput(inputData: InputData, id: String): String {
-        inputLock.withLock {
-            if (id == "0") {
-                return insertInput(inputData, nextInputId())
+    fun insertInput(inputData: InputData, userInputId: Long?): String {
+        return inputLock.withLock {
+            val internalId: Long = when {
+                userInputId != null -> userInputId
+                else -> generateId(inputMap)
             }
 
-            inputMap.put(id, inputData)
+            inputMap.put(internalId, inputData)
+            getInputId(internalId)
         }
-
-        return id
     }
 
-    fun insertContinuation(id: String, continuation: CancellableContinuation<ModalInteractionEvent>) {
-        val data = modalMap[id] ?: throwUser("Unable to find a modal with id '$id' ; Is the modal created with the framework ?")
+    fun insertContinuation(modalId: Long, continuation: CancellableContinuation<ModalInteractionEvent>) {
+        val data = modalMap[modalId] ?: throwInternal("Unable to find a modal with id '$modalId'")
         data.continuations.add(continuation)
     }
 
-    fun removeContinuation(id: String, continuation: CancellableContinuation<ModalInteractionEvent>) {
-        val data = modalMap[id]
+    fun removeContinuation(modalId: Long, continuation: CancellableContinuation<ModalInteractionEvent>) {
+        val data = modalMap[modalId]
         data?.continuations?.remove(continuation)
     }
 
-    fun consumeModal(modalId: String): ModalData? {
-        modalLock.withLock {
-            return modalMap.remove(modalId)?.also { it.cancelTimeout() }
-        }
+    fun consumeModal(modalId: Long): ModalData? = modalLock.withLock {
+       modalMap.remove(modalId)?.also { it.cancelTimeout() }
     }
 
-    fun consumeInput(inputId: String): InputData? {
+    fun consumeInput(inputId: Long): InputData? {
         inputLock.withLock { return inputMap.remove(inputId) }
     }
 
-    private fun nextModalId(): String {
+    private fun generateId(map: TLongObjectMap<*>): Long {
         val random = ThreadLocalRandom.current()
-        modalLock.withLock {
-            return generateId(random, modalMap)
-        }
-    }
-
-    private fun nextInputId(): String {
-        val random = ThreadLocalRandom.current()
-        inputLock.withLock {
-            return generateId(random, inputMap)
-        }
-    }
-
-    private fun generateId(random: ThreadLocalRandom, map: Map<String, *>): String {
         while (true) {
-            val id = random.nextLong(MIN_ID, MAX_ID).toString()
-
-            if (!map.containsKey(id)) {
-                return id
+            val internalId = random.nextLong(MIN_ID, MAX_ID)
+            if (!map.containsKey(internalId)) {
+                return internalId
             }
         }
+    }
+
+    internal companion object {
+        internal fun isCompatibleModal(id: String): Boolean = id.startsWith(MODAL_PREFIX)
+        internal fun parseModalId(id: String): Long {
+            require(isCompatibleModal(id)) {
+                "Cannot use JDA modals ($id), please use modals from ${classRef<Modals>()}"
+            }
+            return java.lang.Long.parseLong(id, MODAL_PREFIX_LENGTH, id.length, 10)
+        }
+        internal fun getModalId(internalId: Long): String = MODAL_PREFIX + internalId
+
+        internal fun isCompatibleInput(id: String): Boolean = id.startsWith(INPUT_PREFIX)
+        internal fun parseInputId(id: String): Long {
+            require(isCompatibleInput(id)) {
+                "Cannot use JDA modal inputs ($id), please use modal inputs from ${classRef<Modals>()}"
+            }
+            return java.lang.Long.parseLong(id, INPUT_PREFIX_LENGTH, id.length, 10)
+        }
+        internal fun getInputId(internalId: Long): String = INPUT_PREFIX + internalId
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalMaps.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalMaps.kt
@@ -45,12 +45,9 @@ internal class ModalMaps(context: BContext) {
     //Modals input IDs are temporarily stored here while it waits for its ModalBuilder owner to be built, and it's InputData to be associated with it
     private val inputMap: TLongObjectMap<InputData> = TLongObjectHashMap()
 
-    fun insertModal(partialModalData: PartialModalData, userModalId: Long?): String {
+    fun insertModal(partialModalData: PartialModalData): String {
         return modalLock.withLock {
-            val internalId: Long = when {
-                userModalId != null -> userModalId
-                else -> generateId(modalMap)
-            }
+            val internalId: Long = generateId(modalMap)
 
             val job = partialModalData.timeoutInfo?.let { timeoutInfo ->
                 // Run timeout user code on the modal scope again
@@ -77,12 +74,9 @@ internal class ModalMaps(context: BContext) {
         exceptionHandler.handleException(null, e, "modal timeout handler", emptyMap())
     }
 
-    fun insertInput(inputData: InputData, userInputId: Long?): String {
+    fun insertInput(inputData: InputData): String {
         return inputLock.withLock {
-            val internalId: Long = when {
-                userInputId != null -> userInputId
-                else -> generateId(inputMap)
-            }
+            val internalId: Long = generateId(inputMap)
 
             inputMap.put(internalId, inputData)
             getInputId(internalId)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/PartialModalData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/PartialModalData.kt
@@ -1,7 +1,9 @@
 package io.github.freya022.botcommands.internal.modals
 
+import gnu.trove.map.TLongObjectMap
+
 internal open class PartialModalData(
     override val handlerData: IModalHandlerData?,
-    override val inputDataMap: Map<String, InputData>,
+    override val inputDataMap: TLongObjectMap<InputData>,
     override val timeoutInfo: ModalTimeoutInfo?
 ) : IPartialModalData

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/TextInputBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/TextInputBuilderImpl.kt
@@ -11,7 +11,7 @@ internal class TextInputBuilderImpl internal constructor(
     style: TextInputStyle?
 ) : TextInputBuilder(label, style) {
     override fun build(): TextInput {
-        id = modalMaps.insertInput(InputData(inputName), id)
+        internetSetId(modalMaps.insertInput(InputData(inputName)))
 
         return jdaBuild()
     }


### PR DESCRIPTION
* Allows for format checks, and thus the ability to skip buttons that aren't from the framework (such as when using 3rd party paginations)
* Custom modal IDs can no longer be set
  * Discord has to figure out a better solution to cache modal values when cancelling a modal
    * Hint: a `cache_key` field on both the modal and inputs