### PR TITLE
Move component expiration timestamp to the root entity

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/ITimeoutableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/ITimeoutableComponent.kt
@@ -9,6 +9,7 @@ import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterR
 import io.github.freya022.botcommands.internal.utils.annotationRef
 import io.github.freya022.botcommands.internal.utils.throwUser
 import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Instant
 import net.dv8tion.jda.api.entities.ISnowflake
 import net.dv8tion.jda.api.entities.User
 import java.util.concurrent.TimeUnit
@@ -33,6 +34,7 @@ import java.time.Duration as JavaDuration
  * - If the component is inside a group, then all the group's components will also be deleted.
  */
 interface ITimeoutableComponent<T : ITimeoutableComponent<T>> : BuilderInstanceHolder<T> {
+    val expiresAt: Instant?
     val timeout: ComponentTimeout?
 
     /**

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/data/ComponentTimeout.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/data/ComponentTimeout.kt
@@ -1,7 +1,3 @@
 package io.github.freya022.botcommands.api.components.data
 
-import kotlinx.datetime.Instant
-
-interface ComponentTimeout {
-    val expirationTimestamp: Instant
-}
+interface ComponentTimeout

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/db/DBResult.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/db/DBResult.kt
@@ -102,3 +102,6 @@ class DBResult internal constructor(resultSet: ResultSet) : Iterable<DBResult>, 
 
 fun DBResult.getKotlinInstant(columnName: String): Instant =
     getTimestamp(columnName).toInstant().toKotlinInstant()
+
+fun DBResult.getKotlinInstantOrNull(columnName: String): Instant? =
+    getTimestamp(columnName)?.toInstant()?.toKotlinInstant()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/EphemeralTimeoutableComponentImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/EphemeralTimeoutableComponentImpl.kt
@@ -5,27 +5,30 @@ import io.github.freya022.botcommands.api.components.builder.IEphemeralTimeoutab
 import io.github.freya022.botcommands.internal.components.data.EphemeralTimeout
 import io.github.freya022.botcommands.internal.utils.throwUser
 import io.github.freya022.botcommands.internal.utils.toTimestampIfFinite
+import kotlinx.datetime.Instant
 import kotlin.time.Duration
 
 internal class EphemeralTimeoutableComponentImpl<T : IEphemeralTimeoutableComponent<T>> internal constructor(
     override val instanceRetriever: InstanceRetriever<T>
 ) : BuilderInstanceHolderImpl<T>(),
     IEphemeralTimeoutableComponent<T> {
-    override var timeout: EphemeralTimeout? = Components.defaultTimeout.toTimestampIfFinite()?.let { EphemeralTimeout(it, null) }
+    override var expiresAt: Instant? = Components.defaultTimeout.toTimestampIfFinite()
+    override var timeout: EphemeralTimeout? = null
         private set
 
     override fun noTimeout(): T = instance.also {
-        timeout = null
+        this.expiresAt = null
+        this.timeout = null
     }
 
     override fun timeout(timeout: Duration): T = instance.also {
-        val expirationTimestamp = timeout.toTimestampIfFinite() ?: throwUser("Timeout must be finite and positive")
-        this.timeout = EphemeralTimeout(expirationTimestamp, null)
+        this.expiresAt = timeout.toTimestampIfFinite() ?: throwUser("Timeout must be finite and positive")
+        this.timeout = null
     }
 
     @JvmSynthetic
     override fun timeout(timeout: Duration, handler: suspend () -> Unit): T = instance.also {
-        val expirationTimestamp = timeout.toTimestampIfFinite() ?: throwUser("Timeout must be finite and positive")
-        this.timeout = EphemeralTimeout(expirationTimestamp, handler)
+        this.expiresAt = timeout.toTimestampIfFinite() ?: throwUser("Timeout must be finite and positive")
+        this.timeout = EphemeralTimeout(handler)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/PersistentTimeoutableComponentImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/PersistentTimeoutableComponentImpl.kt
@@ -4,27 +4,30 @@ import io.github.freya022.botcommands.api.components.builder.IPersistentTimeouta
 import io.github.freya022.botcommands.internal.components.data.PersistentTimeout
 import io.github.freya022.botcommands.internal.utils.throwUser
 import io.github.freya022.botcommands.internal.utils.toTimestampIfFinite
+import kotlinx.datetime.Instant
 import kotlin.time.Duration
 
 internal class PersistentTimeoutableComponentImpl<T : IPersistentTimeoutableComponent<T>> internal constructor(
     override val instanceRetriever: InstanceRetriever<T>
 ) : BuilderInstanceHolderImpl<T>(),
     IPersistentTimeoutableComponent<T> {
-
+    override var expiresAt: Instant? = null
+        private set
     override var timeout: PersistentTimeout? = null
         private set
 
     override fun noTimeout(): T = instance.also {
-        timeout = null
+        this.expiresAt = null
+        this.timeout = null
     }
 
     override fun timeout(timeout: Duration): T = instance.also {
-        val expirationTimestamp = timeout.toTimestampIfFinite() ?: throwUser("Timeout must be positive and finite")
-        this.timeout = PersistentTimeout.create(expirationTimestamp)
+        this.expiresAt = timeout.toTimestampIfFinite() ?: throwUser("Timeout must be positive and finite")
+        this.timeout = null
     }
 
     override fun timeout(timeout: Duration, handlerName: String, vararg data: Any?): T = instance.also {
-        val expirationTimestamp = timeout.toTimestampIfFinite() ?: throwUser("Timeout must be positive and finite")
-        this.timeout = PersistentTimeout.create(expirationTimestamp, handlerName, data.toList())
+        this.expiresAt = timeout.toTimestampIfFinite() ?: throwUser("Timeout must be positive and finite")
+        this.timeout = PersistentTimeout.create(handlerName, data.toList())
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentController.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentController.kt
@@ -94,8 +94,8 @@ internal class ComponentController(
 
         return componentRepository.createComponent(builder)
             .also { id ->
-                val timeout = builder.timeout ?: return@also
-                timeoutManager.scheduleTimeout(id, timeout.expirationTimestamp)
+                val timeout = builder.expiresAt ?: return@also
+                timeoutManager.scheduleTimeout(id, timeout)
             }
     }
 
@@ -105,8 +105,8 @@ internal class ComponentController(
     suspend fun createGroup(group: ComponentGroupBuilder<*>): ComponentGroup {
         return componentRepository.insertGroup(group)
             .also { id ->
-                val timeout = group.timeout ?: return@also
-                timeoutManager.scheduleTimeout(id, timeout.expirationTimestamp)
+                val timeout = group.expiresAt ?: return@also
+                timeoutManager.scheduleTimeout(id, timeout)
             }
             .let { id -> ComponentGroup(this, id) }
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentTimeoutManager.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentTimeoutManager.kt
@@ -71,7 +71,7 @@ internal class ComponentTimeoutManager(
 
         when (val componentTimeout = component.timeout) {
             is PersistentTimeout -> {
-                val handlerName = componentTimeout.handlerName ?: return
+                val handlerName = componentTimeout.handlerName
                 val descriptor = when (component.componentType) {
                     ComponentType.GROUP ->
                         groupTimeoutHandlers[handlerName]
@@ -99,7 +99,7 @@ internal class ComponentTimeoutManager(
 
                 handlePersistentTimeout(descriptor, firstParameter, userData.iterator())
             }
-            is EphemeralTimeout -> componentTimeout.handler?.invoke()
+            is EphemeralTimeout -> componentTimeout.handler()
         }
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/AbstractComponentData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/AbstractComponentData.kt
@@ -6,11 +6,13 @@ import io.github.freya022.botcommands.api.components.data.InteractionConstraints
 import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.LifetimeType
 import io.github.freya022.botcommands.internal.components.handler.ComponentHandler
+import kotlinx.datetime.Instant
 
 internal sealed class AbstractComponentData(
     componentId: Int,
     componentType: ComponentType,
     lifetimeType: LifetimeType,
+    expiresAt: Instant?,
     filters: List<ComponentInteractionFilter<*>>,
     oneUse: Boolean,
     rateLimitGroup: String?,
@@ -18,4 +20,4 @@ internal sealed class AbstractComponentData(
     timeout: ComponentTimeout?,
     final override val constraints: InteractionConstraints,
     groupId: Int?
-): ComponentData(componentId, componentType, lifetimeType, filters, oneUse, rateLimitGroup, handler, timeout, constraints, groupId)
+): ComponentData(componentId, componentType, lifetimeType, expiresAt, filters, oneUse, rateLimitGroup, handler, timeout, constraints, groupId)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentData.kt
@@ -6,11 +6,13 @@ import io.github.freya022.botcommands.api.components.data.InteractionConstraints
 import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.LifetimeType
 import io.github.freya022.botcommands.internal.components.handler.ComponentHandler
+import kotlinx.datetime.Instant
 
 internal sealed class ComponentData(
     val internalId: Int,
     val componentType: ComponentType,
     val lifetimeType: LifetimeType,
+    val expiresAt: Instant?,
     val filters: List<ComponentInteractionFilter<*>>,
     val oneUse: Boolean,
     val rateLimitGroup: String?,

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentGroupData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentGroupData.kt
@@ -3,10 +3,12 @@ package io.github.freya022.botcommands.internal.components.data
 import io.github.freya022.botcommands.api.components.data.ComponentTimeout
 import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.LifetimeType
+import kotlinx.datetime.Instant
 
 internal class ComponentGroupData internal constructor(
     groupId: Int,
     oneUse: Boolean,
+    expiresAt: Instant?,
     timeout: ComponentTimeout?,
     internal val componentIds: List<Int>
-): ComponentData(groupId, ComponentType.GROUP, LifetimeType.PERSISTENT, emptyList(), oneUse, null, null, timeout, null, groupId)
+): ComponentData(groupId, ComponentType.GROUP, LifetimeType.PERSISTENT, expiresAt, emptyList(), oneUse, null, null, timeout, null, groupId)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/EphemeralComponentData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/EphemeralComponentData.kt
@@ -5,11 +5,13 @@ import io.github.freya022.botcommands.api.components.data.InteractionConstraints
 import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.LifetimeType
 import io.github.freya022.botcommands.internal.components.handler.EphemeralHandler
+import kotlinx.datetime.Instant
 
 internal class EphemeralComponentData(
     componentId: Int,
     componentType: ComponentType,
     lifetimeType: LifetimeType,
+    expiresAt: Instant?,
     filters: List<ComponentInteractionFilter<*>>,
     oneUse: Boolean,
     rateLimitGroup: String?,
@@ -17,4 +19,4 @@ internal class EphemeralComponentData(
     override val timeout: EphemeralTimeout?,
     constraints: InteractionConstraints,
     groupId: Int?
-) : AbstractComponentData(componentId, componentType, lifetimeType, filters, oneUse, rateLimitGroup, handler, timeout, constraints, groupId)
+) : AbstractComponentData(componentId, componentType, lifetimeType, expiresAt, filters, oneUse, rateLimitGroup, handler, timeout, constraints, groupId)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/EphemeralTimeout.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/EphemeralTimeout.kt
@@ -1,9 +1,7 @@
 package io.github.freya022.botcommands.internal.components.data
 
 import io.github.freya022.botcommands.api.components.data.ComponentTimeout
-import kotlinx.datetime.Instant
 
 internal class EphemeralTimeout(
-    override val expirationTimestamp: Instant,
-    val handler: (suspend () -> Unit)?
+    val handler: suspend () -> Unit
 ) : ComponentTimeout

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/PersistentComponentData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/PersistentComponentData.kt
@@ -5,11 +5,13 @@ import io.github.freya022.botcommands.api.components.data.InteractionConstraints
 import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.LifetimeType
 import io.github.freya022.botcommands.internal.components.handler.PersistentHandler
+import kotlinx.datetime.Instant
 
 internal class PersistentComponentData(
     componentId: Int,
     componentType: ComponentType,
     lifetimeType: LifetimeType,
+    expiresAt: Instant?,
     filters: List<ComponentInteractionFilter<*>>,
     oneUse: Boolean,
     rateLimitGroup: String?,
@@ -17,4 +19,4 @@ internal class PersistentComponentData(
     override val timeout: PersistentTimeout?,
     constraints: InteractionConstraints,
     groupId: Int?
-) : AbstractComponentData(componentId, componentType, lifetimeType, filters, oneUse, rateLimitGroup, handler, timeout, constraints, groupId)
+) : AbstractComponentData(componentId, componentType, lifetimeType, expiresAt, filters, oneUse, rateLimitGroup, handler, timeout, constraints, groupId)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/PersistentTimeout.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/PersistentTimeout.kt
@@ -1,28 +1,15 @@
 package io.github.freya022.botcommands.internal.components.data
 
 import io.github.freya022.botcommands.api.components.data.ComponentTimeout
-import kotlinx.datetime.Instant
-import kotlinx.datetime.toKotlinInstant
 import net.dv8tion.jda.api.entities.ISnowflake
-import java.sql.Timestamp as SQLTimestamp
 
 internal class PersistentTimeout private constructor(
-    override val expirationTimestamp: Instant,
-    val handlerName: String?,
+    val handlerName: String,
     val userData: List<String?>
 ) : ComponentTimeout {
     internal companion object {
-        internal fun create(expirationTimestamp: Instant): PersistentTimeout {
+        internal fun create(handlerName: String, userData: List<Any?>): PersistentTimeout {
             return PersistentTimeout(
-                expirationTimestamp,
-                null,
-                emptyList()
-            )
-        }
-
-        internal fun create(expirationTimestamp: Instant, handlerName: String?, userData: List<Any?>): PersistentTimeout {
-            return PersistentTimeout(
-                expirationTimestamp,
                 handlerName,
                 userData.map { arg ->
                     when (arg) {
@@ -34,9 +21,8 @@ internal class PersistentTimeout private constructor(
             )
         }
 
-        internal fun fromData(expirationTimestamp: SQLTimestamp, handlerName: String?, userData: List<String>): PersistentTimeout {
+        internal fun fromData(handlerName: String, userData: List<String>): PersistentTimeout {
             return PersistentTimeout(
-                expirationTimestamp.toInstant().toKotlinInstant(),
                 handlerName,
                 userData
             )

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentRepository.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentRepository.kt
@@ -283,14 +283,6 @@ internal class ComponentRepository(
         return@transactional deletedComponents
     }
 
-    suspend fun scheduleExistingTimeouts(timeoutManager: ComponentTimeoutManager) = database.transactional(readOnly = true) {
-        preparedStatement("select component_id, expiration_timestamp from bc_persistent_timeout") {
-            executeQuery().forEach { dbResult ->
-                timeoutManager.scheduleTimeout(dbResult["component_id"], dbResult.get<Timestamp>("expiration_timestamp").toInstant().toKotlinInstant())
-            }
-        }
-    }
-
     context(Transaction)
     private suspend fun getPersistentComponent(
         id: Int,

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/db/DatabaseImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/db/DatabaseImpl.kt
@@ -21,7 +21,7 @@ import java.sql.Connection
 import kotlin.time.toKotlinDuration
 
 // If the build script has 3.0.0-alpha.5_DEV, use the next release version, in this case 3.0.0-alpha.6
-private const val latestVersion = "3.0.0-alpha.8" // Change in the latest migration script too
+private const val latestVersion = "3.0.0-alpha.14" // Change in the latest migration script too
 
 private val logger = KotlinLogging.logger { }
 

--- a/src/main/resources/bc_database_scripts/V3.0.0.2024.05.08__Move_component_timeout.sql
+++ b/src/main/resources/bc_database_scripts/V3.0.0.2024.05.08__Move_component_timeout.sql
@@ -1,0 +1,45 @@
+------------------------------------------------------ 4th migration script for BotCommands ------------------------------------------------------
+---------------------------------- Make sure to run the previous scripts (chronological order) before this one -----------------------------------
+
+SET SCHEMA 'bc';
+
+UPDATE bc_version
+SET version = '3.0.0-alpha.14'
+WHERE one_row = true;
+
+-- Add expiration column to base component
+ALTER TABLE bc_component
+    ADD COLUMN expires_at TIMESTAMP WITH TIME ZONE NULL;
+
+-- Copy existing timestamps to new column
+UPDATE bc_component c
+SET expires_at = (SELECT expiration_timestamp FROM bc_persistent_timeout pt WHERE c.component_id = pt.component_id)
+WHERE lifetime_type = 0;
+
+UPDATE bc_component c
+SET expires_at = (SELECT expiration_timestamp FROM bc_ephemeral_timeout et WHERE c.component_id = et.component_id)
+WHERE lifetime_type = 1;
+
+-- Drop old expiration columns
+ALTER TABLE bc_persistent_timeout
+    DROP COLUMN expiration_timestamp;
+ALTER TABLE bc_ephemeral_timeout
+    DROP COLUMN expiration_timestamp;
+
+-- Previously, the timeout rows could have an expiration timestamp, and a null handler, or, both.
+-- Now, the timeout rows only exist if an handler is entirely set
+
+-- Remove rows with no handler
+DELETE
+FROM bc_ephemeral_timeout
+WHERE handler_id IS NULL;
+
+DELETE
+FROM bc_persistent_timeout
+WHERE handler_name IS NULL;
+
+-- Tighten null constraints
+ALTER TABLE bc_ephemeral_timeout
+    ALTER COLUMN handler_id SET NOT NULL;
+ALTER TABLE bc_persistent_timeout
+    ALTER COLUMN handler_name SET NOT NULL;


### PR DESCRIPTION
Internal refactoring so the expiration timestamp is on `bc_component` instead of `bc_(ephemeral|persistent)_timeout`

No breaking change unless you retrieved the _timeout builder_ expiration timestamp, which doesn't serve any purpose.