### PR TITLE
Make `JDAService` mandatory

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/EventDispatcher.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/EventDispatcher.kt
@@ -5,7 +5,6 @@ import io.github.freya022.botcommands.api.core.annotations.BEventListener
 import io.github.freya022.botcommands.api.core.events.BEvent
 import io.github.freya022.botcommands.api.core.events.InitializationEvent
 import io.github.freya022.botcommands.api.core.service.annotations.BService
-import io.github.freya022.botcommands.api.core.service.getServiceOrNull
 import io.github.freya022.botcommands.api.core.utils.isSubclassOf
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.internal.core.*
@@ -68,11 +67,11 @@ private typealias EventMap = MutableMap<KClass<*>, SortedList<EventHandlerFuncti
 class EventDispatcher internal constructor(
     private val context: BContextImpl,
     private val eventTreeService: EventTreeService,
+    private val jdaService: JDAService,
     functionAnnotationsMap: FunctionAnnotationsMap
 ) {
     private val logger = KotlinLogging.logger { }
     private val eventManager: CoroutineEventManager = context.eventManager
-    private val jdaService: JDAService? = context.getServiceOrNull()
 
     private val map: EventMap = ConcurrentHashMap()
     private val listeners: MutableMap<Class<*>, EventMap> = ConcurrentHashMap()
@@ -185,7 +184,7 @@ class EventDispatcher internal constructor(
             val parameters = function.nonInstanceParameters
 
             val eventErasure = parameters.first().type.jvmErasure
-            if (!annotation.ignoreIntents && jdaService != null && eventErasure.isSubclassOf<Event>()) {
+            if (!annotation.ignoreIntents && eventErasure.isSubclassOf<Event>()) {
                 @Suppress("UNCHECKED_CAST")
                 val requiredIntents = GatewayIntent.fromEvents(eventErasure.java as Class<out Event>)
                 val missingIntents = requiredIntents - jdaService.intents - context.config.ignoredIntents

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/events/InjectedJDAEvent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/events/InjectedJDAEvent.kt
@@ -4,9 +4,10 @@ import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.events.guild.GuildReadyEvent
+import net.dv8tion.jda.api.sharding.ShardManager
 
 /**
- * Indicates that a JDA instance was acquired and injected in the [ServiceContainer].
+ * Indicates that a [JDA] instance was acquired and injected in the [ServiceContainer], alongside its [ShardManager].
  *
  * The JDA instance is not fully initialized, as this event is sent as fast as possible,
  * when the first JDA instance is retrievable.

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/conditions/RequiredIntentsChecker.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/conditions/RequiredIntentsChecker.kt
@@ -4,9 +4,8 @@ import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.JDAService
 import io.github.freya022.botcommands.api.core.conditions.RequiredIntents
 import io.github.freya022.botcommands.api.core.service.CustomConditionChecker
-import io.github.freya022.botcommands.api.core.service.getServiceOrNull
+import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
-import io.github.freya022.botcommands.internal.utils.annotationRef
 
 internal object RequiredIntentsChecker : CustomConditionChecker<RequiredIntents> {
     override val annotationType: Class<RequiredIntents> = RequiredIntents::class.java
@@ -16,11 +15,7 @@ internal object RequiredIntentsChecker : CustomConditionChecker<RequiredIntents>
         checkedClass: Class<*>,
         annotation: RequiredIntents
     ): String? {
-        val jdaService = context.getServiceOrNull<JDAService>()
-        checkNotNull(jdaService) {
-            "A JDAService instance must be present in order to use ${annotationRef<RequiredIntents>()}"
-        }
-
+        val jdaService = context.getService<JDAService>()
         val missingIntents = annotation.intents.asList() - jdaService.intents
         if (missingIntents.isNotEmpty()) {
             return "${checkedClass.simpleNestedName} requires missing intents: $missingIntents"

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/JDAServiceMismatchChecker.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/JDAServiceMismatchChecker.kt
@@ -1,11 +1,9 @@
 package io.github.freya022.botcommands.internal.core
 
-import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.JDAService
 import io.github.freya022.botcommands.api.core.annotations.BEventListener
 import io.github.freya022.botcommands.api.core.events.InjectedJDAEvent
 import io.github.freya022.botcommands.api.core.service.annotations.BService
-import io.github.freya022.botcommands.api.core.service.getServiceOrNull
 import io.github.freya022.botcommands.internal.utils.reference
 import io.github.oshai.kotlinlogging.KotlinLogging
 
@@ -14,32 +12,30 @@ private val logger = KotlinLogging.logger { }
 @BService
 internal object JDAServiceMismatchChecker {
     @BEventListener
-    internal fun onJDA(event: InjectedJDAEvent, context: BContext) {
-        context.getServiceOrNull<JDAService>()?.let { jdaService ->
-            val jdaIntents = event.jda.gatewayIntents
-            val jdaServiceIntents = jdaService.intents
-            if (jdaIntents != jdaServiceIntents) {
-                logger.warn {
-                    """
-                        The intents given in JDAService and JDA should be the same!
-                        JDA intents: $jdaIntents
-                        JDAService intents: $jdaServiceIntents
-                        Hint: you should pass ${JDAService::intents.reference} to your builder
-                    """.trimIndent()
-                }
+    internal fun onJDA(event: InjectedJDAEvent, jdaService: JDAService) {
+        val jdaIntents = event.jda.gatewayIntents
+        val jdaServiceIntents = jdaService.intents
+        if (jdaIntents != jdaServiceIntents) {
+            logger.warn {
+                """
+                    The intents given in JDAService and JDA should be the same!
+                    JDA intents: $jdaIntents
+                    JDAService intents: $jdaServiceIntents
+                    Hint: you should pass ${JDAService::intents.reference} to your builder
+                """.trimIndent()
             }
+        }
 
-            val jdaCacheFlags = event.jda.cacheFlags
-            val jdaServiceCacheFlags = jdaService.cacheFlags
-            if (!jdaCacheFlags.containsAll(jdaServiceCacheFlags)) {
-                logger.warn {
-                    """
-                        The cache flags given in JDAService should at least be a subset of the JDA cache flags!
-                        JDA cache flags: $jdaCacheFlags
-                        JDAService cache flags: $jdaServiceCacheFlags
-                        Hint: you should pass ${JDAService::cacheFlags.reference} to your builder
-                    """.trimIndent()
-                }
+        val jdaCacheFlags = event.jda.cacheFlags
+        val jdaServiceCacheFlags = jdaService.cacheFlags
+        if (!jdaCacheFlags.containsAll(jdaServiceCacheFlags)) {
+            logger.warn {
+                """
+                    The cache flags given in JDAService should at least be a subset of the JDA cache flags!
+                    JDA cache flags: $jdaCacheFlags
+                    JDAService cache flags: $jdaServiceCacheFlags
+                    Hint: you should pass ${JDAService::cacheFlags.reference} to your builder
+                """.trimIndent()
             }
         }
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/ReadyListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/ReadyListener.kt
@@ -28,6 +28,7 @@ internal class ReadyListener {
             }
 
             context.putServiceAs(event.jda)
+            event.jda.shardManager?.let { context.putServiceAs(it) }
 
             context.eventDispatcher.dispatchEvent(InjectedJDAEvent(context, event.jda))
         }


### PR DESCRIPTION
Pros:
* Can check gateway intents, cache flags and member cache required for event listeners and event waiters
* Can conditionally enable services based on the configured intents and cache flags
* JDA is started when every service is ready
* The JDA instance is isolated to the BotCommands context, meaning you can run multiple bots if you wish

Cons:
* JDA cannot be injected in eagerly-loaded services
  * You can still retrieve it lazily
  * You can listen to `InjectedJDAEvent` and store the instance
* Can't create JDA anywhere else, though this should slightly improve project structure

Note: By "JDA" I mean initializing a `JDA` instance or any shard manager