### PR TITLE
Add contextual data to parameter resolvers

### DIFF
--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
@@ -1,7 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers;
 
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
-import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver;
@@ -22,7 +21,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-@Resolver
+/**
+ * @see RoleResolverFactoryProvider
+ */
 public class RoleResolver
 		extends ClassParameterResolver<RoleResolver, Role>
 		implements TextParameterResolver<RoleResolver, Role>,

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/reflect/ParameterWrapper.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/reflect/ParameterWrapper.kt
@@ -1,6 +1,7 @@
 package io.github.freya022.botcommands.api.core.reflect
 
 import io.github.freya022.botcommands.api.core.utils.bestName
+import io.github.freya022.botcommands.internal.utils.ReflectionMetadata.isNullable
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.function
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -20,6 +21,7 @@ class ParameterWrapper private constructor(
     val erasure: KClass<*> = type.jvmErasure
     val javaErasure: Class<*> get() = erasure.java
     val annotations: List<Annotation> get() = parameter.annotations
+    val isRequired get() = !parameter.isNullable && !parameter.isOptional
 
     internal constructor(parameter: KParameter) : this(parameter.type, parameter.index, parameter.bestName, parameter)
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ClassParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ClassParameterResolver.kt
@@ -20,9 +20,9 @@ import kotlin.reflect.KClass
  */
 @InterfacedService(acceptMultiple = true)
 abstract class ClassParameterResolver<T : ClassParameterResolver<T, R>, R : Any>(
-    val jvmErasure: KClass<R>
+    val jvmErasure: KClass<out R>
 ) : ParameterResolver<T, R>() {
-    constructor(clazz: Class<R>) : this(clazz.kotlin)
+    constructor(clazz: Class<out R>) : this(clazz.kotlin)
 
     override fun toString(): String {
         return "ClassParameterResolver(jvmErasure=$jvmErasure)"

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolver.kt
@@ -61,4 +61,4 @@ import net.dv8tion.jda.api.entities.emoji.Emoji
  * @see ICustomResolver
  */
 @InterfacedService(acceptMultiple = true)
-sealed class ParameterResolver<T : ParameterResolver<T, R>, R : Any>
+sealed class ParameterResolver<T : ParameterResolver<T, R>, R : Any> : IParameterResolver<T>

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolverFactory.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
+import io.github.freya022.botcommands.api.parameters.resolvers.IParameterResolver
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
@@ -35,7 +36,7 @@ import kotlin.reflect.KType
  * @see ParameterResolver
  */
 @InterfacedService(acceptMultiple = true)
-abstract class ParameterResolverFactory<T : ParameterResolver<out T, *>>(val resolverType: KClass<out T>) {
+abstract class ParameterResolverFactory<T : IParameterResolver<T>>(val resolverType: KClass<out T>) {
     constructor(resolverType: Class<out T>) : this(resolverType.kotlin)
 
     /**

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolverFactory.kt
@@ -49,18 +49,18 @@ abstract class ParameterResolverFactory<T : IParameterResolver<T>>(val resolverT
     abstract val supportedTypesStr: List<String>
 
     /**
-     * Determines if a given parameter is supported.
+     * Determines if a given parameter is supported, only one factory must return `true`.
      *
-     * Only one factory must return `true`.
+     * This only gets called if the requested resolver is compatible with [resolverType].
      */
-    abstract fun isResolvable(parameter: ParameterWrapper): Boolean
+    abstract fun isResolvable(request: ResolverRequest): Boolean
 
     /**
      * Returns a [ParameterResolver] for the given parameter.
      *
      * This is only called if [isResolvable] returned `true`.
      */
-    abstract fun get(parameter: ParameterWrapper): T
+    abstract fun get(request: ResolverRequest): T
 
     override fun toString(): String {
         return "ParameterResolverFactory(resolverType=${resolverType.shortQualifiedName})"

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
@@ -160,16 +160,19 @@ class ResolverContainer internal constructor(
         return resolver::class.isSubclassOfAny(compatibleInterfaces)
     }
 
-    private object NullServiceCustomResolverFactory : TypedParameterResolverFactory<NullServiceCustomResolverFactory.NullServiceCustomResolver>(NullServiceCustomResolver::class, Any::class) {
-        private object NullServiceCustomResolver : ClassParameterResolver<NullServiceCustomResolver, Any>(Any::class), ICustomResolver<NullServiceCustomResolver, Any> {
+    private data object NullServiceCustomResolverFactory : TypedParameterResolverFactory<NullServiceCustomResolverFactory.NullServiceCustomResolver>(NullServiceCustomResolver::class, Any::class) {
+        private data object NullServiceCustomResolver : ClassParameterResolver<NullServiceCustomResolver, Any>(Any::class), ICustomResolver<NullServiceCustomResolver, Any> {
             override suspend fun resolveSuspend(info: IExecutableInteractionInfo, event: Event): Any? = null
         }
 
         override fun get(request: ResolverRequest): NullServiceCustomResolver = NullServiceCustomResolver
     }
 
-    private class ServiceCustomResolver(private val o: Any) : ClassParameterResolver<ServiceCustomResolver, Any>(Any::class),
-        ICustomResolver<ServiceCustomResolver, Any> {
+    private class ServiceCustomResolver<T : Any>(
+        private val o: T
+    ) : ClassParameterResolver<ServiceCustomResolver<T>, T>(o::class),
+        ICustomResolver<ServiceCustomResolver<T>, T> {
+
         override suspend fun resolveSuspend(info: IExecutableInteractionInfo, event: Event) = o
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
@@ -130,8 +130,8 @@ class ResolverContainer internal constructor(
     }
 
     @JvmSynthetic
-    internal inline fun <reified T : IParameterResolver<T>> getResolverOfType(parameter: ParameterWrapper): T {
-        return getResolver(T::class, ResolverRequest(parameter))
+    internal inline fun <reified T : IParameterResolver<T>> getResolverOfType(request: ResolverRequest): T {
+        return getResolver(T::class, request)
     }
 
     //TODO refactor this and getResolverFactoryOrNull

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
@@ -140,10 +140,6 @@ class ResolverContainer internal constructor(
         return getResolver(T::class, request)
     }
 
-    //TODO refactor this and getResolverFactoryOrNull
-    // They need to run a common function to get the factory alongside the (possible) error message
-    // Factory would just do nothing with it, but it will be useful for getResolver
-    // and will deduplicate code
     @JvmSynthetic
     internal fun <T : IParameterResolver<T>> getResolver(resolverType: KClass<T>, request: ResolverRequest): T {
         val factory = getResolverFactoryOrNull(resolverType, request)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
@@ -10,13 +10,16 @@ import io.github.freya022.botcommands.api.core.utils.*
 import io.github.freya022.botcommands.api.parameters.resolvers.*
 import io.github.freya022.botcommands.internal.IExecutableInteractionInfo
 import io.github.freya022.botcommands.internal.core.service.tryGetWrappedService
+import io.github.freya022.botcommands.internal.parameters.resolvers.TimeoutParameterResolver
 import io.github.freya022.botcommands.internal.parameters.toResolverFactory
 import io.github.freya022.botcommands.internal.utils.ReflectionMetadata.isNullable
 import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.freya022.botcommands.internal.utils.throwUser
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.events.Event
-import java.util.*
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.reflect.KClass
 
 @BService
 class ResolverContainer internal constructor(
@@ -26,8 +29,9 @@ class ResolverContainer internal constructor(
 ) {
     private val logger = KotlinLogging.logger { }
 
-    private val factories: MutableList<ParameterResolverFactory<*>> = Collections.synchronizedList(arrayOfSize(50))
-    private val cache: MutableMap<ParameterWrapper, ParameterResolverFactory<*>> = Collections.synchronizedMap(hashMapOf())
+    private val lock = ReentrantLock()
+    private val factories: MutableList<ParameterResolverFactory<*>> = arrayOfSize(50)
+    private val cache: MutableMap<ResolverRequest, ParameterResolverFactory<*>?> = hashMapOf()
 
     init {
         resolvers.forEach(::addResolver)
@@ -45,14 +49,14 @@ class ResolverContainer internal constructor(
         }
     }
 
-    fun addResolverFactory(resolver: ParameterResolverFactory<*>) {
+    fun addResolverFactory(resolver: ParameterResolverFactory<*>) = lock.withLock {
         factories += resolver
         cache.clear()
     }
 
     @JvmSynthetic
     @BEventListener
-    internal fun onLoad(event: LoadEvent) {
+    internal fun onLoad(event: LoadEvent) = lock.withLock {
         if (factories.isEmpty()) {
             throwInternal("No resolvers/factories were found") //Never happens
         } else {
@@ -73,42 +77,83 @@ class ResolverContainer internal constructor(
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
     @JvmSynthetic
-    internal fun getResolverFactoryOrNull(parameter: ParameterWrapper): ParameterResolverFactory<*>? {
-        val resolvableFactories = factories.filter { it.isResolvable(parameter) }
+    internal fun <T : IParameterResolver<T>> getResolverFactoryOrNull(resolverType: KClass<out T>, request: ResolverRequest): ParameterResolverFactory<T>? = lock.withLock {
+        cache[request]?.let { return@withLock it as ParameterResolverFactory<T>? }
+
+        val resolvableFactories = factories
+            .filter { it.resolverType.isSubclassOf(resolverType) }
+            .map { it as ParameterResolverFactory<T> }
+            .filter { it.isResolvable(request) }
         require(resolvableFactories.size <= 1) {
             val factoryNameList = resolvableFactories.joinAsList { it.resolverType.simpleNestedName }
-            "Found multiple compatible resolvers for parameter of type ${parameter.type.simpleNestedName}\n$factoryNameList"
+            "Found multiple compatible resolvers for the provided request\n$factoryNameList"
         }
 
-        return resolvableFactories.firstOrNull()
+        val factory = getFactoryOrServiceFactory(resolverType, resolvableFactories, request) as ParameterResolverFactory<T>?
+        cache[request] = factory
+        factory
     }
 
-    @JvmSynthetic
-    internal inline fun <reified T : Any> hasResolverOfType(parameter: ParameterWrapper): Boolean {
-        val resolverFactory = getResolverFactoryOrNull(parameter) ?: return false
-        return resolverFactory.resolverType.isSubclassOf<T>()
-    }
-
-    @JvmSynthetic
-    internal fun getResolver(parameter: ParameterWrapper): ParameterResolver<*, *> {
-        return cache.computeIfAbsent(parameter) { wrapper ->
-            getResolverFactoryOrNull(wrapper) ?: run {
-                val serviceResult = serviceContainer.tryGetWrappedService(wrapper.parameter)
-
-                serviceResult.serviceError?.let { serviceError ->
-                    //If a service isn't required then that's fine
-                    if (wrapper.parameter.isNullable || wrapper.parameter.isOptional) {
-                        logger.trace { "Parameter #${wrapper.index} of type '${wrapper.type.simpleNestedName}' and name '${wrapper.name}' does not have any compatible resolver and service loading failed:\n${serviceError.toSimpleString()}" }
-                        return@run NullServiceCustomResolverFactory
-                    }
-
-                    wrapper.throwUser("Parameter #${wrapper.index} of type '${wrapper.type.simpleNestedName}' and name '${wrapper.name}' does not have any compatible resolver and service loading failed:\n${serviceError.toSimpleString()}")
-                }
-
-                ServiceCustomResolver(serviceResult.getOrThrow()).toResolverFactory()
+    private fun <T : IParameterResolver<T>> getFactoryOrServiceFactory(
+        resolverType: KClass<out IParameterResolver<*>>,
+        resolvableFactories: List<ParameterResolverFactory<T>>,
+        request: ResolverRequest
+    ): ParameterResolverFactory<*>? {
+        if (resolvableFactories.isNotEmpty()) {
+            return resolvableFactories.first()
+        } else if (resolverType.isSubclassOf(ICustomResolver::class)) {
+            val wrapper = request.parameter
+            val serviceResult = serviceContainer.tryGetWrappedService(wrapper.parameter)
+            val serviceError = serviceResult.serviceError
+            if (serviceError == null) {
+                return serviceResult.getOrThrow().let(::ServiceCustomResolver).toResolverFactory()
+            } else if (wrapper.parameter.isNullable || wrapper.parameter.isOptional) {
+                // If the parameter is nullable/optional, give a resolver that returns null
+                logger.trace { "No ${resolverType.simpleNestedName} found for parameter '${wrapper.name}: ${wrapper.type.simpleNestedName}' and service loading failed:\n${serviceError.toDetailedString()}" }
+                return NullServiceCustomResolverFactory
             }
-        }.get(parameter)
+        }
+
+        return null
+    }
+
+    @JvmSynthetic
+    internal inline fun <reified T : IParameterResolver<T>> hasResolverOfType(parameter: ParameterWrapper): Boolean {
+        return hasResolverOfType<T>(ResolverRequest(parameter))
+    }
+
+    @JvmSynthetic
+    internal inline fun <reified T : IParameterResolver<T>> hasResolverOfType(request: ResolverRequest): Boolean {
+        return getResolverFactoryOrNull(T::class, request) != null
+    }
+
+    @JvmSynthetic
+    internal inline fun <reified T : IParameterResolver<T>> getResolverOfType(parameter: ParameterWrapper): T {
+        return getResolver(T::class, ResolverRequest(parameter))
+    }
+
+    //TODO refactor this and getResolverFactoryOrNull
+    // They need to run a common function to get the factory alongside the (possible) error message
+    // Factory would just do nothing with it, but it will be useful for getResolver
+    // and will deduplicate code
+    @JvmSynthetic
+    internal fun <T : IParameterResolver<T>> getResolver(resolverType: KClass<T>, request: ResolverRequest): T {
+        val factory = getResolverFactoryOrNull(resolverType, request)
+        if (factory == null) {
+            val wrapper = request.parameter
+            // Custom resolvers are often used for services
+            // if not one, make a simple error
+            if (!resolverType.isSubclassOf(ICustomResolver::class))
+                wrapper.throwUser("No ${resolverType.simpleNestedName} found for parameter '${wrapper.name}: ${wrapper.type.simpleNestedName}'.")
+
+            // If a service factory, add the error
+            val serviceError = serviceContainer.tryGetWrappedService(wrapper.parameter).serviceError ?: throwInternal("Service became available after failing")
+            wrapper.throwUser("No ${resolverType.simpleNestedName} found for parameter '${wrapper.name}: ${wrapper.type.simpleNestedName}' and service loading failed:\n${serviceError.toDetailedString()}")
+        }
+
+        return factory.get(request)
     }
 
     private fun hasCompatibleInterface(resolver: ParameterResolver<*, *>): Boolean {
@@ -120,7 +165,7 @@ class ResolverContainer internal constructor(
             override suspend fun resolveSuspend(info: IExecutableInteractionInfo, event: Event): Any? = null
         }
 
-        override fun get(parameter: ParameterWrapper): NullServiceCustomResolver = NullServiceCustomResolver
+        override fun get(request: ResolverRequest): NullServiceCustomResolver = NullServiceCustomResolver
     }
 
     private class ServiceCustomResolver(private val o: Any) : ClassParameterResolver<ServiceCustomResolver, Any>(Any::class),
@@ -137,6 +182,7 @@ class ResolverContainer internal constructor(
             UserContextParameterResolver::class,
             MessageContextParameterResolver::class,
             ModalParameterResolver::class,
+            TimeoutParameterResolver::class,
             ICustomResolver::class
         )
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverData.kt
@@ -1,0 +1,6 @@
+package io.github.freya022.botcommands.api.parameters
+
+/**
+ * Marker interface for data passed when requesting for a parameter resolver.
+ */
+interface ResolverData

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverRequest.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverRequest.kt
@@ -1,0 +1,32 @@
+package io.github.freya022.botcommands.api.parameters
+
+import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
+
+/**
+ * Data used when retrieving a [resolver factory][ParameterResolverFactory].
+ *
+ * @param parameter    The parameter this resolver factory will be bound to
+ * @param resolverData Contextual data which might be used to do further filtering in [ParameterResolverFactory.isResolvable]
+ */
+class ResolverRequest(
+    val parameter: ParameterWrapper,
+    val resolverData: ResolverData? = null
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ResolverRequest
+
+        if (parameter != other.parameter) return false
+        if (resolverData != other.resolverData) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = parameter.hashCode()
+        result = 31 * result + (resolverData?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/Resolvers.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/Resolvers.kt
@@ -3,7 +3,6 @@ package io.github.freya022.botcommands.api.parameters
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.core.config.BApplicationConfigBuilder
-import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.core.utils.enumSetOf
@@ -298,8 +297,8 @@ fun Enum<*>.toHumanName(locale: Locale = Locale.ROOT): String = toHumanName(this
  * @see ParameterResolverFactory
  * @see ParameterResolver
  */
-inline fun <reified T : ParameterResolver<T, R>, reified R : Any> resolverFactory(crossinline producer: (parameter: ParameterWrapper) -> T): ParameterResolverFactory<T> {
+inline fun <reified T : ParameterResolver<T, R>, reified R : Any> resolverFactory(crossinline producer: (request: ResolverRequest) -> T): ParameterResolverFactory<T> {
     return object : TypedParameterResolverFactory<T>(T::class, R::class) {
-        override fun get(parameter: ParameterWrapper): T = producer(parameter)
+        override fun get(request: ResolverRequest): T = producer(request)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/TypedParameterResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/TypedParameterResolverFactory.kt
@@ -3,6 +3,7 @@ package io.github.freya022.botcommands.api.parameters
 import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
+import io.github.freya022.botcommands.api.parameters.resolvers.IParameterResolver
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.starProjectedType
@@ -22,7 +23,7 @@ import kotlin.reflect.full.withNullability
  * @param type         Type of the objects returned by the parameter resolver
  * @param T            Type of the returned parameter resolver
  */
-abstract class TypedParameterResolverFactory<T : ParameterResolver<T, *>>(
+abstract class TypedParameterResolverFactory<T : IParameterResolver<T>>(
     resolverType: KClass<out T>,
     val type: KType
 ) : ParameterResolverFactory<T>(resolverType) {

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/TypedParameterResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/TypedParameterResolverFactory.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.parameters
 
-import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.parameters.resolvers.IParameterResolver
@@ -38,7 +37,8 @@ abstract class TypedParameterResolverFactory<T : IParameterResolver<T>>(
         }
     }
 
-    override fun isResolvable(parameter: ParameterWrapper): Boolean {
-        return this.type == parameter.type || this.type == parameter.type.withNullability(false)
+    override fun isResolvable(request: ResolverRequest): Boolean {
+        val requestedType = request.parameter.type
+        return this.type == requestedType || this.type == requestedType.withNullability(false)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
@@ -18,8 +18,9 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
-interface ComponentParameterResolver<T, R : Any> where T : ParameterResolver<T, R>,
-                                                       T : ComponentParameterResolver<T, R> {
+interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
+        where T : ParameterResolver<T, R>,
+              T : ComponentParameterResolver<T, R> {
     /**
      * Returns a resolved object from this component interaction.
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ICustomResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ICustomResolver.kt
@@ -14,8 +14,9 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
-interface ICustomResolver<T, R : Any> where T : ParameterResolver<T, R>,
-                                            T : ICustomResolver<T, R> {
+interface ICustomResolver<T, R : Any> : IParameterResolver<T>
+        where T : ParameterResolver<T, R>,
+              T : ICustomResolver<T, R> {
 
     /**
      * Returns an object.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/IParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/IParameterResolver.kt
@@ -1,0 +1,3 @@
+package io.github.freya022.botcommands.api.parameters.resolvers
+
+interface IParameterResolver<out T : IParameterResolver<T>>

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/MessageContextParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/MessageContextParameterResolver.kt
@@ -15,8 +15,9 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
-interface MessageContextParameterResolver<T, R : Any> where T : ParameterResolver<T, R>,
-                                                            T : MessageContextParameterResolver<T, R> {
+interface MessageContextParameterResolver<T, R : Any> : IParameterResolver<T>
+        where T : ParameterResolver<T, R>,
+              T : MessageContextParameterResolver<T, R> {
     /**
      * Returns a resolved object from this message context interaction.
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ModalParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ModalParameterResolver.kt
@@ -16,8 +16,9 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
-interface ModalParameterResolver<T, R : Any> where T : ParameterResolver<T, R>,
-                                                   T : ModalParameterResolver<T, R> {
+interface ModalParameterResolver<T, R : Any> : IParameterResolver<T>
+        where T : ParameterResolver<T, R>,
+              T : ModalParameterResolver<T, R> {
     /**
      * Returns a resolved object for this [ModalMapping].
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/SlashParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/SlashParameterResolver.kt
@@ -26,8 +26,9 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
-interface SlashParameterResolver<T, R : Any> where T : ParameterResolver<T, R>,
-                                                   T : SlashParameterResolver<T, R> {
+interface SlashParameterResolver<T, R : Any> : IParameterResolver<T>
+        where T : ParameterResolver<T, R>,
+              T : SlashParameterResolver<T, R> {
     /**
      * Returns the corresponding [OptionType] for this slash command parameter.
      */

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TextParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TextParameterResolver.kt
@@ -18,8 +18,9 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
-interface TextParameterResolver<T, R : Any> where T : ParameterResolver<T, R>,
-                                                  T : TextParameterResolver<T, R> {
+interface TextParameterResolver<T, R : Any> : IParameterResolver<T>
+        where T : ParameterResolver<T, R>,
+              T : TextParameterResolver<T, R> {
     /**
      * Returns a resolved object from this text command.
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/UserContextParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/UserContextParameterResolver.kt
@@ -15,8 +15,9 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
-interface UserContextParameterResolver<T, R : Any> where T : ParameterResolver<T, R>,
-                                                         T : UserContextParameterResolver<T, R> {
+interface UserContextParameterResolver<T, R : Any> : IParameterResolver<T>
+        where T : ParameterResolver<T, R>,
+              T : UserContextParameterResolver<T, R> {
     /**
      * Returns a resolved object from this user context interaction.
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/CommandOptions.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/CommandOptions.kt
@@ -8,7 +8,6 @@ import io.github.freya022.botcommands.api.core.options.builder.OptionBuilder
 import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.reflect.wrap
 import io.github.freya022.botcommands.api.core.service.getService
-import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.parameters.ResolverContainer
 import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.IParameterResolver
@@ -17,10 +16,8 @@ import io.github.freya022.botcommands.internal.core.options.builder.InternalAggr
 import io.github.freya022.botcommands.internal.core.options.builder.InternalAggregators.isVarargAggregator
 import io.github.freya022.botcommands.internal.parameters.CustomMethodOption
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.nonEventParameters
-import io.github.freya022.botcommands.internal.utils.classRef
 import io.github.freya022.botcommands.internal.utils.requireUser
 import io.github.freya022.botcommands.internal.utils.throwInternal
-import io.github.freya022.botcommands.internal.utils.throwUser
 
 internal object CommandOptions {
     internal inline fun <reified T : OptionBuilder, reified R : IParameterResolver<R>> transform(
@@ -43,27 +40,15 @@ internal object CommandOptions {
                 is T -> {
                     val parameter = optionBuilder.innerWrappedParameter
 
-                    // TODO replace with getResolverOrNull<R>(parameter) ?: throwUser
-                    when (val resolver = resolverContainer.getResolverOfType<R>(parameter)) {
-                        is R -> config.transformOption(optionBuilder, resolver)
-                        else -> throwUser(
-                            optionBuilder.owner,
-                            "Expected a resolver of type ${R::class.simpleNestedName} but ${resolver.javaClass.simpleNestedName} does not support it"
-                        )
-                    }
+                    val resolver = resolverContainer.getResolverOfType<R>(parameter)
+                    config.transformOption(optionBuilder, resolver)
                 }
                 is GeneratedOptionBuilder -> optionBuilder.toGeneratedOption()
                 is CustomOptionBuilder -> {
                     val parameter = optionBuilder.innerWrappedParameter
 
-                    // TODO replace with getResolverOrNull<R>(parameter) ?: throwUser
-                    when (val resolver = resolverContainer.getResolverOfType<ICustomResolver<*, *>>(parameter)) {
-                        is ICustomResolver<*, *> -> CustomMethodOption(optionBuilder.optionParameter, resolver)
-                        else -> throwUser(
-                            optionBuilder.owner,
-                            "Expected a resolver of type ${classRef<ICustomResolver<*, *>>()} but ${resolver.javaClass.simpleNestedName} does not support it"
-                        )
-                    }
+                    val resolver = resolverContainer.getResolverOfType<ICustomResolver<*, *>>(parameter)
+                    CustomMethodOption(optionBuilder.optionParameter, resolver)
                 }
                 else -> throwInternal("Unsupported option builder: $optionBuilder")
             }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/CommandOptions.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/CommandOptions.kt
@@ -43,7 +43,8 @@ internal object CommandOptions {
                 is T -> {
                     val parameter = optionBuilder.innerWrappedParameter
 
-                    when (val resolver = resolverContainer.getResolver(parameter)) {
+                    // TODO replace with getResolverOrNull<R>(parameter) ?: throwUser
+                    when (val resolver = resolverContainer.getResolverOfType<R>(parameter)) {
                         is R -> config.transformOption(optionBuilder, resolver)
                         else -> throwUser(
                             optionBuilder.owner,
@@ -55,7 +56,8 @@ internal object CommandOptions {
                 is CustomOptionBuilder -> {
                     val parameter = optionBuilder.innerWrappedParameter
 
-                    when (val resolver = resolverContainer.getResolver(parameter)) {
+                    // TODO replace with getResolverOrNull<R>(parameter) ?: throwUser
+                    when (val resolver = resolverContainer.getResolverOfType<ICustomResolver<*, *>>(parameter)) {
                         is ICustomResolver<*, *> -> CustomMethodOption(optionBuilder.optionParameter, resolver)
                         else -> throwUser(
                             optionBuilder.owner,

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/CommandOptions.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/CommandOptions.kt
@@ -11,6 +11,7 @@ import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.parameters.ResolverContainer
 import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.IParameterResolver
 import io.github.freya022.botcommands.internal.core.options.Option
 import io.github.freya022.botcommands.internal.core.options.builder.InternalAggregators.isSpecialAggregator
 import io.github.freya022.botcommands.internal.core.options.builder.InternalAggregators.isVarargAggregator
@@ -22,7 +23,7 @@ import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.freya022.botcommands.internal.utils.throwUser
 
 internal object CommandOptions {
-    internal inline fun <reified T : OptionBuilder, reified R : Any> transform(
+    internal inline fun <reified T : OptionBuilder, reified R : IParameterResolver<R>> transform(
         context: BContext,
         aggregateBuilder: OptionAggregateBuilder<*>,
         config: Configuration<T, R>

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/CommandOptions.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/CommandOptions.kt
@@ -9,6 +9,8 @@ import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.reflect.wrap
 import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.parameters.ResolverContainer
+import io.github.freya022.botcommands.api.parameters.ResolverData
+import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.IParameterResolver
 import io.github.freya022.botcommands.internal.core.options.Option
@@ -22,6 +24,7 @@ import io.github.freya022.botcommands.internal.utils.throwInternal
 internal object CommandOptions {
     internal inline fun <reified T : OptionBuilder, reified R : IParameterResolver<R>> transform(
         context: BContext,
+        resolverData: ResolverData?,
         aggregateBuilder: OptionAggregateBuilder<*>,
         config: Configuration<T, R>
     ): List<Option> {
@@ -40,14 +43,14 @@ internal object CommandOptions {
                 is T -> {
                     val parameter = optionBuilder.innerWrappedParameter
 
-                    val resolver = resolverContainer.getResolverOfType<R>(parameter)
+                    val resolver = resolverContainer.getResolverOfType<R>(ResolverRequest(parameter, resolverData))
                     config.transformOption(optionBuilder, resolver)
                 }
                 is GeneratedOptionBuilder -> optionBuilder.toGeneratedOption()
                 is CustomOptionBuilder -> {
                     val parameter = optionBuilder.innerWrappedParameter
 
-                    val resolver = resolverContainer.getResolverOfType<ICustomResolver<*, *>>(parameter)
+                    val resolver = resolverContainer.getResolverOfType<ICustomResolver<*, *>>(ResolverRequest(parameter, resolverData))
                     CustomMethodOption(optionBuilder.optionParameter, resolver)
                 }
                 else -> throwInternal("Unsupported option builder: $optionBuilder")

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandInfo.kt
@@ -10,7 +10,9 @@ import io.github.freya022.botcommands.internal.commands.application.mixins.ITopL
 import io.github.freya022.botcommands.internal.utils.reference
 
 abstract class ApplicationCommandInfo internal constructor(
-    builder: ApplicationCommandBuilder<*>
+    // Unfortunately needs to be kept due to ApplicationCommandResolverDataKt.checkGuildOnly;
+    // without it, we would try to access being-initialized objects and cause NPEs
+    internal val builder: ApplicationCommandBuilder<*>
 ) : AbstractCommandInfo(builder), IExecutableInteractionInfo {
     abstract val topLevelInstance: ITopLevelApplicationCommandInfo
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandResolverData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandResolverData.kt
@@ -1,0 +1,7 @@
+package io.github.freya022.botcommands.internal.commands.application
+
+import io.github.freya022.botcommands.api.parameters.ResolverData
+
+internal class ApplicationCommandResolverData(
+    val commandInfo: ApplicationCommandInfo
+) : ResolverData

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandResolverData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandResolverData.kt
@@ -1,7 +1,20 @@
 package io.github.freya022.botcommands.internal.commands.application
 
+import io.github.freya022.botcommands.api.core.reflect.throwUser
+import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.parameters.ResolverData
+import io.github.freya022.botcommands.api.parameters.ResolverRequest
+import kotlin.reflect.KClass
 
 internal class ApplicationCommandResolverData(
     val commandInfo: ApplicationCommandInfo
 ) : ResolverData
+
+internal fun ResolverRequest.checkGuildOnly(returnType: KClass<*>) {
+    (resolverData as? ApplicationCommandResolverData)?.let { data ->
+        //TODO[User apps] throw if there is no guild scope at all, regardless of nullability
+        if (!data.commandInfo.builder.topLevelBuilder.scope.isGuildOnly && parameter.isRequired) {
+            parameter.throwUser("Cannot get a required ${returnType.simpleNestedName} in a global command")
+        }
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfo.kt
@@ -37,7 +37,7 @@ class MessageCommandInfo internal constructor(
         eventFunction.checkEventScope<GuildMessageEvent>(builder)
 
         parameters = builder.optionAggregateBuilders.transform {
-            MessageContextCommandParameter(context, this@MessageCommandInfo, it)
+            MessageContextCommandParameter(context, this, it)
         }
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfo.kt
@@ -37,7 +37,7 @@ class MessageCommandInfo internal constructor(
         eventFunction.checkEventScope<GuildMessageEvent>(builder)
 
         parameters = builder.optionAggregateBuilders.transform {
-            MessageContextCommandParameter(context, it)
+            MessageContextCommandParameter(context, this@MessageCommandInfo, it)
         }
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageContextCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageContextCommandParameter.kt
@@ -5,19 +5,22 @@ import io.github.freya022.botcommands.api.commands.application.context.builder.M
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.parameters.resolvers.MessageContextParameterResolver
 import io.github.freya022.botcommands.internal.CommandOptions
+import io.github.freya022.botcommands.internal.commands.application.ApplicationCommandResolverData
 import io.github.freya022.botcommands.internal.commands.application.context.ContextCommandParameter
 import io.github.freya022.botcommands.internal.transform
 
 class MessageContextCommandParameter(
     context: BContext,
+    messageCommandInfo: MessageCommandInfo,
     optionAggregateBuilder: MessageCommandOptionAggregateBuilder
 ) : ContextCommandParameter(context, optionAggregateBuilder) {
     override val nestedAggregatedParameters = optionAggregateBuilder.nestedAggregates.transform {
-        MessageContextCommandParameter(context, it)
+        MessageContextCommandParameter(context, messageCommandInfo, it)
     }
 
     override val options = CommandOptions.transform(
         context,
+        ApplicationCommandResolverData(messageCommandInfo),
         optionAggregateBuilder,
         object : CommandOptions.Configuration<MessageCommandOptionBuilder, MessageContextParameterResolver<*, *>> {
             override fun transformOption(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfo.kt
@@ -37,7 +37,7 @@ class UserCommandInfo internal constructor(
         eventFunction.checkEventScope<GuildUserEvent>(builder)
 
         parameters = builder.optionAggregateBuilders.transform {
-            UserContextCommandParameter(context, it)
+            UserContextCommandParameter(context, this, it)
         }
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserContextCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserContextCommandParameter.kt
@@ -5,19 +5,22 @@ import io.github.freya022.botcommands.api.commands.application.context.builder.U
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.parameters.resolvers.UserContextParameterResolver
 import io.github.freya022.botcommands.internal.CommandOptions
+import io.github.freya022.botcommands.internal.commands.application.ApplicationCommandResolverData
 import io.github.freya022.botcommands.internal.commands.application.context.ContextCommandParameter
 import io.github.freya022.botcommands.internal.transform
 
 class UserContextCommandParameter(
     context: BContext,
+    userCommandInfo: UserCommandInfo,
     optionAggregateBuilder: UserCommandOptionAggregateBuilder
 ) : ContextCommandParameter(context, optionAggregateBuilder) {
     override val nestedAggregatedParameters = optionAggregateBuilder.nestedAggregates.transform {
-        UserContextCommandParameter(context, it)
+        UserContextCommandParameter(context, userCommandInfo, it)
     }
 
     override val options = CommandOptions.transform(
         context,
+        ApplicationCommandResolverData(userCommandInfo),
         optionAggregateBuilder,
         object : CommandOptions.Configuration<UserCommandOptionBuilder, UserContextParameterResolver<*, *>> {
             override fun transformOption(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/AbstractSlashCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/AbstractSlashCommandParameter.kt
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.builder.Sla
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.internal.CommandOptions
 import io.github.freya022.botcommands.internal.commands.application.ApplicationCommandParameter
+import io.github.freya022.botcommands.internal.commands.application.ApplicationCommandResolverData
 
 abstract class AbstractSlashCommandParameter(
     slashCommandInfo: SlashCommandInfo,
@@ -13,6 +14,7 @@ abstract class AbstractSlashCommandParameter(
 ) : ApplicationCommandParameter(slashCommandInfo.context, optionAggregateBuilder) {
     final override val options = CommandOptions.transform(
         slashCommandInfo.context,
+        ApplicationCommandResolverData(slashCommandInfo),
         optionAggregateBuilder,
         object : CommandOptions.Configuration<SlashCommandOptionBuilder, SlashParameterResolver<*, *>> {
             override fun transformOption(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/autobuilder/AutoBuilderUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/autobuilder/AutoBuilderUtils.kt
@@ -14,7 +14,6 @@ import io.github.freya022.botcommands.api.commands.builder.CommandBuilder
 import io.github.freya022.botcommands.api.commands.builder.DeclarationSite
 import io.github.freya022.botcommands.api.commands.text.annotations.NSFW
 import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.core.config.BApplicationConfig
 import io.github.freya022.botcommands.api.core.reflect.wrap
 import io.github.freya022.botcommands.api.core.utils.joinAsList
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
@@ -187,8 +186,8 @@ internal fun ApplicationCommandBuilder<*>.fillApplicationCommandBuilder(func: KF
 
 internal fun ResolverContainer.requireCustomOption(func: KFunction<*>, kParameter: KParameter, optionAnnotation: KClass<out Annotation>) {
     val parameterWrapper = kParameter.wrap()
-    if (getResolver(parameterWrapper) !is ICustomResolver<*, *>) {
-        throwUser(func, "Custom option '${parameterWrapper.name}' (${parameterWrapper.type.simpleNestedName}) does not have a compatible ICustomResolver, " +
-                "if this is a Discord option, use @${optionAnnotation.simpleNestedName}")
+    requireUser(hasResolverOfType<ICustomResolver<*, *>>(parameterWrapper), func) {
+        "Custom option '${parameterWrapper.name}' (${parameterWrapper.type.simpleNestedName}) does not have a compatible ICustomResolver, " +
+                "if this is a Discord option, use @${optionAnnotation.simpleNestedName}"
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandParameter.kt
@@ -19,6 +19,7 @@ class TextCommandParameter(
 
     override val options = CommandOptions.transform(
         context,
+        null,
         optionAggregateBuilder,
         object : CommandOptions.Configuration<TextCommandOptionBuilder, TextParameterResolver<*, *>> {
             override fun transformOption(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerParameter.kt
@@ -21,6 +21,7 @@ class ComponentHandlerParameter internal constructor(
 
     override val options = CommandOptions.transform(
         context,
+        null,
         aggregateBuilder,
         object : CommandOptions.Configuration<ComponentHandlerOptionBuilder, ComponentParameterResolver<*, *>> {
             override fun transformOption(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutHandlerParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutHandlerParameter.kt
@@ -23,6 +23,7 @@ internal class TimeoutHandlerParameter internal constructor(
 
     override val options = CommandOptions.transform(
         context,
+        null,
         aggregateBuilder,
         object : CommandOptions.Configuration<TimeoutHandlerOptionBuilder, TimeoutParameterResolver<*, *>> {
             override fun transformOption(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerParameter.kt
@@ -21,6 +21,7 @@ class ModalHandlerParameter internal constructor(
 
     override val options = CommandOptions.transform(
         context,
+        null,
         aggregateBuilder,
         object : CommandOptions.Configuration<ModalHandlerInputOptionBuilder, ModalParameterResolver<*, *>> {
             override fun transformOption(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ParameterResolverAdapters.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ParameterResolverAdapters.kt
@@ -1,9 +1,9 @@
 package io.github.freya022.botcommands.internal.parameters
 
-import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.ParameterResolverFactory
+import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.TypedParameterResolver
 
 private class ClassParameterResolverFactoryAdapter<T : ClassParameterResolver<out T, *>>(
@@ -11,8 +11,8 @@ private class ClassParameterResolverFactoryAdapter<T : ClassParameterResolver<ou
 ): ParameterResolverFactory<T>(resolver::class) {
     override val supportedTypesStr: List<String> = listOf(resolver.jvmErasure.simpleNestedName)
 
-    override fun isResolvable(parameter: ParameterWrapper): Boolean = resolver.jvmErasure == parameter.erasure
-    override fun get(parameter: ParameterWrapper): T = resolver
+    override fun isResolvable(request: ResolverRequest): Boolean = resolver.jvmErasure == request.parameter.erasure
+    override fun get(request: ResolverRequest): T = resolver
     override fun toString(): String = "ClassParameterResolverFactoryAdapter(resolver=$resolver)"
 }
 
@@ -25,8 +25,8 @@ private class TypedParameterResolverFactoryAdapter<T : TypedParameterResolver<ou
 ): ParameterResolverFactory<T>(resolver::class) {
     override val supportedTypesStr: List<String> = listOf(resolver.type.simpleNestedName)
 
-    override fun isResolvable(parameter: ParameterWrapper): Boolean = resolver.type == parameter.type
-    override fun get(parameter: ParameterWrapper): T = resolver
+    override fun isResolvable(request: ResolverRequest): Boolean = resolver.type == request.parameter.type
+    override fun get(request: ResolverRequest): T = resolver
     override fun toString(): String = "TypedParameterResolverFactoryAdapter(resolver=$resolver)"
 }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -15,6 +15,7 @@ import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver
+import io.github.freya022.botcommands.internal.commands.application.checkGuildOnly
 import io.github.freya022.botcommands.internal.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.internal.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.internal.components.handler.ComponentDescriptor
@@ -169,6 +170,8 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
         val erasure = parameter.erasure
         if (!erasure.isSubclassOf<GuildChannel>()) return false
         erasure as KClass<out GuildChannel>
+
+        request.checkGuildOnly(erasure)
 
         val channelTypes = when (val annotation = parameter.findAnnotation<ChannelTypes>()) {
             null -> channelTypesFrom(erasure.java)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -5,13 +5,13 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.exceptions.InvalidChannelTypeException
-import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.reflect.findAnnotation
 import io.github.freya022.botcommands.api.core.reflect.function
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.core.utils.*
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.ParameterResolverFactory
+import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver
@@ -164,7 +164,8 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
     override val supportedTypesStr: List<String> = listOf("<out GuildChannel>")
 
     @Suppress("UNCHECKED_CAST")
-    override fun isResolvable(parameter: ParameterWrapper): Boolean {
+    override fun isResolvable(request: ResolverRequest): Boolean {
+        val parameter = request.parameter
         val erasure = parameter.erasure
         if (!erasure.isSubclassOf<GuildChannel>()) return false
         erasure as KClass<out GuildChannel>
@@ -201,7 +202,8 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun get(parameter: ParameterWrapper): ChannelResolver {
+    override fun get(request: ResolverRequest): ChannelResolver {
+        val parameter = request.parameter
         val erasure = parameter.erasure as KClass<out GuildChannel>
         val channelTypes = when (val annotation = parameter.findAnnotation<ChannelTypes>()) {
             null -> channelTypesFrom(erasure.java)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/MemberResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/MemberResolver.kt
@@ -1,13 +1,24 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers
 
 import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.core.service.annotations.Resolver
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
+import io.github.freya022.botcommands.api.parameters.resolverFactory
+import io.github.freya022.botcommands.internal.commands.application.checkGuildOnly
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.User
 
-@Resolver
 internal class MemberResolver internal constructor(
     context: BContext
 ) : AbstractUserSnowflakeResolver<MemberResolver, Member>(context, Member::class) {
     override fun transformEntities(user: User, member: Member?): Member? = member
+}
+
+@BService
+internal data object MemberResolverFactoryProvider {
+    @ResolverFactory
+    internal fun memberResolverFactory(context: BContext) = resolverFactory { request ->
+        request.checkGuildOnly(Member::class)
+        MemberResolver(context)
+    }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/MentionsStringResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/MentionsStringResolverFactory.kt
@@ -2,7 +2,7 @@ package io.github.freya022.botcommands.internal.parameters.resolvers
 
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.MentionsString
 import io.github.freya022.botcommands.api.core.entities.InputUser
-import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
+import io.github.freya022.botcommands.api.core.reflect.findAnnotation
 import io.github.freya022.botcommands.api.core.reflect.requireUser
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.core.utils.isAssignableFrom
@@ -10,6 +10,7 @@ import io.github.freya022.botcommands.api.core.utils.isSubclassOf
 import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.parameters.ParameterResolverFactory
+import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.TypedParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.slash.SlashCommandInfo
@@ -27,7 +28,6 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.SlashCommandReference
 import kotlin.reflect.KClass
-import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.safeCast
 import kotlin.reflect.typeOf
@@ -65,8 +65,9 @@ internal object MentionsStringResolverFactory : ParameterResolverFactory<Mention
 
     override val supportedTypesStr: List<String> = listOf(IMentionable::class.shortQualifiedName)
 
-    override fun isResolvable(parameter: ParameterWrapper): Boolean {
-        val annotation = parameter.parameter.findAnnotation<MentionsString>() ?: return false
+    override fun isResolvable(request: ResolverRequest): Boolean {
+        val parameter = request.parameter
+        val annotation = parameter.findAnnotation<MentionsString>() ?: return false
         // Must be a List
         parameter.requireUser(parameter.erasure.isSubclassOf<List<*>>()) {
             "Parameter '${parameter.name}' annotated with ${annotationRef<MentionsString>()} must be a ${classRef<List<*>>()} subtype"
@@ -90,8 +91,9 @@ internal object MentionsStringResolverFactory : ParameterResolverFactory<Mention
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun get(parameter: ParameterWrapper): MentionsStringResolver {
-        val annotation = parameter.parameter.findAnnotation<MentionsString>()
+    override fun get(request: ResolverRequest): MentionsStringResolver {
+        val parameter = request.parameter
+        val annotation = parameter.findAnnotation<MentionsString>()
             ?: throwInternal("Missing ${annotationRef<MentionsString>()}")
 
         val elementErasure = parameter.type.findErasureOfAt<List<*>>(0).jvmErasure as KClass<out IMentionable>

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/MentionsStringResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/MentionsStringResolverFactory.kt
@@ -13,6 +13,7 @@ import io.github.freya022.botcommands.api.parameters.ParameterResolverFactory
 import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.TypedParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
+import io.github.freya022.botcommands.internal.commands.application.checkGuildOnly
 import io.github.freya022.botcommands.internal.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.internal.core.entities.InputUserImpl
 import io.github.freya022.botcommands.internal.utils.*
@@ -108,6 +109,7 @@ internal object MentionsStringResolverFactory : ParameterResolverFactory<Mention
                 }
             }
         } else if (elementErasure == Member::class) {
+            request.checkGuildOnly(Member::class)
             MentionsStringResolver.ofEntity(elementErasure, MentionType.USER)
         } else if (elementErasure == InputUser::class) {
             MentionsStringResolver.ofEntity(MentionType.USER) {
@@ -118,8 +120,10 @@ internal object MentionsStringResolverFactory : ParameterResolverFactory<Mention
                 }
             }
         } else if (elementErasure.isSubclassOf<GuildChannel>()) {
+            request.checkGuildOnly(elementErasure)
             MentionsStringResolver.ofEntity(elementErasure, MentionType.CHANNEL)
         } else if (elementErasure == Role::class) {
+            request.checkGuildOnly(Role::class)
             MentionsStringResolver.ofEntity(elementErasure, MentionType.ROLE)
         } else if (elementErasure == CustomEmoji::class) {
             MentionsStringResolver.ofEntity(elementErasure, MentionType.EMOJI)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.kt
@@ -1,0 +1,16 @@
+package io.github.freya022.botcommands.internal.parameters.resolvers
+
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
+import io.github.freya022.botcommands.api.parameters.resolverFactory
+import io.github.freya022.botcommands.internal.commands.application.checkGuildOnly
+import net.dv8tion.jda.api.entities.Role
+
+@BService
+internal data object RoleResolverFactoryProvider {
+    @ResolverFactory
+    internal fun roleResolverFactory() = resolverFactory { request ->
+        request.checkGuildOnly(Role::class)
+        RoleResolver()
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/TimeoutParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/TimeoutParameterResolver.kt
@@ -1,9 +1,11 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers
 
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.IParameterResolver
 import io.github.freya022.botcommands.internal.components.timeout.TimeoutDescriptor
 
-internal interface TimeoutParameterResolver<T, R : Any> where T : ParameterResolver<T, R>,
-                                                              T : TimeoutParameterResolver<T, R> {
+internal interface TimeoutParameterResolver<T, R : Any> : IParameterResolver<T>
+        where T : ParameterResolver<T, R>,
+              T : TimeoutParameterResolver<T, R> {
     fun resolve(descriptor: TimeoutDescriptor<*>, arg: String): R
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/localization/LocalizationContextResolverFactories.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/localization/LocalizationContextResolverFactories.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers.localization
 
-import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.core.utils.isSubclassOfAny
 import io.github.freya022.botcommands.api.core.utils.nullIfBlank
@@ -8,6 +7,7 @@ import io.github.freya022.botcommands.api.localization.LocalizationService
 import io.github.freya022.botcommands.api.localization.annotations.LocalizationBundle
 import io.github.freya022.botcommands.api.localization.context.AppLocalizationContext
 import io.github.freya022.botcommands.api.localization.context.TextLocalizationContext
+import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.TypedParameterResolverFactory
 import io.github.freya022.botcommands.internal.localization.LocalizationContextImpl
 import io.github.freya022.botcommands.internal.parameters.resolvers.localization.LocalizationContextResolverFactories.getBaseLocalizationContext
@@ -18,6 +18,7 @@ import io.github.freya022.botcommands.internal.utils.throwUser
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.interactions.Interaction
 import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.valueParameters
 import kotlin.reflect.jvm.jvmErasure
@@ -27,9 +28,9 @@ import kotlin.reflect.typeOf
 internal class AppLocalizationContextResolverFactory(
     private val localizationService: LocalizationService
 ) : TypedParameterResolverFactory<AppLocalizationContextResolver>(AppLocalizationContextResolver::class, typeOf<AppLocalizationContext>()) {
-    override fun get(parameter: ParameterWrapper) =
+    override fun get(request: ResolverRequest) =
         AppLocalizationContextResolver(getBaseLocalizationContext(
-            localizationService, parameter, Interaction::class
+            localizationService, request.parameter.parameter, Interaction::class
         ))
 }
 
@@ -37,15 +38,14 @@ internal class AppLocalizationContextResolverFactory(
 internal class TextLocalizationContextResolverFactory(
     private val localizationService: LocalizationService
 ) : TypedParameterResolverFactory<TextLocalizationContextResolver>(TextLocalizationContextResolver::class, typeOf<TextLocalizationContext>()) {
-    override fun get(parameter: ParameterWrapper) =
+    override fun get(request: ResolverRequest) =
         TextLocalizationContextResolver(getBaseLocalizationContext(
-            localizationService, parameter, Interaction::class, MessageReceivedEvent::class
+            localizationService, request.parameter.parameter, Interaction::class, MessageReceivedEvent::class
         ))
 }
 
 internal object LocalizationContextResolverFactories {
-    fun getBaseLocalizationContext(localizationService: LocalizationService, parameterWrapper: ParameterWrapper, vararg requiredEventTypes: KClass<*>): LocalizationContextImpl {
-        val parameter = parameterWrapper.parameter
+    fun getBaseLocalizationContext(localizationService: LocalizationService, parameter: KParameter, vararg requiredEventTypes: KClass<*>): LocalizationContextImpl {
         val parameterFunction = parameter.function
         val annotation = parameter.findAnnotation<LocalizationBundle>()
             ?: throwUser(parameterFunction, "${parameter.type.jvmErasure.simpleName} parameters must be annotated with ${annotationRef<LocalizationBundle>()}")

--- a/src/test/kotlin/doc/kotlin/examples/parameters/MyCustomLocalizationResolverProvider.kt
+++ b/src/test/kotlin/doc/kotlin/examples/parameters/MyCustomLocalizationResolverProvider.kt
@@ -1,5 +1,6 @@
 package doc.kotlin.examples.parameters
 
+import io.github.freya022.botcommands.api.core.reflect.findAnnotation
 import io.github.freya022.botcommands.api.core.service.annotations.BConfiguration
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService
@@ -16,7 +17,6 @@ import io.github.freya022.botcommands.internal.IExecutableInteractionInfo
 import net.dv8tion.jda.api.events.Event
 import net.dv8tion.jda.api.interactions.Interaction
 import java.util.*
-import kotlin.reflect.full.findAnnotation
 
 @InterfacedService(acceptMultiple = false)
 interface GuildSettingsService {

--- a/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/ListResolver.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/ListResolver.kt
@@ -1,7 +1,7 @@
 package io.github.freya022.botcommands.test.resolvers
 
-import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
+import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.TypedParameterResolver
 import io.github.freya022.botcommands.api.parameters.TypedParameterResolverFactory
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
@@ -26,5 +26,5 @@ object ListResolver :
 
 @ResolverFactory
 object ListResolverFactory : TypedParameterResolverFactory<ListResolver>(ListResolver::class, typeOf<List<Double>>()) {
-    override fun get(parameter: ParameterWrapper): ListResolver = ListResolver
+    override fun get(request: ResolverRequest): ListResolver = ListResolver
 }

--- a/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/MapResolver.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/MapResolver.kt
@@ -1,9 +1,9 @@
 package io.github.freya022.botcommands.test.resolvers
 
-import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.parameters.ParameterResolverFactory
+import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.TypedParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
 import io.github.freya022.botcommands.internal.IExecutableInteractionInfo
@@ -27,11 +27,11 @@ object MapResolverFactory : ParameterResolverFactory<MapResolver<*>>(MapResolver
 
     override val supportedTypesStr: List<String> = resolvers.map { it.type.simpleNestedName }
 
-    override fun isResolvable(parameter: ParameterWrapper): Boolean {
-        return resolvers.any { it.type == parameter.type }
+    override fun isResolvable(request: ResolverRequest): Boolean {
+        return resolvers.any { it.type == request.parameter.type }
     }
 
-    override fun get(parameter: ParameterWrapper): MapResolver<*> {
-        return resolvers.first { it.type == parameter.type }
+    override fun get(request: ResolverRequest): MapResolver<*> {
+        return resolvers.first { it.type == request.parameter.type }
     }
 }


### PR DESCRIPTION
- [Small breaking] Added `ResolverRequest`, holds the `ParameterWrapper` and `RequestData`
- Resolvers factories are now only checked if their output matches the requested resolver
  - This does not break existing factories
  - For example, a factory returning a `SlashParameterResolver` is only queried if it was requested for a slash command
- Prevent usage of *required* guild-only entities in global commands