### PR TITLE
Add `AwaitableComponent`, use typed `awaitOrNull`

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/AwaitableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/AwaitableComponent.kt
@@ -3,7 +3,7 @@ package io.github.freya022.botcommands.api.components
 import kotlinx.coroutines.TimeoutCancellationException
 import net.dv8tion.jda.api.interactions.components.ComponentInteraction
 
-sealed interface AwaitableComponent<T : ComponentInteraction> {
+interface AwaitableComponent<T : ComponentInteraction> : IdentifiableComponent {
     /**
      * Suspends until the component is used and all checks passed, and returns the event.
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/AwaitableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/AwaitableComponent.kt
@@ -1,0 +1,25 @@
+package io.github.freya022.botcommands.api.components
+
+import kotlinx.coroutines.TimeoutCancellationException
+import net.dv8tion.jda.api.interactions.components.ComponentInteraction
+
+sealed interface AwaitableComponent<T : ComponentInteraction> {
+    /**
+     * Suspends until the component is used and all checks passed, and returns the event.
+     *
+     * @throws TimeoutCancellationException If the timeout set in the component builder has been reached
+     */
+    @JvmSynthetic
+    suspend fun await(): T
+}
+
+/**
+ * Suspends until the component is used and all checks passed, and returns the event,
+ * or `null` if the timeout has been reached.
+ */
+@JvmSynthetic
+suspend fun <T : ComponentInteraction> AwaitableComponent<T>.awaitOrNull(): T? = try {
+    await()
+} catch (e: TimeoutCancellationException) {
+    null
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/Button.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/Button.kt
@@ -12,7 +12,10 @@ class Button internal constructor(
     private val componentController: ComponentController,
     override val internalId: Int,
     private val button: JDAButton
-) : JDAButton by button, IdentifiableComponent {
+) : JDAButton by button,
+    IdentifiableComponent,
+    AwaitableComponent<ButtonEvent> {
+
     override fun asDisabled(): Button = withDisabled(true)
 
     override fun asEnabled(): Button = withDisabled(false)
@@ -42,6 +45,8 @@ class Button internal constructor(
     override fun getUrl(): String? = null
 
     /**
+     * Suspends until the component is used and all checks passed, and returns the event.
+     *
      * **Awaiting on a component that is part of a group is undefined behavior**
      *
      * @throws TimeoutCancellationException If the timeout set in the component builder has been reached

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/Button.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/Button.kt
@@ -1,20 +1,20 @@
 package io.github.freya022.botcommands.api.components
 
 import io.github.freya022.botcommands.api.components.event.ButtonEvent
+import io.github.freya022.botcommands.internal.components.AbstractAwaitableComponent
 import io.github.freya022.botcommands.internal.components.controller.ComponentController
 import io.github.freya022.botcommands.internal.utils.throwInternal
-import kotlinx.coroutines.TimeoutCancellationException
 import net.dv8tion.jda.api.entities.emoji.Emoji
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle
 import net.dv8tion.jda.api.interactions.components.buttons.Button as JDAButton
 
 class Button internal constructor(
-    private val componentController: ComponentController,
+    componentController: ComponentController,
     override val internalId: Int,
     private val button: JDAButton
-) : JDAButton by button,
-    IdentifiableComponent,
-    AwaitableComponent<ButtonEvent> {
+) : AbstractAwaitableComponent<ButtonEvent>(componentController),
+    JDAButton by button,
+    IdentifiableComponent {
 
     override fun asDisabled(): Button = withDisabled(true)
 
@@ -43,16 +43,6 @@ class Button internal constructor(
     override fun getId(): String = button.id ?: throwInternal("BC components cannot have null IDs")
 
     override fun getUrl(): String? = null
-
-    /**
-     * Suspends until the component is used and all checks passed, and returns the event.
-     *
-     * **Awaiting on a component that is part of a group is undefined behavior**
-     *
-     * @throws TimeoutCancellationException If the timeout set in the component builder has been reached
-     */
-    @JvmSynthetic
-    override suspend fun await(): ButtonEvent = componentController.awaitComponent(this)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/ComponentGroup.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/ComponentGroup.kt
@@ -8,6 +8,8 @@ class ComponentGroup internal constructor(
     private val componentController: ComponentController,
     override val internalId: Int
 ) : IdentifiableComponent, AwaitableComponent<GenericComponentInteractionCreateEvent> {
+    override val group: ComponentGroup get() = this
+
     @JvmSynthetic
     override suspend fun await(): GenericComponentInteractionCreateEvent = componentController.awaitComponent(this)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/ComponentGroup.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/ComponentGroup.kt
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteract
 class ComponentGroup internal constructor(
     private val componentController: ComponentController,
     override val internalId: Int
-) : IdentifiableComponent {
+) : IdentifiableComponent, AwaitableComponent<GenericComponentInteractionCreateEvent> {
     @JvmSynthetic
     override suspend fun await(): GenericComponentInteractionCreateEvent = componentController.awaitComponent(this)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/EntitySelectMenu.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/EntitySelectMenu.kt
@@ -9,7 +9,10 @@ class EntitySelectMenu internal constructor(
     private val componentController: ComponentController,
     override val internalId: Int,
     private val selectMenu: JDAEntitySelectMenu
-) : JDAEntitySelectMenu by selectMenu, IdentifiableComponent {
+) : JDAEntitySelectMenu by selectMenu,
+    IdentifiableComponent,
+    AwaitableComponent<EntitySelectEvent> {
+
     override fun asEnabled(): JDAEntitySelectMenu = withDisabled(false)
 
     override fun asDisabled(): JDAEntitySelectMenu = withDisabled(true)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/EntitySelectMenu.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/EntitySelectMenu.kt
@@ -1,17 +1,18 @@
 package io.github.freya022.botcommands.api.components
 
 import io.github.freya022.botcommands.api.components.event.EntitySelectEvent
+import io.github.freya022.botcommands.internal.components.AbstractAwaitableComponent
 import io.github.freya022.botcommands.internal.components.controller.ComponentController
 import io.github.freya022.botcommands.internal.utils.throwInternal
 import net.dv8tion.jda.api.interactions.components.selections.EntitySelectMenu as JDAEntitySelectMenu
 
 class EntitySelectMenu internal constructor(
-    private val componentController: ComponentController,
+    componentController: ComponentController,
     override val internalId: Int,
     private val selectMenu: JDAEntitySelectMenu
-) : JDAEntitySelectMenu by selectMenu,
-    IdentifiableComponent,
-    AwaitableComponent<EntitySelectEvent> {
+) : AbstractAwaitableComponent<EntitySelectEvent>(componentController),
+    JDAEntitySelectMenu by selectMenu,
+    IdentifiableComponent {
 
     override fun asEnabled(): JDAEntitySelectMenu = withDisabled(false)
 
@@ -22,9 +23,6 @@ class EntitySelectMenu internal constructor(
     }
 
     override fun getId(): String = selectMenu.id ?: throwInternal("BC components cannot have null IDs")
-
-    @JvmSynthetic
-    override suspend fun await(): EntitySelectEvent = componentController.awaitComponent(this)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/IdentifiableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/IdentifiableComponent.kt
@@ -1,27 +1,5 @@
 package io.github.freya022.botcommands.api.components
 
-import kotlinx.coroutines.TimeoutCancellationException
-import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
-
 interface IdentifiableComponent {
     val internalId: Int
-
-    /**
-     * Suspends until the component is used and all checks passed, and returns the event.
-     *
-     * @throws TimeoutCancellationException If the timeout set in the component builder has been reached
-     */
-    @JvmSynthetic
-    suspend fun await(): GenericComponentInteractionCreateEvent
-}
-
-/**
- * Suspends until the component is used and all checks passed, and returns the event,
- * or `null` if the timeout has been reached.
- */
-@JvmSynthetic
-suspend fun IdentifiableComponent.awaitOrNull(): GenericComponentInteractionCreateEvent? = try {
-    await()
-} catch (e: TimeoutCancellationException) {
-    null
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/IdentifiableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/IdentifiableComponent.kt
@@ -2,4 +2,6 @@ package io.github.freya022.botcommands.api.components
 
 interface IdentifiableComponent {
     val internalId: Int
+
+    val group: ComponentGroup?
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/StringSelectMenu.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/StringSelectMenu.kt
@@ -1,17 +1,18 @@
 package io.github.freya022.botcommands.api.components
 
 import io.github.freya022.botcommands.api.components.event.StringSelectEvent
+import io.github.freya022.botcommands.internal.components.AbstractAwaitableComponent
 import io.github.freya022.botcommands.internal.components.controller.ComponentController
 import io.github.freya022.botcommands.internal.utils.throwInternal
 import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu as JDAStringSelectMenu
 
 class StringSelectMenu internal constructor(
-    private val componentController: ComponentController,
+    componentController: ComponentController,
     override val internalId: Int,
     private val selectMenu: JDAStringSelectMenu
-) : JDAStringSelectMenu by selectMenu,
-    IdentifiableComponent,
-    AwaitableComponent<StringSelectEvent> {
+) : AbstractAwaitableComponent<StringSelectEvent>(componentController),
+    JDAStringSelectMenu by selectMenu,
+    IdentifiableComponent {
 
     override fun asEnabled(): StringSelectMenu = withDisabled(false)
 
@@ -22,9 +23,6 @@ class StringSelectMenu internal constructor(
     }
 
     override fun getId(): String = selectMenu.id ?: throwInternal("BC components cannot have null IDs")
-
-    @JvmSynthetic
-    override suspend fun await(): StringSelectEvent = componentController.awaitComponent(this)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/StringSelectMenu.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/StringSelectMenu.kt
@@ -9,7 +9,10 @@ class StringSelectMenu internal constructor(
     private val componentController: ComponentController,
     override val internalId: Int,
     private val selectMenu: JDAStringSelectMenu
-) : JDAStringSelectMenu by selectMenu, IdentifiableComponent {
+) : JDAStringSelectMenu by selectMenu,
+    IdentifiableComponent,
+    AwaitableComponent<StringSelectEvent> {
+
     override fun asEnabled(): StringSelectMenu = withDisabled(false)
 
     override fun asDisabled(): StringSelectMenu = withDisabled(true)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/AbstractAwaitableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/AbstractAwaitableComponent.kt
@@ -1,0 +1,26 @@
+package io.github.freya022.botcommands.internal.components
+
+import io.github.freya022.botcommands.api.components.AwaitableComponent
+import io.github.freya022.botcommands.api.components.ComponentGroup
+import io.github.freya022.botcommands.internal.components.controller.ComponentController
+import net.dv8tion.jda.api.interactions.components.ComponentInteraction
+
+//TODO hide component internals properly
+abstract class AbstractAwaitableComponent<T : ComponentInteraction> internal constructor(
+    @get:JvmSynthetic
+    internal val componentController: ComponentController
+) : AwaitableComponent<T> {
+
+    @set:JvmSynthetic
+    override var group: ComponentGroup? = null
+        internal set
+
+    @JvmSynthetic
+    override suspend fun await(): T {
+        check(group == null) {
+            "Cannot await on a component owned by a group"
+        }
+
+        return componentController.awaitComponent(this)
+    }
+}


### PR DESCRIPTION
- Made the `awaitOrNull` extension to return the correct event type
- Throw an exception when attempting to await a component that's inside a group