### PR TITLE
Remove ability to add services using `BServiceConfigBuilder`

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
@@ -1,17 +1,14 @@
 package io.github.freya022.botcommands.api.core.config
 
 import io.github.freya022.botcommands.api.commands.application.annotations.Test
-import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.AutocompleteTransformer
 import io.github.freya022.botcommands.api.core.service.annotations.InjectedService
 import io.github.freya022.botcommands.api.core.utils.toImmutableList
 import io.github.freya022.botcommands.api.core.utils.toImmutableMap
 import io.github.freya022.botcommands.api.localization.providers.DefaultLocalizationMapProvider
 import io.github.freya022.botcommands.internal.core.config.ConfigDSL
 import net.dv8tion.jda.api.interactions.DiscordLocale
-import net.dv8tion.jda.api.interactions.commands.Command.Choice
 import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFunction
 import java.util.*
-import kotlin.reflect.KClass
 
 @InjectedService
 interface BApplicationConfig {
@@ -64,7 +61,7 @@ interface BApplicationConfig {
 }
 
 @ConfigDSL
-class BApplicationConfigBuilder internal constructor(private val serviceConfig: BServiceConfigBuilder) : BApplicationConfig {
+class BApplicationConfigBuilder internal constructor() : BApplicationConfig {
     override val slashGuildIds: MutableList<Long> = mutableListOf()
     override val testGuildIds: MutableList<Long> = mutableListOf()
     @set:DevConfig
@@ -77,34 +74,6 @@ class BApplicationConfigBuilder internal constructor(private val serviceConfig: 
     private val _baseNameToLocalesMap: MutableMap<String, MutableList<Locale>> = hashMapOf()
     override val baseNameToLocalesMap: Map<String, List<Locale>>
         get() = _baseNameToLocalesMap.toImmutableMap()
-
-    /**
-     * Registers an autocomplete transformer.
-     *
-     * If your autocomplete handler return a `List<YourObject>`,
-     * you will have to register an `AutocompleteTransformer<YourObject>`
-     *
-     * @param transformerType The type of the transformer service, which will transform an element of a [List], into a [Choice].
-     *
-     * @return This builder for chaining convenience
-     */
-    fun registerAutocompleteTransformer(transformerType: Class<AutocompleteTransformer<*>>) =
-        registerAutocompleteTransformer(transformerType.kotlin)
-
-    /**
-     * Registers an autocomplete transformer.
-     *
-     * If your autocomplete handler return a `List<YourObject>`,
-     * you will have to register an `AutocompleteTransformer<YourObject>`
-     *
-     * @param transformerType The type of the transformer service, which will transform an element of a [List], into a [Choice].
-     *
-     * @return This builder for chaining convenience
-     */
-    @JvmSynthetic
-    fun registerAutocompleteTransformer(transformerType: KClass<AutocompleteTransformer<*>>) {
-        serviceConfig.registerService(transformerType)
-    }
 
     /**
      * Adds the specified bundle names with its locales;

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BConfig.kt
@@ -94,7 +94,7 @@ class BConfigBuilder internal constructor() : BConfig {
     override val serviceConfig = BServiceConfigBuilder()
     override val databaseConfig = BDatabaseConfigBuilder()
     override val textConfig = BTextConfigBuilder()
-    override val applicationConfig = BApplicationConfigBuilder(serviceConfig)
+    override val applicationConfig = BApplicationConfigBuilder()
     override val componentsConfig = BComponentsConfigBuilder()
     override val coroutineScopesConfig = BCoroutineScopesConfigBuilder()
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
@@ -3,7 +3,6 @@ package io.github.freya022.botcommands.api.core.config
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.core.annotations.Handler
 import io.github.freya022.botcommands.api.core.service.InstanceSupplier
-import io.github.freya022.botcommands.api.core.service.ServiceStart
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.service.annotations.InjectedService
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
@@ -11,23 +10,18 @@ import io.github.freya022.botcommands.api.core.service.annotations.ResolverFacto
 import io.github.freya022.botcommands.api.core.utils.toImmutableMap
 import io.github.freya022.botcommands.api.core.utils.toImmutableSet
 import io.github.freya022.botcommands.internal.core.config.ConfigDSL
-import io.github.freya022.botcommands.internal.core.service.ServiceAnnotationsMap
 import kotlin.reflect.KClass
 
 @InjectedService
 interface BServiceConfig {
+    //TODO document - this seems to be mostly used to retain classpath elements
     val serviceAnnotations: Set<KClass<out Annotation>>
-    val serviceAnnotationsMap: Map<KClass<out Annotation>, Map<KClass<*>, Annotation>>
     val instanceSupplierMap: Map<KClass<*>, InstanceSupplier<*>>
 }
 
 @ConfigDSL
 class BServiceConfigBuilder internal constructor() : BServiceConfig {
     override val serviceAnnotations: MutableSet<KClass<out Annotation>> = hashSetOf(BService::class, Command::class, Resolver::class, ResolverFactory::class, Handler::class)
-
-    private val _serviceAnnotationsMap = ServiceAnnotationsMap()
-    override val serviceAnnotationsMap: Map<KClass<out Annotation>, Map<KClass<*>, Annotation>>
-        get() = _serviceAnnotationsMap.toImmutableMap()
 
     private val _instanceSupplierMap: MutableMap<KClass<*>, InstanceSupplier<*>> = hashMapOf()
     override val instanceSupplierMap: Map<KClass<*>, InstanceSupplier<*>>
@@ -42,47 +36,9 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
         _instanceSupplierMap[clazz.kotlin] = instanceSupplier
     }
 
-    @JvmOverloads
-    fun registerService(annotationReceiver: Class<*>, start: ServiceStart = ServiceStart.DEFAULT, name: String = "", priority: Int = 0) =
-        registerService(annotationReceiver.kotlin, start, name, priority)
-
-    @JvmSynthetic
-    fun registerService(annotationReceiver: KClass<*>, start: ServiceStart = ServiceStart.DEFAULT, name: String = "", priority: Int = 0) {
-        _serviceAnnotationsMap.put(annotationReceiver, BService::class, BService(start, name, priority))
-    }
-
-    fun registerCommand(annotationReceiver: Class<*>) =
-        registerCommand(annotationReceiver.kotlin)
-
-    @JvmSynthetic
-    fun registerCommand(annotationReceiver: KClass<*>) {
-        _serviceAnnotationsMap.put(annotationReceiver, Command::class, Command())
-    }
-
-    fun registerResolver(annotationReceiver: Class<*>) =
-        registerResolver(annotationReceiver.kotlin)
-
-    @JvmSynthetic
-    fun registerResolver(annotationReceiver: KClass<*>) {
-        _serviceAnnotationsMap.put(annotationReceiver, Resolver::class,
-            Resolver()
-        )
-    }
-
-    fun registerResolverFactory(annotationReceiver: Class<*>) =
-        registerResolverFactory(annotationReceiver.kotlin)
-
-    @JvmSynthetic
-    fun registerResolverFactory(annotationReceiver: KClass<*>) {
-        _serviceAnnotationsMap.put(annotationReceiver, ResolverFactory::class,
-            ResolverFactory()
-        )
-    }
-
     @JvmSynthetic
     internal fun build() = object : BServiceConfig {
         override val serviceAnnotations = this@BServiceConfigBuilder.serviceAnnotations.toImmutableSet()
-        override val serviceAnnotationsMap = this@BServiceConfigBuilder.serviceAnnotationsMap //Already immutable
         override val instanceSupplierMap = this@BServiceConfigBuilder.instanceSupplierMap //Already immutable
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/BContextImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/BContextImpl.kt
@@ -33,7 +33,7 @@ internal class BContextImpl internal constructor(override val config: BConfig, v
 
     override val serviceContainer = ServiceContainerImpl(this) //Puts itself
 
-    internal val serviceAnnotationsMap = ServiceAnnotationsMap(config.serviceConfig)
+    internal val serviceAnnotationsMap = ServiceAnnotationsMap()
     internal val instantiableServiceAnnotationsMap get() = getService<InstantiableServiceAnnotationsMap>()
     internal val serviceProviders = ServiceProviders()
     internal val customConditionsContainer = CustomConditionsContainer()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/ServiceAnnotationsMap.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/ServiceAnnotationsMap.kt
@@ -3,7 +3,6 @@ package io.github.freya022.botcommands.internal.core.service
 import io.github.classgraph.ClassInfo
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.config.BConfig
-import io.github.freya022.botcommands.api.core.config.BServiceConfig
 import io.github.freya022.botcommands.api.core.service.ClassGraphProcessor
 import io.github.freya022.botcommands.api.core.service.ServiceError.ErrorType.*
 import io.github.freya022.botcommands.api.core.service.ServiceStart
@@ -154,12 +153,9 @@ internal class InstantiableServiceAnnotationsMap internal constructor(private va
 
 private val logger = KotlinLogging.logger { }
 
-internal class ServiceAnnotationsMap private constructor(
+internal class ServiceAnnotationsMap internal constructor() {
     //Annotation type match such as: Map<KClass<A>, Map<KClass<*>, A>>
-    private val map: MutableMap<KClass<out Annotation>, MutableMap<KClass<*>, Annotation>>
-) {
-    internal constructor() : this(hashMapOf())
-    internal constructor(serviceConfig: BServiceConfig) : this(serviceConfig.serviceAnnotationsMap.mapValuesTo(hashMapOf()) { it.value.toMap(hashMapOf()) })
+    private val map: MutableMap<KClass<out Annotation>, MutableMap<KClass<*>, Annotation>> = hashMapOf()
 
     internal fun <A : Annotation> put(annotationReceiver: KClass<*>, annotationType: KClass<A>, annotation: A) {
         val instanceAnnotationMap = map.computeIfAbsent(annotationType) { hashMapOf() }


### PR DESCRIPTION
It had multiple issues such as:
- Allowing classes that were not scanned, which causes further issues
- Creating synthetic annotations, which cannot be read using reflection
- The map storing the annotation and added class was only retrieved for the class

Service factories can easily replace such usages