### PR TITLE
Add support for archived thread in options, attribute types and improve type inference

### DIFF
--- a/src/main/java/io/github/freya022/botcommands/api/localization/DefaultMessages.java
+++ b/src/main/java/io/github/freya022/botcommands/api/localization/DefaultMessages.java
@@ -159,6 +159,13 @@ public final class DefaultMessages {
 	}
 
 	/**
+	 * @return Message to display when a channel parameter could not be resolved
+	 */
+	public String getResolverChannelMissingAccessMsg(String channelMention) {
+		return getLocalizationTemplate("resolver.channel.missing_access.message").localize(entry("channel_mention", channelMention));
+	}
+
+	/**
 	 * @return Message to display when a user parameter could not be resolved
 	 */
 	public String getResolverUserNotFoundMsg() {

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAMessageCommand.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAMessageCommand.kt
@@ -28,7 +28,7 @@ import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFuncti
  * [GuildMessageEvent] for [global guild-only][CommandScope.GLOBAL_NO_DM] and [guild][CommandScope.GUILD] commands.
  *
  * ### Option types
- * - Input options: Uses [@ContextOption][ContextOption], supported types are in [ParameterResolver],
+ * - Input options: Uses [@ContextOption][ContextOption], supported types and modifiers are in [ParameterResolver],
  * but only the targeted [Message][GlobalMessageEvent.getTarget] is supported by default,
  * additional types can be added by implementing [MessageContextParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAUserCommand.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAUserCommand.kt
@@ -29,7 +29,7 @@ import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFuncti
  * [GuildUserEvent] for [global guild-only][CommandScope.GLOBAL_NO_DM] and [guild][CommandScope.GUILD] commands.
  *
  * ### Option types
- * - Input options: Uses [@ContextOption][ContextOption], supported types are in [ParameterResolver],
+ * - Input options: Uses [@ContextOption][ContextOption], supported types and modifiers are in [ParameterResolver],
  * but only the targeted [User][GlobalUserEvent.getTarget]/[Member][GlobalUserEvent.getTargetMember] and [InputUser] are supported by default,
  * additional types can be added by implementing [UserContextParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/MessageCommandBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/MessageCommandBuilder.kt
@@ -26,7 +26,7 @@ class MessageCommandBuilder internal constructor(
     override val parentInstance: INamedCommand? = null
 
     /**
-     * Declares an input option, supported types are in [ParameterResolver],
+     * Declares an input option, supported types and modifiers are in [ParameterResolver],
      * additional types can be added by implementing [MessageContextParameterResolver].
      *
      * @param declaredName Name of the declared parameter in the [command function][function]

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/UserCommandBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/UserCommandBuilder.kt
@@ -26,7 +26,7 @@ class UserCommandBuilder internal constructor(
     override val parentInstance: INamedCommand? = null
 
     /**
-     * Declares an input option, supported types are in [ParameterResolver],
+     * Declares an input option, supported types and modifiers are in [ParameterResolver],
      * additional types can be added by implementing [UserContextParameterResolver].
      *
      * @param declaredName Name of the declared parameter in the [command function][function]

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/ChannelTypes.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/ChannelTypes.kt
@@ -1,16 +1,15 @@
 package io.github.freya022.botcommands.api.commands.application.slash.annotations
 
-import io.github.freya022.botcommands.api.commands.application.slash.builder.SlashCommandOptionBuilder
 import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 
 /**
- * Sets the desired channel types for this [@SlashOption][SlashOption].
+ * Sets the desired channel types for this parameter.
+ *
+ * This works for annotated commands as well as code-declared commands
  *
  * You can alternatively use a specific channel type,
  * such as [TextChannel] to automatically restrict the channel type.
- *
- * @see SlashCommandOptionBuilder.channelTypes DSL equivalent
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/JDASlashCommand.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/JDASlashCommand.kt
@@ -39,7 +39,7 @@ import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFuncti
  * e.g., if you have `/tag create` and `/tag edit`, you can annotate at most one of them.
  *
  * ### Option types
- * - Input options: Uses [@SlashOption][SlashOption], supported types are in [ParameterResolver],
+ * - Input options: Uses [@SlashOption][SlashOption], supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [SlashParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
  * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/autocomplete/annotations/AutocompleteHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/autocomplete/annotations/AutocompleteHandler.kt
@@ -44,7 +44,7 @@ import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInterac
  * **Note:** Parameters refers to method parameters, not Discord options.
  *
  * ## Registering more option types
- * Supported types are in [ParameterResolver],
+ * Supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [SlashParameterResolver].
  *
  * @see SlashOption @SlashOption

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandBuilder.kt
@@ -55,7 +55,7 @@ abstract class SlashCommandBuilder internal constructor(
     }
 
     /**
-     * Declares an input option, supported types are in [ParameterResolver],
+     * Declares an input option, supported types and modifiers are in [ParameterResolver],
      * additional types can be added by implementing [SlashParameterResolver].
      *
      * @param declaredName Name of the declared parameter in the [command function][function]
@@ -92,7 +92,7 @@ abstract class SlashCommandBuilder internal constructor(
     /**
      * Declares an input option encapsulated in an inline class.
      *
-     * Supported types are in [ParameterResolver],
+     * Supported types and modifiers are in [ParameterResolver],
      * additional types can be added by implementing [SlashParameterResolver].
      *
      * @param declaredName Name of the declared parameter in the [command function][function]

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandOptionAggregateBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandOptionAggregateBuilder.kt
@@ -19,7 +19,7 @@ class SlashCommandOptionAggregateBuilder internal constructor(
     aggregator: KFunction<*>
 ) : ApplicationCommandOptionAggregateBuilder<SlashCommandOptionAggregateBuilder>(aggregatorParameter, aggregator) {
     /**
-     * Declares an input option, supported types are in [ParameterResolver],
+     * Declares an input option, supported types and modifiers are in [ParameterResolver],
      * additional types can be added by implementing [SlashParameterResolver].
      *
      * @param declaredName Name of the declared parameter in the aggregator

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandOptionBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandOptionBuilder.kt
@@ -102,6 +102,7 @@ class SlashCommandOptionBuilder internal constructor(
      *
      * @see ChannelTypes
      */
+    @Deprecated("Replaced with @ChannelTypes")
     var channelTypes: EnumSet<ChannelType>? = null
 
     internal var autocompleteInfo: AutocompleteInfoImpl? = null

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandOptionBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandOptionBuilder.kt
@@ -4,8 +4,10 @@ import io.github.freya022.botcommands.api.commands.application.ApplicationComman
 import io.github.freya022.botcommands.api.commands.application.LengthRange
 import io.github.freya022.botcommands.api.commands.application.ValueRange
 import io.github.freya022.botcommands.api.commands.application.builder.ApplicationCommandOptionBuilder
-import io.github.freya022.botcommands.api.commands.application.slash.annotations.*
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.DoubleRange
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.Length
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.LongRange
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.annotations.AutocompleteHandler
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.declaration.AutocompleteManager
 import io.github.freya022.botcommands.api.core.BContext
@@ -17,12 +19,9 @@ import io.github.freya022.botcommands.internal.commands.application.slash.autoco
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
 import io.github.freya022.botcommands.internal.utils.shortSignatureNoSrc
 import io.github.freya022.botcommands.internal.utils.throwUser
-import net.dv8tion.jda.api.entities.channel.ChannelType
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.interactions.commands.Command.Choice
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFunction
-import java.util.*
 import kotlin.reflect.KFunction
 
 class SlashCommandOptionBuilder internal constructor(
@@ -93,17 +92,6 @@ class SlashCommandOptionBuilder internal constructor(
      * @see Length
      */
     var lengthRange: LengthRange? = null
-
-    /**
-     * Sets the desired channel types for this option.
-     *
-     * You can alternatively use a specific channel type,
-     * such as [TextChannel] to automatically restrict the channel type.
-     *
-     * @see ChannelTypes
-     */
-    @Deprecated("Replaced with @ChannelTypes")
-    var channelTypes: EnumSet<ChannelType>? = null
 
     internal var autocompleteInfo: AutocompleteInfoImpl? = null
         private set

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/JDATextCommandVariation.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/JDATextCommandVariation.kt
@@ -41,7 +41,7 @@ import net.dv8tion.jda.internal.utils.Checks
  * - First parameter must be [BaseCommandEvent], or, [CommandEvent] for fallback commands/manual token consumption.
  *
  * ### Option types
- * - Input options: Uses [@TextOption][TextOption], supported types are in [ParameterResolver],
+ * - Input options: Uses [@TextOption][TextOption], supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [TextParameterResolver].
  * - [TextLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
  * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDAButtonListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDAButtonListener.kt
@@ -25,7 +25,7 @@ import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
  *
  * ### Option types
  * - User data: No annotation, the order must match the data passed when creating the button,
- * supported types are in [ParameterResolver],
+ * supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [ComponentParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
  * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDASelectMenuListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDASelectMenuListener.kt
@@ -26,7 +26,7 @@ import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
  *
  * ### Option types
  * - User data: No annotation, the order must match the data passed when creating the select menu,
- * supported types are in [ParameterResolver],
+ * supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [ComponentParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
  * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/exceptions/InvalidChannelTypeException.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/exceptions/InvalidChannelTypeException.kt
@@ -1,0 +1,10 @@
+package io.github.freya022.botcommands.api.core.exceptions
+
+import io.github.freya022.botcommands.api.core.utils.retrieveThreadChannelById
+
+/**
+ * Exception thrown when retrieving a channel by ID, but the type is incorrect.
+ *
+ * @see retrieveThreadChannelById
+ */
+class InvalidChannelTypeException(message: String) : IllegalArgumentException(message)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/reflect/ParameterWrapper.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/reflect/ParameterWrapper.kt
@@ -60,6 +60,11 @@ class ParameterWrapper private constructor(
     }
 }
 
+internal val ParameterWrapper.function get() = parameter.function
+
+inline fun <reified A : Annotation> ParameterWrapper.hasAnnotation(): Boolean = hasAnnotation(A::class.java)
+inline fun <reified A : Annotation> ParameterWrapper.findAnnotation(): A? = getAnnotation(A::class.java)
+
 @OptIn(ExperimentalContracts::class)
 @JvmSynthetic
 internal inline fun ParameterWrapper.requireUser(value: Boolean, lazyMessage: () -> Any?) {

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/utils/Reflection.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/utils/Reflection.kt
@@ -109,6 +109,27 @@ val Class<*>.allSuperclasses: List<Class<*>>
         }
     }
 
+val Class<*>.allSuperclassesAndInterfaces: List<Class<*>>
+    get() = buildList {
+        val visited = hashSetOf<Class<*>>()
+        val queue = ArrayDeque<Class<*>>()
+
+        visited += this@allSuperclassesAndInterfaces
+        queue += this@allSuperclassesAndInterfaces
+
+        while (queue.isNotEmpty()) {
+            val c = queue.removeFirst()
+            this += c // Add to list
+
+            // Get next elements
+            (c.interfaces + c.superclass).filterNotNull().forEach {
+                if (visited.add(it)) {
+                    queue += it
+                }
+            }
+        }
+    }
+
 fun KFunction<*>.getSignature(
     parameterNames: List<String> = listOf(),
     qualifiedClass: Boolean = false,

--- a/src/main/kotlin/io/github/freya022/botcommands/api/modals/annotations/ModalHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/modals/annotations/ModalHandler.kt
@@ -23,7 +23,7 @@ import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
  *
  * ### Option types
  * - Input options: Uses [@ModalInput][ModalInput], the annotation's value must match the name given in [Modals.createTextInput],
- * supported types are in [ParameterResolver],
+ * supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [ModalParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
  * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolver.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.api.parameters
 
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.ChannelTypes
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.MentionsString
 import io.github.freya022.botcommands.api.core.entities.InputUser
 import io.github.freya022.botcommands.api.core.service.annotations.BService
@@ -9,12 +10,9 @@ import net.dv8tion.jda.api.entities.*
 import net.dv8tion.jda.api.entities.Message.Attachment
 import net.dv8tion.jda.api.entities.channel.attribute.IPositionableChannel
 import net.dv8tion.jda.api.entities.channel.concrete.Category
-import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
 import net.dv8tion.jda.api.entities.emoji.Emoji
 
-// NOTE: you can edit the built-in resolvers docs using https://www.tablesgenerator.com/markdown_tables
-// see the File > Paste table data
 /**
  * Base class for parameter resolvers used in text commands, application commands, and component callbacks.
  *
@@ -22,27 +20,28 @@ import net.dv8tion.jda.api.entities.emoji.Emoji
  *
  * ### Default parameter resolvers
  *
- * |                                                               | Text                          | Slash           | Message context    | User context    | Components                    | Modals |
- * |---------------------------------------------------------------|-------------------------------|-----------------|--------------------|-----------------|-------------------------------|--------|
- * | [String]                                                      | ✓ (can be quoted)             | ✓               |                    |                 | ✓                             | ✓      |
- * | [Boolean]                                                     | ✓                             | ✓               |                    |                 | ✓                             |        |
- * | [Int]                                                         | ✓                             | ✓               |                    |                 | ✓                             |        |
- * | [Long]                                                        | ✓                             | ✓               |                    |                 | ✓                             |        |
- * | [Double]                                                      | ✓                             | ✓               |                    |                 | ✓                             |        |
- * | [Emoji]                                                       | ✓                             | ✓               |                    |                 | ✓                             |        |
- * | [IMentionable]                                                | ✓ (only mentions)             | ✓               |                    |                 |                               |        |
- * | [List] of mentionable (see [@MentionsString][MentionsString]) |                               | ✓               |                    |                 |                               |        |
- * | [Role]                                                        | ✓                             | ✓               |                    |                 | ✓                             |        |
- * | [User]                                                        | ✓                             | ✓               |                    | ✓ (target user) | ✓                             |        |
- * | [Member]                                                      | ✓                             | ✓               |                    | ✓ (target user) | ✓                             |        |
- * | [InputUser]                                                   | ✓                             | ✓               |                    | ✓ (target user) | ✓                             |        |
- * | Concrete [GuildChannel] subtypes<sup>1</sup>                  | ✓ (excluding [ThreadChannel]) | ✓               |                    |                 | ✓ (excluding [ThreadChannel]) |        |
- * | [Guild]                                                       | ✓                             | ✓ (as a String) |                    |                 | ✓                             |        |
- * | [Message]                                                     |                               |                 | ✓ (target message) |                 |                               |        |
- * | [Attachment]                                                  |                               | ✓               |                    |                 |                               |        |
+ * |                                                               | Text              | Slash           | Message context    | User context    | Components | Modals |
+ * |---------------------------------------------------------------|-------------------|-----------------|--------------------|-----------------|------------|--------|
+ * | [String]                                                      | ✓ (can be quoted) | ✓               |                    |                 | ✓          | ✓      |
+ * | [Boolean]                                                     | ✓                 | ✓               |                    |                 | ✓          |        |
+ * | [Int]                                                         | ✓                 | ✓               |                    |                 | ✓          |        |
+ * | [Long]                                                        | ✓                 | ✓               |                    |                 | ✓          |        |
+ * | [Double]                                                      | ✓                 | ✓               |                    |                 | ✓          |        |
+ * | [Emoji]                                                       | ✓                 | ✓               |                    |                 | ✓          |        |
+ * | [IMentionable]                                                | ✓ (only mentions) | ✓               |                    |                 |            |        |
+ * | [List] of mentionable (see [@MentionsString][MentionsString]) |                   | ✓               |                    |                 |            |        |
+ * | [Role]                                                        | ✓                 | ✓               |                    |                 | ✓          |        |
+ * | [User]                                                        | ✓                 | ✓               |                    | ✓ (target user) | ✓          |        |
+ * | [Member]                                                      | ✓                 | ✓               |                    | ✓ (target user) | ✓          |        |
+ * | [InputUser]                                                   | ✓                 | ✓               |                    | ✓ (target user) | ✓          |        |
+ * | Concrete [GuildChannel] subtypes<sup>1</sup>                  | ✓                 | ✓               |                    |                 | ✓          |        |
+ * | [Guild]                                                       | ✓                 | ✓ (as a String) |                    |                 | ✓          |        |
+ * | [Message]                                                     |                   |                 | ✓ (target message) |                 |            |        |
+ * | [Attachment]                                                  |                   | ✓               |                    |                 |            |        |
  *
  * 1. Only allows [concrete][net.dv8tion.jda.api.entities.channel.concrete] channels, including [Category],
  * but excludes any attribute interface such as [IPositionableChannel].
+ * A broader channel type can be used and restricted to multiple concrete types by using [@ChannelTypes][ChannelTypes].
  *
  * Parameter resolvers for services exist by default, and follow the rules described in [@BService][BService].
  *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolver.kt
@@ -8,8 +8,6 @@ import io.github.freya022.botcommands.api.core.service.annotations.InterfacedSer
 import io.github.freya022.botcommands.api.parameters.resolvers.*
 import net.dv8tion.jda.api.entities.*
 import net.dv8tion.jda.api.entities.Message.Attachment
-import net.dv8tion.jda.api.entities.channel.attribute.IPositionableChannel
-import net.dv8tion.jda.api.entities.channel.concrete.Category
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
 import net.dv8tion.jda.api.entities.emoji.Emoji
 
@@ -34,14 +32,14 @@ import net.dv8tion.jda.api.entities.emoji.Emoji
  * | [User]                                                        | ✓                 | ✓               |                    | ✓ (target user) | ✓          |        |
  * | [Member]                                                      | ✓                 | ✓               |                    | ✓ (target user) | ✓          |        |
  * | [InputUser]                                                   | ✓                 | ✓               |                    | ✓ (target user) | ✓          |        |
- * | Concrete [GuildChannel] subtypes<sup>1</sup>                  | ✓                 | ✓               |                    |                 | ✓          |        |
+ * | [GuildChannel] subtypes<sup>1</sup>                           | ✓                 | ✓               |                    |                 | ✓          |        |
  * | [Guild]                                                       | ✓                 | ✓ (as a String) |                    |                 | ✓          |        |
  * | [Message]                                                     |                   |                 | ✓ (target message) |                 |            |        |
  * | [Attachment]                                                  |                   | ✓               |                    |                 |            |        |
  *
- * 1. Only allows [concrete][net.dv8tion.jda.api.entities.channel.concrete] channels, including [Category],
- * but excludes any attribute interface such as [IPositionableChannel].
- * A broader channel type can be used and restricted to multiple concrete types by using [@ChannelTypes][ChannelTypes].
+ * 1. The channel types are set automatically depending on the type,
+ * but a broader channel type can be used
+ * and restricted to multiple concrete types by using [@ChannelTypes][ChannelTypes].
  *
  * Parameter resolvers for services exist by default, and follow the rules described in [@BService][BService].
  *

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/SlashCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/SlashCommandAutoBuilder.kt
@@ -19,7 +19,6 @@ import io.github.freya022.botcommands.api.commands.application.slash.builder.Sla
 import io.github.freya022.botcommands.api.core.config.BApplicationConfig
 import io.github.freya022.botcommands.api.core.reflect.ParameterType
 import io.github.freya022.botcommands.api.core.service.annotations.BService
-import io.github.freya022.botcommands.api.core.utils.enumSetOf
 import io.github.freya022.botcommands.api.core.utils.joinAsList
 import io.github.freya022.botcommands.api.core.utils.nullIfBlank
 import io.github.freya022.botcommands.api.parameters.ResolverContainer
@@ -33,7 +32,6 @@ import io.github.freya022.botcommands.internal.utils.*
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.nonInstanceParameters
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.entities.Guild
-import net.dv8tion.jda.api.entities.channel.ChannelType
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
@@ -332,12 +330,6 @@ internal class SlashCommandAutoBuilder(
         kParameter.findAnnotation<LongRange>()?.let { range -> valueRange = ValueRange.ofLong(range.from, range.to) }
         kParameter.findAnnotation<DoubleRange>()?.let { range -> valueRange = ValueRange.ofDouble(range.from, range.to) }
         kParameter.findAnnotation<Length>()?.let { length -> lengthRange = LengthRange.of(length.min, length.max) }
-
-        kParameter.findAnnotation<ChannelTypes>()?.let { channelTypesAnnotation ->
-            channelTypes = enumSetOf<ChannelType>().also { types ->
-                types += channelTypesAnnotation.value
-            }
-        }
 
         processAutocomplete(optionAnnotation)
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandOption.kt
@@ -4,14 +4,11 @@ import io.github.freya022.botcommands.api.commands.application.LengthRange
 import io.github.freya022.botcommands.api.commands.application.ValueRange
 import io.github.freya022.botcommands.api.commands.application.slash.builder.SlashCommandOptionAggregateBuilder
 import io.github.freya022.botcommands.api.commands.application.slash.builder.SlashCommandOptionBuilder
-import io.github.freya022.botcommands.api.core.utils.enumSetOf
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.slash.autocomplete.AutocompleteHandler
 import io.github.freya022.botcommands.internal.utils.LocalizationUtils
-import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.interactions.commands.OptionType
-import java.util.*
 
 class SlashCommandOption(
     slashCommandInfo: SlashCommandInfo,
@@ -32,9 +29,6 @@ class SlashCommandOption(
     val choices: List<Command.Choice>? = optionBuilder.choices
     val range: ValueRange? = optionBuilder.valueRange
     val length: LengthRange? = optionBuilder.lengthRange
-
-    @Deprecated("Replaced with @ChannelTypes")
-    val channelTypes: EnumSet<ChannelType> = optionBuilder.channelTypes ?: enumSetOf()
 
     init {
         description = LocalizationUtils.getOptionDescription(slashCommandInfo.context, optionBuilder)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandOption.kt
@@ -8,13 +8,10 @@ import io.github.freya022.botcommands.api.core.utils.enumSetOf
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.slash.autocomplete.AutocompleteHandler
 import io.github.freya022.botcommands.internal.utils.LocalizationUtils
-import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import java.util.*
-
-private val logger = KotlinLogging.logger { }
 
 class SlashCommandOption(
     slashCommandInfo: SlashCommandInfo,
@@ -36,6 +33,7 @@ class SlashCommandOption(
     val range: ValueRange? = optionBuilder.valueRange
     val length: LengthRange? = optionBuilder.lengthRange
 
+    @Deprecated("Replaced with @ChannelTypes")
     val channelTypes: EnumSet<ChannelType> = optionBuilder.channelTypes ?: enumSetOf()
 
     init {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashUtils.kt
@@ -1,15 +1,18 @@
 package io.github.freya022.botcommands.internal.commands.application.slash
 
 import io.github.freya022.botcommands.api.commands.application.slash.GlobalSlashEvent
+import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
 import io.github.freya022.botcommands.internal.IExecutableInteractionInfo
 import io.github.freya022.botcommands.internal.commands.GeneratedOption
 import io.github.freya022.botcommands.internal.core.options.isRequired
 import io.github.freya022.botcommands.internal.parameters.resolvers.IChannelResolver
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.function
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.reflectReference
+import io.github.freya022.botcommands.internal.utils.classRef
 import io.github.freya022.botcommands.internal.utils.requireUser
 import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.freya022.botcommands.internal.utils.throwUser
+import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
@@ -19,6 +22,8 @@ import kotlin.reflect.jvm.jvmErasure
 import net.dv8tion.jda.api.interactions.commands.OptionType as JDAOptionType
 
 internal object SlashUtils {
+    private val logger = KotlinLogging.logger { }
+
     internal val fakeSlashFunction = SlashUtils::fakeFunction.reflectReference()
 
     @Suppress("UNUSED_PARAMETER", "MemberVisibilityCanBePrivate")
@@ -75,10 +80,10 @@ internal object SlashUtils {
             JDAOptionType.CHANNEL -> {
                 //If there are no specified channel types, then try to get the channel type from AbstractChannelResolver
                 // Otherwise set the channel types of the option, if available
-                if (option.channelTypes.isEmpty() && resolver is IChannelResolver) {
+                if (resolver is IChannelResolver) {
                     data.setChannelTypes(resolver.channelTypes)
-                } else if (option.channelTypes.isEmpty()) {
-                    data.setChannelTypes(option.channelTypes)
+                } else {
+                    logger.warn { "Encountered a CHANNEL slash command option, but the resolver (${resolver.javaClass.shortQualifiedName}) does not implement ${classRef<IChannelResolver>()}" }
                 }
             }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -24,9 +24,7 @@ import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.freya022.botcommands.internal.utils.throwUser
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.entities.Guild
-import net.dv8tion.jda.api.entities.channel.Channel
 import net.dv8tion.jda.api.entities.channel.ChannelType
-import net.dv8tion.jda.api.entities.channel.ChannelType.UNKNOWN
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
@@ -186,7 +184,7 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
                     "Channel type was $channelType, meaning that the parameter '$paramName' must use a type that is itself or extends superclasses of $requireType: $signature"
                 } else {
                     val compatibleTypes = channelTypes.map { it.`interface` }
-                        .mapTo(linkedSetOf()) { it.allSuperclassesAndInterfaces.filterTo(linkedSetOf()) { GuildChannel::class.java.isAssignableFrom(it) } }
+                        .map { it.allSuperclassesAndInterfaces.filterTo(linkedSetOf(), GuildChannel::class.java::isAssignableFrom) }
                         .reduce { acc, interfaces ->
                             acc.retainAll(interfaces)
                             acc
@@ -212,8 +210,8 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
         }
         return ChannelResolver(context, erasure.java, channelTypes)
     }
-}
 
-private fun channelTypesFrom(clazz: Class<out Channel>): EnumSet<ChannelType> {
-    return ChannelType.entries.filterTo(enumSetOf<ChannelType>()) { type -> type.getInterface() == clazz && type != UNKNOWN }
+    private fun channelTypesFrom(clazz: Class<out GuildChannel>): EnumSet<ChannelType> {
+        return ChannelType.entries.filterTo(enumSetOf<ChannelType>()) { type -> clazz.isAssignableFrom(type.getInterface()) }
+    }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -1,13 +1,13 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers
 
+import dev.minn.jda.ktx.coroutines.await
 import dev.minn.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.exceptions.InvalidChannelTypeException
 import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
-import io.github.freya022.botcommands.api.core.utils.enumSetOf
-import io.github.freya022.botcommands.api.core.utils.isSubclassOf
-import io.github.freya022.botcommands.api.core.utils.simpleNestedName
+import io.github.freya022.botcommands.api.core.utils.*
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.ParameterResolverFactory
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
@@ -16,8 +16,11 @@ import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterReso
 import io.github.freya022.botcommands.internal.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.internal.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.internal.components.handler.ComponentDescriptor
+import io.github.freya022.botcommands.internal.parameters.resolvers.ChannelResolverFactory.ChannelResolver
 import io.github.freya022.botcommands.internal.utils.throwInternal
+import io.github.freya022.botcommands.internal.utils.throwUser
 import io.github.oshai.kotlinlogging.KotlinLogging
+import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.channel.Channel
 import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.entities.channel.ChannelType.UNKNOWN
@@ -25,9 +28,11 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
 import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.requests.ErrorResponse
 import java.util.*
 import java.util.regex.Pattern
 import kotlin.reflect.KClass
@@ -38,16 +43,39 @@ interface IChannelResolver {
 }
 
 @ResolverFactory
-internal class ChannelResolverFactory(private val context: BContext) : ParameterResolverFactory<ChannelResolverFactory.LimitedChannelResolver>(LimitedChannelResolver::class) {
-    // Only for slash commands where Discord always provides the data
-    // Channels such as threads are not easily resolvable when used in text commands / components,
-    // let the user use the channel id + thread id to find threads themselves
-    internal open class LimitedChannelResolver(
-        protected val type: Class<out GuildChannel>,
+internal class ChannelResolverFactory(private val context: BContext) : ParameterResolverFactory<ChannelResolver>(ChannelResolver::class) {
+    internal class ChannelResolver(
+        private val context: BContext,
+        private val type: Class<out GuildChannel>,
         override val channelTypes: EnumSet<ChannelType>
     ) : ClassParameterResolver<ChannelResolver, GuildChannel>(GuildChannel::class),
+        TextParameterResolver<ChannelResolver, GuildChannel>,
         SlashParameterResolver<ChannelResolver, GuildChannel>,
+        ComponentParameterResolver<ChannelResolver, GuildChannel>,
         IChannelResolver {
+
+        //region Text
+        override val pattern: Pattern = channelPattern
+        override val testExample: String = "<#1234>"
+
+        override fun getHelpExample(parameter: KParameter, event: BaseCommandEvent, isID: Boolean): String =
+            event.channel.asMention
+
+        override suspend fun resolveSuspend(
+            variation: TextCommandVariation,
+            event: MessageReceivedEvent,
+            args: Array<String?>
+        ): GuildChannel? {
+            val channelId = args[0]!!.toLong()
+            val channel = event.guild.getChannelById(type, channelId)
+            if (channel == null) {
+                if (ThreadChannel::class.java.isAssignableFrom(type))
+                    return retrieveThreadChannel(event, channelId)
+                logger.trace { "Could not find channel of type ${type.simpleNestedName} and id $channelId" }
+            }
+            return channel
+        }
+        //endregion
 
         //region Slash
         override val optionType: OptionType = OptionType.CHANNEL
@@ -65,26 +93,6 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
             }
         }
         //endregion
-    }
-
-    internal class ChannelResolver(private val context: BContext, type: Class<out GuildChannel>, channelTypes: EnumSet<ChannelType>) :
-        LimitedChannelResolver(type, channelTypes),
-        TextParameterResolver<ChannelResolver, GuildChannel>,
-        ComponentParameterResolver<ChannelResolver, GuildChannel> {
-
-        //region Text
-        override val pattern: Pattern = channelPattern
-        override val testExample: String = "<#1234>"
-
-        override fun getHelpExample(parameter: KParameter, event: BaseCommandEvent, isID: Boolean): String =
-            event.channel.asMention
-
-        override suspend fun resolveSuspend(
-            variation: TextCommandVariation,
-            event: MessageReceivedEvent,
-            args: Array<String?>
-        ): GuildChannel? = event.guild.getChannelById(type, args[0]!!)
-        //endregion
 
         //region Component
         override suspend fun resolveSuspend(
@@ -92,10 +100,14 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
             event: GenericComponentInteractionCreateEvent,
             arg: String
         ): GuildChannel? {
-            val guild = event.guild ?: throwInternal(descriptor.function, "Cannot resolve a Channel outside of a Guild")
-            val channel = guild.getChannelById(type, arg)
+            val guild = event.guild ?: throwUser("Cannot resolve a channel outside of a guild")
+            val channelId = arg.toLong()
+            val channel = guild.getChannelById(type, channelId)
             if (channel == null) {
-                logger.trace { "Could not find channel of type ${type.simpleNestedName} and id $arg" }
+                if (ThreadChannel::class.java.isAssignableFrom(type))
+                    return retrieveThreadChannel(event, guild, channelId)
+
+                logger.trace { "Could not find channel of type ${type.simpleNestedName} and id $channelId" }
                 event.reply_(context.getDefaultMessages(event).resolverChannelNotFoundMsg, ephemeral = true).queue()
             }
 
@@ -103,7 +115,47 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
         }
         //endregion
 
-        companion object {
+        private suspend fun retrieveThreadChannel(
+            event: MessageReceivedEvent,
+            channelId: Long
+        ): ThreadChannel? = retrieveThreadChannel(event.guild, channelId, onMissingAccess = {
+            if (event.channel.canTalk())
+                event.message.reply(context.getDefaultMessages(event.guild).getResolverChannelMissingAccessMsg("<#$channelId>")).queue()
+        })
+
+        private suspend fun retrieveThreadChannel(
+            event: IReplyCallback,
+            guild: Guild,
+            channelId: Long
+        ): ThreadChannel? = retrieveThreadChannel(guild, channelId, onMissingAccess = {
+            event.reply_(context.getDefaultMessages(event).getResolverChannelMissingAccessMsg("<#$channelId>"), ephemeral = true).queue()
+        })
+
+        private suspend fun retrieveThreadChannel(
+            guild: Guild,
+            channelId: Long,
+            onMissingAccess: () -> Unit
+        ): ThreadChannel? {
+            return runCatching { guild.retrieveThreadChannelById(channelId).await() }
+                .onErrorResponse(ErrorResponse.UNKNOWN_CHANNEL) {
+                    logger.trace { "Could not find thread channel $channelId" }
+                    return null
+                }
+                .onErrorResponse(ErrorResponse.MISSING_ACCESS) {
+                    logger.trace { "Could not retrieve thread channel $channelId due to missing access" }
+                    onMissingAccess()
+                    return null
+                }
+                .onFailure {
+                    if (it is InvalidChannelTypeException) {
+                        logger.trace { "Could not retrieve thread channel $channelId is not a thread channel" }
+                        return null
+                    }
+                }
+                .getOrThrow()
+        }
+
+        private companion object {
             private val channelPattern = Pattern.compile("(?:<#)?(\\d+)>?")
             private val logger = KotlinLogging.logger { }
         }
@@ -124,13 +176,9 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun get(parameter: ParameterWrapper): LimitedChannelResolver {
+    override fun get(parameter: ParameterWrapper): ChannelResolver {
         val erasure = parameter.erasure as KClass<out GuildChannel>
         val channelTypes = channelTypesFrom(erasure.java)
-        if (erasure.isSubclassOf<ThreadChannel>()) {
-            return LimitedChannelResolver(erasure.java, channelTypes)
-        }
-
         return ChannelResolver(context, erasure.java, channelTypes)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/utils/InternalJDAUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/utils/InternalJDAUtils.kt
@@ -1,0 +1,9 @@
+package io.github.freya022.botcommands.internal.utils
+
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.requests.RestAction
+import net.dv8tion.jda.api.requests.restaction.CacheRestAction
+import net.dv8tion.jda.internal.requests.DeferredRestAction
+
+internal inline fun <reified R : Any> JDA.deferredRestAction(noinline valueSupplier: () -> R?, noinline actionSupplier: () -> RestAction<R>): CacheRestAction<R> =
+    DeferredRestAction(this, R::class.java, valueSupplier, actionSupplier)

--- a/src/main/resources/bc_localization/DefaultMessages-default.json
+++ b/src/main/resources/bc_localization/DefaultMessages-default.json
@@ -13,6 +13,7 @@
     "command.not.found.message": "Unknown command, maybe you meant: {suggestions}",
 
     "resolver.channel.not_found.message": "The target channel does not exist anymore",
+    "resolver.channel.missing_access.message": "The bot cannot access {channel_mention}",
     "resolver.user.not_found.message": "The target user does not exist anymore",
 
     "closed.dm.error.message": "Unable to send you a DM, please open your DMs from this server",

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashMyCommand.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashMyCommand.kt
@@ -9,16 +9,13 @@ import io.github.freya022.botcommands.api.commands.application.ValueRange.Compan
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
-import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.*
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.LongRange
-import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
-import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.AutocompleteCacheMode
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.declaration.AutocompleteHandlerProvider
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.declaration.AutocompleteManager
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.reflect.ParameterType
-import io.github.freya022.botcommands.api.core.utils.enumSetOf
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.ChannelType
@@ -61,7 +58,7 @@ class SlashMyCommand : ApplicationCommand(), GlobalApplicationCommandProvider, A
         @SlashOption(name = "string_annotated", description = "Option description") stringOption: String,
         @SlashOption(name = "int_annotated", description = "An integer") @LongRange(from = 1, to = 2) intOption: Int,
         @SlashOption(name = "user_annotated", description = "An user") userOption: User,
-        @SlashOption(name = "channel_annotated") channelOption: GuildChannel,
+        @SlashOption(name = "channel_annotated") @ChannelTypes(ChannelType.TEXT) channelOption: GuildChannel,
         @SlashOption(name = "autocomplete_str_annotated", description = "Autocomplete !", autocomplete = autocompleteHandlerName) autocompleteStr: String,
         @SlashOption(name = "double_annotated", description = "A double") doubleOption: Double?,
         custom: BContext,
@@ -120,9 +117,7 @@ class SlashMyCommand : ApplicationCommand(), GlobalApplicationCommandProvider, A
                         description = "An user"
                     }
 
-                    option("channelOption") {
-                        channelTypes = enumSetOf(ChannelType.TEXT)
-                    }
+                    option("channelOption")
 
                     customOption("custom")
 

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashMyJavaCommand.java
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashMyJavaCommand.java
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.commands.annotations.*;
 import io.github.freya022.botcommands.api.commands.application.ApplicationCommand;
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier;
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent;
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.ChannelTypes;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.LongRange;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption;
@@ -16,6 +17,7 @@ import io.github.freya022.botcommands.api.core.BContext;
 import io.github.freya022.botcommands.api.core.reflect.ParameterType;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import org.jetbrains.annotations.NotNull;
@@ -71,7 +73,7 @@ public class SlashMyJavaCommand extends ApplicationCommand {
 	                @SlashOption(name = "string_annotated", description = "Option description") String stringOption,
 	                @SlashOption(name = "int_annotated", description = "An integer") @LongRange(from = 1, to = 2) int intOption,
 	                @SlashOption(name = "user_annotated", description = "An user") User userOption,
-	                @SlashOption(name = "channel_annotated") GuildChannel channelOption,
+	                @SlashOption(name = "channel_annotated") @ChannelTypes(ChannelType.TEXT) GuildChannel channelOption,
 	                @SlashOption(name = "autocomplete_str_annotated", description = "Autocomplete !", autocomplete = SlashMyCommand.autocompleteHandlerName) String autocompleteStr,
 	                @SlashOption(name = "double_annotated", description = "A double") @Optional double doubleOption,
 	                BContext custom,

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashResolveMentions.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashResolveMentions.kt
@@ -13,6 +13,7 @@ import io.github.freya022.botcommands.api.components.annotations.JDAButtonListen
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.components.builder.bindTo
 import io.github.freya022.botcommands.api.components.event.ButtonEvent
+import net.dv8tion.jda.api.entities.channel.attribute.IPostContainer
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
 
@@ -22,15 +23,16 @@ class SlashResolveMentions(private val buttons: Buttons) : ApplicationCommand() 
     @JDASlashCommand(name = "resolve_mentions")
     suspend fun onSlashResolveMentions(
         event: GuildSlashEvent,
+        @SlashOption postContainer: IPostContainer,
         @SlashOption forumChannel: ForumChannel,
         @SlashOption threadChannel: ThreadChannel,
         @SlashOption archivedThreadChannel: ThreadChannel
     ) {
         val button1 = buttons.primary("Resolve given channels").persistent {
-            bindTo(::onResolveChannelsClick, forumChannel, threadChannel, archivedThreadChannel)
+            bindTo(::onResolveChannelsClick, postContainer, forumChannel, threadChannel, archivedThreadChannel)
         }
         val button2 = buttons.primary("Resolve mentioned channels").persistent {
-            bindTo(::onResolveChannelsClick, forumChannel, threadChannel, archivedThreadChannel)
+            bindTo(::onResolveChannelsClick, postContainer, forumChannel, threadChannel, archivedThreadChannel)
         }
         event.reply_(
             "${forumChannel.asMention} ${threadChannel.asMention} ${archivedThreadChannel.asMention}",
@@ -42,12 +44,14 @@ class SlashResolveMentions(private val buttons: Buttons) : ApplicationCommand() 
     @JDAButtonListener("SlashResolveMentions: ResolveChannelsButton")
     suspend fun onResolveChannelsClick(
         event: ButtonEvent,
+        postContainer: IPostContainer,
         forumChannel: ForumChannel,
         threadChannel: ThreadChannel,
         archivedThreadChannel: ThreadChannel
     ) {
         event.reply_(
             """
+                $postContainer
                 $forumChannel
                 $threadChannel
                 $archivedThreadChannel

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashResolveMentions.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashResolveMentions.kt
@@ -1,0 +1,56 @@
+package io.github.freya022.botcommands.test.commands.slash
+
+import dev.minn.jda.ktx.coroutines.await
+import dev.minn.jda.ktx.interactions.components.row
+import dev.minn.jda.ktx.messages.reply_
+import io.github.freya022.botcommands.api.commands.annotations.Command
+import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
+import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
+import io.github.freya022.botcommands.api.components.Buttons
+import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
+import io.github.freya022.botcommands.api.components.builder.bindTo
+import io.github.freya022.botcommands.api.components.event.ButtonEvent
+import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
+
+@Command
+class SlashResolveMentions(private val buttons: Buttons) : ApplicationCommand() {
+    @JDASlashCommand(name = "resolve_mentions")
+    suspend fun onSlashResolveMentions(
+        event: GuildSlashEvent,
+        @SlashOption forumChannel: ForumChannel,
+        @SlashOption threadChannel: ThreadChannel,
+        @SlashOption archivedThreadChannel: ThreadChannel
+    ) {
+        val button1 = buttons.primary("Resolve given channels").persistent {
+            bindTo(::onResolveChannelsClick, forumChannel, threadChannel, archivedThreadChannel)
+        }
+        val button2 = buttons.primary("Resolve mentioned channels").persistent {
+            bindTo(::onResolveChannelsClick, forumChannel, threadChannel, archivedThreadChannel)
+        }
+        event.reply_(
+            "${forumChannel.asMention} ${threadChannel.asMention} ${archivedThreadChannel.asMention}",
+            components = listOf(row(button1, button2)),
+            ephemeral = true
+        ).await()
+    }
+
+    @JDAButtonListener("SlashResolveMentions: ResolveChannelsButton")
+    suspend fun onResolveChannelsClick(
+        event: ButtonEvent,
+        forumChannel: ForumChannel,
+        threadChannel: ThreadChannel,
+        archivedThreadChannel: ThreadChannel
+    ) {
+        event.reply_(
+            """
+                $forumChannel
+                $threadChannel
+                $archivedThreadChannel
+            """.trimIndent(),
+            ephemeral = true
+        ).await()
+    }
+}

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashResolveMentions.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashResolveMentions.kt
@@ -10,12 +10,14 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
 import io.github.freya022.botcommands.api.components.Buttons
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
+import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.components.builder.bindTo
 import io.github.freya022.botcommands.api.components.event.ButtonEvent
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
 
 @Command
+@RequiresComponents
 class SlashResolveMentions(private val buttons: Buttons) : ApplicationCommand() {
     @JDASlashCommand(name = "resolve_mentions")
     suspend fun onSlashResolveMentions(

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashThreadById.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashThreadById.kt
@@ -6,14 +6,13 @@ import io.github.freya022.botcommands.api.commands.application.ApplicationComman
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
-import io.github.freya022.botcommands.api.core.utils.retrieveThreadChannelByIdOrNull
+import io.github.freya022.botcommands.api.core.utils.retrieveThreadChannelOrNull
 
 @Command
 class SlashThreadById : ApplicationCommand() {
     @JDASlashCommand(name = "thread_by_id")
     suspend fun execute(event: GuildSlashEvent, @SlashOption id: String) {
-        val container = event.channel.asThreadContainer()
-        val threadChannel = container.retrieveThreadChannelByIdOrNull(id.toLong())
+        val threadChannel = event.guild.retrieveThreadChannelOrNull(id.toLong())
         event.reply_(threadChannel?.asMention.toString(), ephemeral = true).queue()
     }
 }


### PR DESCRIPTION
## New features
- Added `Guild#retrieveThreadChannelOrNull`
- Added `Guild#retrieveThreadChannelById`
  - Throws `InvalidChannelTypeException` if the channel ID does not represent a thread
- Channel options now support (archived) threads in text commands and component data
  - They will be retrieved if they are archived
  - Added localization key `resolver.channel.missing_access.message` in case the thread channel exists but isn't accessible
- Channel options now support [attribute channel types](https://github.com/discord-jda/JDA/tree/e82f4dcceedf0635d8c91f3213949aba216464e5/src/main/java/net/dv8tion/jda/api/entities/channel/attribute)
  - The channel types will be set to all channels which have the said attribute, unless overridden with `@ChannelTypes`

## Removals
- [Small breaking] Removed `IThreadContainer#retrieveThreadChannelByIdOrNull`
  - Replaced with `Guild#retrieveThreadChannelOrNull`
- [Small breaking] Replaced `SlashCommandOption(Builder)#channelTypes` by `@ChannelTypes`