### PR TITLE
Separate custom options and services, add categorizing annotations

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/builder/ApplicationCommandBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/builder/ApplicationCommandBuilder.kt
@@ -22,8 +22,7 @@ abstract class ApplicationCommandBuilder<T : ApplicationCommandOptionAggregateBu
     val filters: MutableList<ApplicationCommandFilter<*>> = arrayListOf()
 
     /**
-     * Declares a custom option, such as an [AppLocalizationContext] (with [@LocalizationBundle][LocalizationBundle])
-     * or a service.
+     * Declares a custom option, such as an [AppLocalizationContext] (with [@LocalizationBundle][LocalizationBundle]).
      *
      * Additional types can be added by implementing [ICustomResolver].
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/builder/ApplicationCommandOptionAggregateBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/builder/ApplicationCommandOptionAggregateBuilder.kt
@@ -3,9 +3,6 @@ package io.github.freya022.botcommands.api.commands.application.builder
 import io.github.freya022.botcommands.api.commands.CommandOptionAggregateBuilder
 import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier
-import io.github.freya022.botcommands.api.localization.annotations.LocalizationBundle
-import io.github.freya022.botcommands.api.localization.context.AppLocalizationContext
-import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
 import io.github.freya022.botcommands.internal.parameters.AggregatorParameter
 import kotlin.reflect.KFunction
 
@@ -13,15 +10,6 @@ abstract class ApplicationCommandOptionAggregateBuilder<T : ApplicationCommandOp
     aggregatorParameter: AggregatorParameter,
     aggregator: KFunction<*>
 ) : CommandOptionAggregateBuilder<T>(aggregatorParameter, aggregator) {
-    /**
-     * Declares a custom option, such as an [AppLocalizationContext] (with [@LocalizationBundle][LocalizationBundle]).
-     *
-     * Additional types can be added by implementing [ICustomResolver].
-     *
-     * @param declaredName Name of the declared parameter in the aggregator
-     */
-    abstract fun customOption(declaredName: String)
-
     /**
      * Declares a generated option, the supplier gets called on each command execution.
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/builder/ApplicationCommandOptionAggregateBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/builder/ApplicationCommandOptionAggregateBuilder.kt
@@ -14,8 +14,7 @@ abstract class ApplicationCommandOptionAggregateBuilder<T : ApplicationCommandOp
     aggregator: KFunction<*>
 ) : CommandOptionAggregateBuilder<T>(aggregatorParameter, aggregator) {
     /**
-     * Declares a custom option, such as an [AppLocalizationContext] (with [@LocalizationBundle][LocalizationBundle])
-     * or a service.
+     * Declares a custom option, such as an [AppLocalizationContext] (with [@LocalizationBundle][LocalizationBundle]).
      *
      * Additional types can be added by implementing [ICustomResolver].
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAMessageCommand.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAMessageCommand.kt
@@ -32,7 +32,8 @@ import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFuncti
  * but only the targeted [Message][GlobalMessageEvent.getTarget] is supported by default,
  * additional types can be added by implementing [MessageContextParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
- * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Custom options: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Service options: No annotation, however, I recommend injecting the service in the class instead.
  *
  * @see GlobalMessageEvent.getTarget
  *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAUserCommand.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAUserCommand.kt
@@ -33,7 +33,8 @@ import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFuncti
  * but only the targeted [User][GlobalUserEvent.getTarget]/[Member][GlobalUserEvent.getTargetMember] and [InputUser] are supported by default,
  * additional types can be added by implementing [UserContextParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
- * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Custom options: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Service options: No annotation, however, I recommend injecting the service in the class instead.
  *
  * @see GlobalUserEvent.getTarget
  * @see GlobalUserEvent.getTargetMember

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/MessageCommandBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/MessageCommandBuilder.kt
@@ -38,7 +38,7 @@ class MessageCommandBuilder internal constructor(
     }
 
     override fun constructAggregate(aggregatorParameter: AggregatorParameter, aggregator: KFunction<*>) =
-        MessageCommandOptionAggregateBuilder(aggregatorParameter, aggregator)
+        MessageCommandOptionAggregateBuilder(context, this, aggregatorParameter, aggregator)
 
     internal fun build(): MessageCommandInfo {
         return MessageCommandInfo(context, this)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/MessageCommandOptionAggregateBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/MessageCommandOptionAggregateBuilder.kt
@@ -3,18 +3,14 @@ package io.github.freya022.botcommands.api.commands.application.context.builder
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier
 import io.github.freya022.botcommands.api.commands.application.builder.ApplicationCommandOptionAggregateBuilder
 import io.github.freya022.botcommands.api.commands.application.builder.ApplicationGeneratedOptionBuilder
-import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
+import io.github.freya022.botcommands.api.commands.builder.IDeclarationSiteHolder
 import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.core.objectLogger
-import io.github.freya022.botcommands.api.core.utils.getSignature
-import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.AggregatorParameter
-import io.github.freya022.botcommands.internal.utils.ReflectionUtils.resolveBestReference
 import kotlin.reflect.KFunction
 
 class MessageCommandOptionAggregateBuilder internal constructor(
-    private val context: BContext,
-    private val commandBuilder: MessageCommandBuilder,
+    override val context: BContext,
+    override val declarationSiteHolder: IDeclarationSiteHolder,
     aggregatorParameter: AggregatorParameter,
     aggregator: KFunction<*>
 ) : ApplicationCommandOptionAggregateBuilder<MessageCommandOptionAggregateBuilder>(aggregatorParameter, aggregator) {
@@ -22,18 +18,10 @@ class MessageCommandOptionAggregateBuilder internal constructor(
         this += MessageCommandOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName))
     }
 
-    override fun customOption(declaredName: String) {
-        if (context.serviceContainer.canCreateWrappedService(aggregatorParameter.typeCheckingParameter) == null) {
-            objectLogger().warn { "Using ${this::customOption.resolveBestReference().getSignature(source = false)} **for services** has been deprecated, please use ${this::serviceOption.resolveBestReference().getSignature(source = false)} instead, parameter '$declaredName' of ${commandBuilder.declarationSite}" }
-            return serviceOption(declaredName)
-        }
-        this += CustomOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName))
-    }
-
     override fun generatedOption(declaredName: String, generatedValueSupplier: ApplicationGeneratedValueSupplier) {
         this += ApplicationGeneratedOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName), generatedValueSupplier)
     }
 
     override fun constructNestedAggregate(aggregatorParameter: AggregatorParameter, aggregator: KFunction<*>) =
-        MessageCommandOptionAggregateBuilder(context, commandBuilder, aggregatorParameter, aggregator)
+        MessageCommandOptionAggregateBuilder(context, declarationSiteHolder, aggregatorParameter, aggregator)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/UserCommandBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/UserCommandBuilder.kt
@@ -38,7 +38,7 @@ class UserCommandBuilder internal constructor(
     }
 
     override fun constructAggregate(aggregatorParameter: AggregatorParameter, aggregator: KFunction<*>) =
-        UserCommandOptionAggregateBuilder(aggregatorParameter, aggregator)
+        UserCommandOptionAggregateBuilder(context, this, aggregatorParameter, aggregator)
 
     internal fun build(): UserCommandInfo {
         return UserCommandInfo(context, this)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/UserCommandOptionAggregateBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/UserCommandOptionAggregateBuilder.kt
@@ -3,18 +3,14 @@ package io.github.freya022.botcommands.api.commands.application.context.builder
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier
 import io.github.freya022.botcommands.api.commands.application.builder.ApplicationCommandOptionAggregateBuilder
 import io.github.freya022.botcommands.api.commands.application.builder.ApplicationGeneratedOptionBuilder
-import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
+import io.github.freya022.botcommands.api.commands.builder.IDeclarationSiteHolder
 import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.core.objectLogger
-import io.github.freya022.botcommands.api.core.utils.getSignature
-import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.AggregatorParameter
-import io.github.freya022.botcommands.internal.utils.ReflectionUtils.resolveBestReference
 import kotlin.reflect.KFunction
 
 class UserCommandOptionAggregateBuilder internal constructor(
-    private val context: BContext,
-    private val commandBuilder: UserCommandBuilder,
+    override val context: BContext,
+    override val declarationSiteHolder: IDeclarationSiteHolder,
     aggregatorParameter: AggregatorParameter,
     aggregator: KFunction<*>
 ) : ApplicationCommandOptionAggregateBuilder<UserCommandOptionAggregateBuilder>(aggregatorParameter, aggregator) {
@@ -22,18 +18,10 @@ class UserCommandOptionAggregateBuilder internal constructor(
         this += UserCommandOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName))
     }
 
-    override fun customOption(declaredName: String) {
-        if (context.serviceContainer.canCreateWrappedService(aggregatorParameter.typeCheckingParameter) == null) {
-            objectLogger().warn { "Using ${this::customOption.resolveBestReference().getSignature(source = false)} **for services** has been deprecated, please use ${this::serviceOption.resolveBestReference().getSignature(source = false)} instead, parameter '$declaredName' of ${commandBuilder.declarationSite}" }
-            return serviceOption(declaredName)
-        }
-        this += CustomOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName))
-    }
-
     override fun generatedOption(declaredName: String, generatedValueSupplier: ApplicationGeneratedValueSupplier) {
         this += ApplicationGeneratedOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName), generatedValueSupplier)
     }
 
     override fun constructNestedAggregate(aggregatorParameter: AggregatorParameter, aggregator: KFunction<*>) =
-        UserCommandOptionAggregateBuilder(context, commandBuilder, aggregatorParameter, aggregator)
+        UserCommandOptionAggregateBuilder(context, declarationSiteHolder, aggregatorParameter, aggregator)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/UserCommandOptionAggregateBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/builder/UserCommandOptionAggregateBuilder.kt
@@ -4,10 +4,17 @@ import io.github.freya022.botcommands.api.commands.application.ApplicationGenera
 import io.github.freya022.botcommands.api.commands.application.builder.ApplicationCommandOptionAggregateBuilder
 import io.github.freya022.botcommands.api.commands.application.builder.ApplicationGeneratedOptionBuilder
 import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
+import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.objectLogger
+import io.github.freya022.botcommands.api.core.utils.getSignature
+import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.AggregatorParameter
+import io.github.freya022.botcommands.internal.utils.ReflectionUtils.resolveBestReference
 import kotlin.reflect.KFunction
 
 class UserCommandOptionAggregateBuilder internal constructor(
+    private val context: BContext,
+    private val commandBuilder: UserCommandBuilder,
     aggregatorParameter: AggregatorParameter,
     aggregator: KFunction<*>
 ) : ApplicationCommandOptionAggregateBuilder<UserCommandOptionAggregateBuilder>(aggregatorParameter, aggregator) {
@@ -16,6 +23,10 @@ class UserCommandOptionAggregateBuilder internal constructor(
     }
 
     override fun customOption(declaredName: String) {
+        if (context.serviceContainer.canCreateWrappedService(aggregatorParameter.typeCheckingParameter) == null) {
+            objectLogger().warn { "Using ${this::customOption.resolveBestReference().getSignature(source = false)} **for services** has been deprecated, please use ${this::serviceOption.resolveBestReference().getSignature(source = false)} instead, parameter '$declaredName' of ${commandBuilder.declarationSite}" }
+            return serviceOption(declaredName)
+        }
         this += CustomOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName))
     }
 
@@ -24,5 +35,5 @@ class UserCommandOptionAggregateBuilder internal constructor(
     }
 
     override fun constructNestedAggregate(aggregatorParameter: AggregatorParameter, aggregator: KFunction<*>) =
-        UserCommandOptionAggregateBuilder(aggregatorParameter, aggregator)
+        UserCommandOptionAggregateBuilder(context, commandBuilder, aggregatorParameter, aggregator)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/JDASlashCommand.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/JDASlashCommand.kt
@@ -42,7 +42,8 @@ import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFuncti
  * - Input options: Uses [@SlashOption][SlashOption], supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [SlashParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
- * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Custom options: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Service options: No annotation, however, I recommend injecting the service in the class instead.
  *
  * @see Command @Command
  * @see TopLevelSlashCommandData @TopLevelSlashCommandData

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandOptionAggregateBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandOptionAggregateBuilder.kt
@@ -6,9 +6,13 @@ import io.github.freya022.botcommands.api.commands.application.builder.Applicati
 import io.github.freya022.botcommands.api.commands.application.builder.ApplicationGeneratedOptionBuilder
 import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
 import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.objectLogger
+import io.github.freya022.botcommands.api.core.utils.getSignature
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
+import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.AggregatorParameter
+import io.github.freya022.botcommands.internal.utils.ReflectionUtils.resolveBestReference
 import io.github.freya022.botcommands.internal.utils.toDiscordString
 import kotlin.reflect.KFunction
 
@@ -31,6 +35,10 @@ class SlashCommandOptionAggregateBuilder internal constructor(
     }
 
     override fun customOption(declaredName: String) {
+        if (context.serviceContainer.canCreateWrappedService(aggregatorParameter.typeCheckingParameter) == null) {
+            objectLogger().warn { "Using ${this::customOption.resolveBestReference().getSignature(source = false)} **for services** has been deprecated, please use ${this::serviceOption.resolveBestReference().getSignature(source = false)} instead, parameter '$declaredName' of ${commandBuilder.declarationSite}" }
+            return serviceOption(declaredName)
+        }
         this += CustomOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName))
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/builder/ExecutableCommandBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/builder/ExecutableCommandBuilder.kt
@@ -3,6 +3,9 @@ package io.github.freya022.botcommands.api.commands.builder
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.options.annotations.Aggregate
 import io.github.freya022.botcommands.api.core.options.builder.OptionAggregateBuilder
+import io.github.freya022.botcommands.api.core.service.annotations.Condition
+import io.github.freya022.botcommands.api.core.service.annotations.ConditionalService
+import io.github.freya022.botcommands.api.core.service.annotations.Dependencies
 import io.github.freya022.botcommands.internal.core.options.builder.OptionAggregateBuildersImpl
 import io.github.freya022.botcommands.internal.parameters.AggregatorParameter
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.reflectReference
@@ -19,6 +22,23 @@ abstract class ExecutableCommandBuilder<T : OptionAggregateBuilder<T>, R> intern
 
     internal val optionAggregateBuilders: Map<String, T>
         get() = _optionAggregateBuilders.optionAggregateBuilders
+
+    /**
+     * Declares a service option, allowing injection of services, which must be available.
+     *
+     * If the service is not available, then either don't declare this command,
+     * or make the declaring class disabled by using one of:
+     * - [@Condition][Condition]
+     * - [@ConditionalService][ConditionalService]
+     * - [@Dependencies][Dependencies]
+     *
+     * @param declaredName Name of the declared parameter in the [command function][function]
+     */
+    fun serviceOption(declaredName: String) {
+        selfAggregate(declaredName) {
+            serviceOption(declaredName)
+        }
+    }
 
     /**
      * Declares multiple options aggregated in a single parameter.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/builder/ServiceOptionBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/builder/ServiceOptionBuilder.kt
@@ -1,0 +1,6 @@
+package io.github.freya022.botcommands.api.commands.builder
+
+import io.github.freya022.botcommands.api.core.options.builder.OptionBuilder
+import io.github.freya022.botcommands.internal.parameters.OptionParameter
+
+class ServiceOptionBuilder internal constructor(optionParameter: OptionParameter) : OptionBuilder(optionParameter)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/JDATextCommandVariation.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/JDATextCommandVariation.kt
@@ -44,7 +44,8 @@ import net.dv8tion.jda.internal.utils.Checks
  * - Input options: Uses [@TextOption][TextOption], supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [TextParameterResolver].
  * - [TextLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
- * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Custom options: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Service options: No annotation, however, I recommend injecting the service in the class instead.
  *
  * @see Command @Command
  * @see TextCommandData @TextCommandData

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/builder/TextCommandOptionAggregateBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/builder/TextCommandOptionAggregateBuilder.kt
@@ -1,33 +1,21 @@
 package io.github.freya022.botcommands.api.commands.text.builder
 
-import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
+import io.github.freya022.botcommands.api.commands.builder.IDeclarationSiteHolder
 import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSupplier
 import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.core.objectLogger
 import io.github.freya022.botcommands.api.core.options.builder.OptionAggregateBuilder
-import io.github.freya022.botcommands.api.core.utils.getSignature
-import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.AggregatorParameter
-import io.github.freya022.botcommands.internal.utils.ReflectionUtils.resolveBestReference
 import io.github.freya022.botcommands.internal.utils.toDiscordString
 import kotlin.reflect.KFunction
 
 class TextCommandOptionAggregateBuilder internal constructor(
-    private val context: BContext,
-    private val commandBuilder: TextCommandVariationBuilder,
+    override val context: BContext,
+    override val declarationSiteHolder: IDeclarationSiteHolder,
     aggregatorParameter: AggregatorParameter,
     aggregator: KFunction<*>
 ) : OptionAggregateBuilder<TextCommandOptionAggregateBuilder>(aggregatorParameter, aggregator) {
     fun option(declaredName: String, optionName: String = declaredName.toDiscordString(), block: TextCommandOptionBuilder.() -> Unit = {}) {
         this += TextCommandOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName), optionName).apply(block)
-    }
-
-    fun customOption(declaredName: String) {
-        if (context.serviceContainer.canCreateWrappedService(aggregatorParameter.typeCheckingParameter) == null) {
-            objectLogger().warn { "Using ${this::customOption.resolveBestReference().getSignature(source = false)} **for services** has been deprecated, please use ${this::serviceOption.resolveBestReference().getSignature(source = false)} instead, parameter '$declaredName' of ${commandBuilder.declarationSite}" }
-            return serviceOption(declaredName)
-        }
-        this += CustomOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName))
     }
 
     fun generatedOption(declaredName: String, generatedValueSupplier: TextGeneratedValueSupplier) {
@@ -47,5 +35,5 @@ class TextCommandOptionAggregateBuilder internal constructor(
     }
 
     override fun constructNestedAggregate(aggregatorParameter: AggregatorParameter, aggregator: KFunction<*>) =
-        TextCommandOptionAggregateBuilder(context, commandBuilder, aggregatorParameter, aggregator)
+        TextCommandOptionAggregateBuilder(context, declarationSiteHolder, aggregatorParameter, aggregator)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/builder/TextCommandOptionAggregateBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/builder/TextCommandOptionAggregateBuilder.kt
@@ -2,12 +2,19 @@ package io.github.freya022.botcommands.api.commands.text.builder
 
 import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
 import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSupplier
+import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.objectLogger
 import io.github.freya022.botcommands.api.core.options.builder.OptionAggregateBuilder
+import io.github.freya022.botcommands.api.core.utils.getSignature
+import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.AggregatorParameter
+import io.github.freya022.botcommands.internal.utils.ReflectionUtils.resolveBestReference
 import io.github.freya022.botcommands.internal.utils.toDiscordString
 import kotlin.reflect.KFunction
 
 class TextCommandOptionAggregateBuilder internal constructor(
+    private val context: BContext,
+    private val commandBuilder: TextCommandVariationBuilder,
     aggregatorParameter: AggregatorParameter,
     aggregator: KFunction<*>
 ) : OptionAggregateBuilder<TextCommandOptionAggregateBuilder>(aggregatorParameter, aggregator) {
@@ -16,6 +23,10 @@ class TextCommandOptionAggregateBuilder internal constructor(
     }
 
     fun customOption(declaredName: String) {
+        if (context.serviceContainer.canCreateWrappedService(aggregatorParameter.typeCheckingParameter) == null) {
+            objectLogger().warn { "Using ${this::customOption.resolveBestReference().getSignature(source = false)} **for services** has been deprecated, please use ${this::serviceOption.resolveBestReference().getSignature(source = false)} instead, parameter '$declaredName' of ${commandBuilder.declarationSite}" }
+            return serviceOption(declaredName)
+        }
         this += CustomOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName))
     }
 
@@ -36,5 +47,5 @@ class TextCommandOptionAggregateBuilder internal constructor(
     }
 
     override fun constructNestedAggregate(aggregatorParameter: AggregatorParameter, aggregator: KFunction<*>) =
-        TextCommandOptionAggregateBuilder(aggregatorParameter, aggregator)
+        TextCommandOptionAggregateBuilder(context, commandBuilder, aggregatorParameter, aggregator)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/builder/TextCommandVariationBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/builder/TextCommandVariationBuilder.kt
@@ -8,6 +8,9 @@ import io.github.freya022.botcommands.api.commands.text.TextCommandFilter
 import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSupplier
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.service.annotations.Condition
+import io.github.freya022.botcommands.api.core.service.annotations.ConditionalService
+import io.github.freya022.botcommands.api.core.service.annotations.Dependencies
 import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.internal.commands.CommandDSL
@@ -31,7 +34,7 @@ class TextCommandVariationBuilder internal constructor(
     override val function: KFunction<Any> = function.reflectReference()
 
     private val _optionAggregateBuilders = OptionAggregateBuildersImpl(function) { aggregatorParameter, aggregator ->
-        TextCommandOptionAggregateBuilder(aggregatorParameter, aggregator)
+        TextCommandOptionAggregateBuilder(context, this, aggregatorParameter, aggregator)
     }
 
     internal val optionAggregateBuilders: Map<String, TextCommandOptionAggregateBuilder>
@@ -125,6 +128,23 @@ class TextCommandVariationBuilder internal constructor(
                     isOptional = i >= requiredAmount
                 }
             }
+        }
+    }
+
+    /**
+     * Declares a service option, allowing injection of services, which must be available.
+     *
+     * If the service is not available, then either don't declare this command,
+     * or make the declaring class disabled by using one of:
+     * - [@Condition][Condition]
+     * - [@ConditionalService][ConditionalService]
+     * - [@Dependencies][Dependencies]
+     *
+     * @param declaredName Name of the declared parameter in the [command function][function]
+     */
+    fun serviceOption(declaredName: String) {
+        selfAggregate(declaredName) {
+            serviceOption(declaredName)
         }
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/ComponentData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/ComponentData.kt
@@ -1,0 +1,15 @@
+package io.github.freya022.botcommands.api.components.annotations
+
+import io.github.freya022.botcommands.api.components.builder.IPersistentActionableComponent
+
+/**
+ * Sets this parameter as data coming from [IPersistentActionableComponent.bindTo].
+ *
+ * The order and types of the passed data must match with the handler parameters.
+ *
+ * @see JDAButtonListener @JDAButtonListener
+ * @see JDASelectMenuListener @JDASelectMenuListener
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ComponentData

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/ComponentTimeoutHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/ComponentTimeoutHandler.kt
@@ -1,13 +1,31 @@
 package io.github.freya022.botcommands.api.components.annotations
 
+import io.github.freya022.botcommands.api.components.builder.IPersistentTimeoutableComponent
 import io.github.freya022.botcommands.api.components.data.ComponentTimeoutData
+import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder
+import io.github.freya022.botcommands.api.core.options.annotations.Aggregate
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.parameters.ParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
 
 /**
- * Annotation marking a method as a persistent component timeout handler
+ * Declares this function as a component timeout handler with the given name.
  *
- * Requirements:
- * - Public & non-static
- * - First parameter is a [ComponentTimeoutData]
+ * ### Requirements
+ * - The declaring class must be annotated with [@BService][BService]
+ * or [any annotation that enables your class for dependency injection][BServiceConfigBuilder.serviceAnnotations].
+ * - The annotation value to have same name as the one given to [IPersistentTimeoutableComponent.timeout].
+ * - First parameter must be [ComponentTimeoutData].
+ *
+ * ### Option types
+ * - User data: Uses [@TimeoutData][TimeoutData], the order must match the data passed when creating the select menu,
+ * supported types and modifiers are in [ParameterResolver],
+ * additional types can be added by implementing [TimeoutParameterResolver].
+ * - Service options: No annotation, however, I recommend injecting the service in the class instead.
+ *
+ * @see IPersistentTimeoutableComponent.timeout
+ *
+ * @see Aggregate @Aggregate
  */
 @Target(AnnotationTarget.FUNCTION)
 annotation class ComponentTimeoutHandler(@get:JvmName("value") val name: String)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/GroupTimeoutHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/GroupTimeoutHandler.kt
@@ -1,13 +1,31 @@
 package io.github.freya022.botcommands.api.components.annotations
 
+import io.github.freya022.botcommands.api.components.builder.group.ComponentGroupBuilder
 import io.github.freya022.botcommands.api.components.data.GroupTimeoutData
+import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder
+import io.github.freya022.botcommands.api.core.options.annotations.Aggregate
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.parameters.ParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
 
 /**
- * Annotation marking a method as a persistent group timeout handler
+ * Declares this function as a component group timeout handler with the given name.
  *
- * Requirements:
- * - Public & non-static
- * - First parameter is a [GroupTimeoutData]
+ * ### Requirements
+ * - The declaring class must be annotated with [@BService][BService]
+ * or [any annotation that enables your class for dependency injection][BServiceConfigBuilder.serviceAnnotations].
+ * - The annotation value to have same name as the one given to [ComponentGroupBuilder.timeout].
+ * - First parameter must be [GroupTimeoutData].
+ *
+ * ### Option types
+ * - User data: Uses [@TimeoutData][TimeoutData], the order must match the data passed when creating the select menu,
+ * supported types and modifiers are in [ParameterResolver],
+ * additional types can be added by implementing [TimeoutParameterResolver].
+ * - Service options: No annotation, however, I recommend injecting the service in the class instead.
+ *
+ * @see ComponentGroupBuilder.timeout
+ *
+ * @see Aggregate @Aggregate
  */
 @Target(AnnotationTarget.FUNCTION)
 annotation class GroupTimeoutHandler(@get:JvmName("value") val name: String)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDAButtonListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDAButtonListener.kt
@@ -28,7 +28,8 @@ import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
  * supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [ComponentParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
- * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Custom options: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Service options: No annotation, however, I recommend injecting the service in the class instead.
  *
  * @see Components
  * @see Aggregate @Aggregate

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDAButtonListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDAButtonListener.kt
@@ -21,10 +21,9 @@ import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
  * - The declaring class must be annotated with [@Handler][Handler] or [@Command][Command].
  * - The annotation value to have same name as the one given to [PersistentButtonBuilder.bindTo].
  * - First parameter must be [ButtonEvent].
- * - Have all your consecutive user data, passed when creating the button.
  *
  * ### Option types
- * - User data: No annotation, the order must match the data passed when creating the button,
+ * - User data: Uses [@ComponentData][ComponentData], the order must match the data passed when creating the button,
  * supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [ComponentParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDASelectMenuListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDASelectMenuListener.kt
@@ -29,7 +29,8 @@ import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
  * supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [ComponentParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
- * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Custom options: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Service options: No annotation, however, I recommend injecting the service in the class instead.
  *
  * @see Components
  * @see Aggregate @Aggregate

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDASelectMenuListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDASelectMenuListener.kt
@@ -22,10 +22,9 @@ import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
  * - The declaring class must be annotated with [@Handler][Handler] or [@Command][Command].
  * - The annotation value to have same name as the one given to [IPersistentActionableComponent.bindTo].
  * - First parameter must be [StringSelectEvent]/[EntitySelectEvent].
- * - Have all your consecutive user data, passed when creating the select menu.
  *
  * ### Option types
- * - User data: No annotation, the order must match the data passed when creating the select menu,
+ * - User data: Uses [@ComponentData][ComponentData], the order must match the data passed when creating the select menu,
  * supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [ComponentParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/TimeoutData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/TimeoutData.kt
@@ -1,0 +1,15 @@
+package io.github.freya022.botcommands.api.components.annotations
+
+import io.github.freya022.botcommands.api.components.builder.IPersistentTimeoutableComponent
+
+/**
+ * Sets this parameter as data coming from [IPersistentTimeoutableComponent.timeout].
+ *
+ * The order and types of the passed data must match with the handler parameters.
+ *
+ * @see ComponentTimeoutHandler @ComponentTimeoutHandler
+ * @see GroupTimeoutHandler @GroupTimeoutHandler
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class TimeoutData

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/options/annotations/Aggregate.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/options/annotations/Aggregate.kt
@@ -1,5 +1,7 @@
 package io.github.freya022.botcommands.api.core.options.annotations
 
+import io.github.freya022.botcommands.api.components.annotations.ComponentTimeoutHandler
+import io.github.freya022.botcommands.api.components.annotations.GroupTimeoutHandler
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
 import io.github.freya022.botcommands.api.components.annotations.JDASelectMenuListener
 import io.github.freya022.botcommands.api.modals.annotations.ModalHandler
@@ -14,8 +16,12 @@ import io.github.freya022.botcommands.api.modals.annotations.ModalHandler
  *
  * **Note:** The first parameter can be the event or a subtype of it, but is optional.
  *
- * Can be used on parameters of [@ModalHandler][ModalHandler], [@JDASelectMenuListener][JDASelectMenuListener]
- * or [@JDAButtonListener][JDAButtonListener] functions.
+ * Can be used on parameters of:
+ * - [@ModalHandler][ModalHandler]
+ * - [@JDASelectMenuListener][JDASelectMenuListener]
+ * - [@JDAButtonListener][JDAButtonListener]
+ * - [@ComponentTimeoutHandler][ComponentTimeoutHandler]
+ * - [@GroupTimeoutHandler][GroupTimeoutHandler]
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/options/builder/OptionAggregateBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/options/builder/OptionAggregateBuilder.kt
@@ -1,6 +1,10 @@
 package io.github.freya022.botcommands.api.core.options.builder
 
+import io.github.freya022.botcommands.api.commands.builder.ServiceOptionBuilder
 import io.github.freya022.botcommands.api.core.options.annotations.Aggregate
+import io.github.freya022.botcommands.api.core.service.annotations.Condition
+import io.github.freya022.botcommands.api.core.service.annotations.ConditionalService
+import io.github.freya022.botcommands.api.core.service.annotations.Dependencies
 import io.github.freya022.botcommands.internal.commands.CommandDSL
 import io.github.freya022.botcommands.internal.core.options.builder.InternalAggregators.isSpecialAggregator
 import io.github.freya022.botcommands.internal.core.options.builder.OptionAggregateBuildersImpl
@@ -30,6 +34,21 @@ abstract class OptionAggregateBuilder<T : OptionAggregateBuilder<T>> internal co
         requireUser(aggregator.isSpecialAggregator() || aggregator.returnType == aggregatorParameter.typeCheckingParameter.type, aggregator) {
             "Aggregator should have the same return type as the parameter (required: ${aggregatorParameter.typeCheckingParameter.type}, found: ${aggregator.returnType})"
         }
+    }
+
+    /**
+     * Declares a service option, allowing injection of services, which must be available.
+     *
+     * If the service is not available, then either don't declare this command,
+     * or make the declaring class disabled by using one of:
+     * - [@Condition][Condition]
+     * - [@ConditionalService][ConditionalService]
+     * - [@Dependencies][Dependencies]
+     *
+     * @param declaredName Name of the declared parameter in the aggregator
+     */
+    fun serviceOption(declaredName: String) {
+        this += ServiceOptionBuilder(aggregatorParameter.toOptionParameter(aggregator, declaredName))
     }
 
     /**

--- a/src/main/kotlin/io/github/freya022/botcommands/api/modals/annotations/ModalHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/modals/annotations/ModalHandler.kt
@@ -26,7 +26,8 @@ import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
  * supported types and modifiers are in [ParameterResolver],
  * additional types can be added by implementing [ModalParameterResolver].
  * - [AppLocalizationContext]: Uses [@LocalizationBundle][LocalizationBundle].
- * - Custom options and services: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Custom options: No annotation, additional types can be added by implementing [ICustomResolver].
+ * - Service options: No annotation, however, I recommend injecting the service in the class instead.
  *
  * @see ModalData @ModalData
  * @see ModalInput @ModalInput

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
@@ -144,12 +144,6 @@ class ResolverContainer internal constructor(
         val factory = getResolverFactoryOrNull(resolverType, request)
         if (factory == null) {
             val wrapper = request.parameter
-            // Custom resolvers are often used for services
-            // if not one, make a simple error
-            if (!resolverType.isSubclassOf(ICustomResolver::class))
-                wrapper.throwUser("No ${resolverType.simpleNestedName} found for parameter '${wrapper.name}: ${wrapper.type.simpleNestedName}'.")
-
-            // If a service factory, add the error
             val serviceError = serviceContainer.tryGetWrappedService(wrapper.parameter).serviceError ?: throwInternal("Service became available after failing")
             wrapper.throwUser("No ${resolverType.simpleNestedName} found for parameter '${wrapper.name}: ${wrapper.type.simpleNestedName}' and service loading failed:\n${serviceError.toDetailedString()}")
         }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
@@ -4,7 +4,6 @@ import io.github.freya022.botcommands.api.core.annotations.BEventListener
 import io.github.freya022.botcommands.api.core.events.LoadEvent
 import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.reflect.throwUser
-import io.github.freya022.botcommands.api.core.reflect.wrap
 import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.utils.*
@@ -20,7 +19,6 @@ import net.dv8tion.jda.api.events.Event
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.reflect.KClass
-import kotlin.reflect.KParameter
 
 @BService
 class ResolverContainer internal constructor(
@@ -187,6 +185,3 @@ class ResolverContainer internal constructor(
         )
     }
 }
-
-internal fun ResolverContainer.hasCustomResolver(parameter: KParameter) =
-    hasResolverOfType<ICustomResolver<*, *>>(parameter.wrap())

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.core.annotations.BEventListener
 import io.github.freya022.botcommands.api.core.events.LoadEvent
 import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.reflect.throwUser
+import io.github.freya022.botcommands.api.core.reflect.wrap
 import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.utils.*
@@ -19,6 +20,7 @@ import net.dv8tion.jda.api.events.Event
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
 
 @BService
 class ResolverContainer internal constructor(
@@ -185,3 +187,6 @@ class ResolverContainer internal constructor(
         )
     }
 }
+
+internal fun ResolverContainer.hasCustomResolver(parameter: KParameter) =
+    hasResolverOfType<ICustomResolver<*, *>>(parameter.wrap())

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ResolverContainer.kt
@@ -4,11 +4,9 @@ import io.github.freya022.botcommands.api.core.annotations.BEventListener
 import io.github.freya022.botcommands.api.core.events.LoadEvent
 import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.reflect.throwUser
-import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.utils.*
 import io.github.freya022.botcommands.api.parameters.resolvers.*
-import io.github.freya022.botcommands.internal.core.service.tryGetWrappedService
 import io.github.freya022.botcommands.internal.parameters.toResolverFactory
 import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.freya022.botcommands.internal.utils.throwUser
@@ -21,7 +19,6 @@ import kotlin.reflect.KClass
 class ResolverContainer internal constructor(
     resolvers: List<ParameterResolver<*, *>>,
     resolverFactories: List<ParameterResolverFactory<*>>,
-    private val serviceContainer: ServiceContainer
 ) {
     private data class CacheKey(
         private val requestedType: KClass<out IParameterResolver<*>>,
@@ -118,8 +115,7 @@ class ResolverContainer internal constructor(
         val factory = getResolverFactoryOrNull(resolverType, request)
         if (factory == null) {
             val wrapper = request.parameter
-            val serviceError = serviceContainer.tryGetWrappedService(wrapper.parameter).serviceError ?: throwInternal("Service became available after failing")
-            wrapper.throwUser("No ${resolverType.simpleNestedName} found for parameter '${wrapper.name}: ${wrapper.type.simpleNestedName}' and service loading failed:\n${serviceError.toDetailedString()}")
+            wrapper.throwUser("No ${resolverType.simpleNestedName} found for parameter '${wrapper.name}: ${wrapper.type.simpleNestedName}'")
         }
 
         return factory.get(request)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/CommandOptions.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/CommandOptions.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.internal
 
 import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
 import io.github.freya022.botcommands.api.commands.builder.GeneratedOptionBuilder
+import io.github.freya022.botcommands.api.commands.builder.ServiceOptionBuilder
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.options.builder.OptionAggregateBuilder
 import io.github.freya022.botcommands.api.core.options.builder.OptionBuilder
@@ -17,6 +18,7 @@ import io.github.freya022.botcommands.internal.core.options.Option
 import io.github.freya022.botcommands.internal.core.options.builder.InternalAggregators.isSpecialAggregator
 import io.github.freya022.botcommands.internal.core.options.builder.InternalAggregators.isVarargAggregator
 import io.github.freya022.botcommands.internal.parameters.CustomMethodOption
+import io.github.freya022.botcommands.internal.parameters.ServiceMethodOption
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.nonEventParameters
 import io.github.freya022.botcommands.internal.utils.requireUser
 import io.github.freya022.botcommands.internal.utils.throwInternal
@@ -47,6 +49,7 @@ internal object CommandOptions {
                     config.transformOption(optionBuilder, resolver)
                 }
                 is GeneratedOptionBuilder -> optionBuilder.toGeneratedOption()
+                is ServiceOptionBuilder -> ServiceMethodOption(optionBuilder.optionParameter, context.serviceContainer)
                 is CustomOptionBuilder -> {
                     val parameter = optionBuilder.innerWrappedParameter
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/MethodParameters.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/MethodParameters.kt
@@ -1,5 +1,7 @@
 package io.github.freya022.botcommands.internal
 
+import io.github.freya022.botcommands.api.commands.builder.IDeclarationSiteHolder
+import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.options.annotations.Aggregate
 import io.github.freya022.botcommands.api.core.options.builder.OptionAggregateBuilder
 import io.github.freya022.botcommands.api.core.options.builder.OptionBuilder
@@ -10,6 +12,7 @@ import io.github.freya022.botcommands.internal.parameters.MethodParameter
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.function
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.nonInstanceParameters
 import io.github.freya022.botcommands.internal.utils.findDeclarationName
+import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.freya022.botcommands.internal.utils.throwUser
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
@@ -21,6 +24,12 @@ internal class BasicOptionAggregateBuilder(
     aggregatorParameter: AggregatorParameter,
     aggregator: KFunction<*>
 ) : OptionAggregateBuilder<BasicOptionAggregateBuilder>(aggregatorParameter, aggregator) {
+    override val context: BContext
+        get() = throwInternal("Internal aggregate builder should not be used outside of the += operator")
+
+    override val declarationSiteHolder: IDeclarationSiteHolder
+        get() = throwInternal("Internal aggregate builder should not be used outside of the += operator")
+
     override fun constructNestedAggregate(aggregatorParameter: AggregatorParameter, aggregator: KFunction<*>) =
         BasicOptionAggregateBuilder(aggregatorParameter, aggregator)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/ContextCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/ContextCommandAutoBuilder.kt
@@ -11,23 +11,29 @@ import io.github.freya022.botcommands.api.commands.application.provider.GlobalAp
 import io.github.freya022.botcommands.api.commands.application.provider.GuildApplicationCommandProvider
 import io.github.freya022.botcommands.api.core.config.BApplicationConfig
 import io.github.freya022.botcommands.api.core.reflect.ParameterType
+import io.github.freya022.botcommands.api.core.reflect.wrap
 import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.parameters.ResolverContainer
-import io.github.freya022.botcommands.internal.commands.autobuilder.requireCustomOption
-import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
+import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
+import io.github.freya022.botcommands.internal.commands.autobuilder.CommandAutoBuilder
+import io.github.freya022.botcommands.internal.commands.autobuilder.requireServiceOptionOrOptional
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.nonInstanceParameters
 import io.github.freya022.botcommands.internal.utils.findDeclarationName
 import io.github.freya022.botcommands.internal.utils.findOptionName
 import net.dv8tion.jda.api.entities.Guild
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.hasAnnotation
 
 internal sealed class ContextCommandAutoBuilder(
-    private val serviceContainer: ServiceContainer,
+    override val serviceContainer: ServiceContainer,
     applicationConfig: BApplicationConfig,
     private val resolverContainer: ResolverContainer
-) : GlobalApplicationCommandProvider, GuildApplicationCommandProvider {
+) : CommandAutoBuilder, GlobalApplicationCommandProvider, GuildApplicationCommandProvider {
+
+    override val optionAnnotation: KClass<out Annotation> = ContextOption::class
+
     protected val forceGuildCommands = applicationConfig.forceGuildCommands
 
     protected fun ApplicationCommandBuilder<*>.processOptions(
@@ -46,11 +52,11 @@ internal sealed class ContextCommandAutoBuilder(
             } else {
                 when (kParameter.findAnnotation<GeneratedOption>()) {
                     null -> {
-                        if (serviceContainer.canCreateWrappedService(kParameter) == null) {
-                            serviceOption(declaredName)
-                        } else {
-                            resolverContainer.requireCustomOption(func, kParameter, ContextOption::class)
+                        if (resolverContainer.hasResolverOfType<ICustomResolver<*, *>>(kParameter.wrap())) {
                             customOption(declaredName)
+                        } else {
+                            requireServiceOptionOrOptional(func, kParameter)
+                            serviceOption(declaredName)
                         }
                     }
                     else -> generatedOption(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/ContextCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/ContextCommandAutoBuilder.kt
@@ -11,8 +11,10 @@ import io.github.freya022.botcommands.api.commands.application.provider.GlobalAp
 import io.github.freya022.botcommands.api.commands.application.provider.GuildApplicationCommandProvider
 import io.github.freya022.botcommands.api.core.config.BApplicationConfig
 import io.github.freya022.botcommands.api.core.reflect.ParameterType
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.parameters.ResolverContainer
 import io.github.freya022.botcommands.internal.commands.autobuilder.requireCustomOption
+import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.nonInstanceParameters
 import io.github.freya022.botcommands.internal.utils.findDeclarationName
 import io.github.freya022.botcommands.internal.utils.findOptionName
@@ -22,6 +24,7 @@ import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.hasAnnotation
 
 internal sealed class ContextCommandAutoBuilder(
+    private val serviceContainer: ServiceContainer,
     applicationConfig: BApplicationConfig,
     private val resolverContainer: ResolverContainer
 ) : GlobalApplicationCommandProvider, GuildApplicationCommandProvider {
@@ -34,19 +37,24 @@ internal sealed class ContextCommandAutoBuilder(
         commandId: String?
     ) {
         func.nonInstanceParameters.drop(1).forEach { kParameter ->
+            val declaredName = kParameter.findDeclarationName()
             if (kParameter.hasAnnotation<ContextOption>()) {
                 when (this) {
-                    is UserCommandBuilder -> option(kParameter.findDeclarationName())
-                    is MessageCommandBuilder -> option(kParameter.findDeclarationName())
+                    is UserCommandBuilder -> option(declaredName)
+                    is MessageCommandBuilder -> option(declaredName)
                 }
             } else {
                 when (kParameter.findAnnotation<GeneratedOption>()) {
                     null -> {
-                        resolverContainer.requireCustomOption(func, kParameter, ContextOption::class)
-                        customOption(kParameter.findDeclarationName())
+                        if (serviceContainer.canCreateWrappedService(kParameter) == null) {
+                            serviceOption(declaredName)
+                        } else {
+                            resolverContainer.requireCustomOption(func, kParameter, ContextOption::class)
+                            customOption(declaredName)
+                        }
                     }
                     else -> generatedOption(
-                        kParameter.findDeclarationName(), instance.getGeneratedValueSupplier(
+                        declaredName, instance.getGeneratedValueSupplier(
                             guild,
                             commandId,
                             CommandPath.ofName(name),

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/ContextCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/ContextCommandAutoBuilder.kt
@@ -39,6 +39,7 @@ internal sealed class ContextCommandAutoBuilder(
     protected fun ApplicationCommandBuilder<*>.processOptions(
         guild: Guild?,
         func: KFunction<*>,
+        commandAnnotation: KClass<out Annotation>,
         instance: ApplicationCommand,
         commandId: String?
     ) {
@@ -55,7 +56,7 @@ internal sealed class ContextCommandAutoBuilder(
                         if (resolverContainer.hasResolverOfType<ICustomResolver<*, *>>(kParameter.wrap())) {
                             customOption(declaredName)
                         } else {
-                            requireServiceOptionOrOptional(func, kParameter)
+                            requireServiceOptionOrOptional(func, kParameter, commandAnnotation)
                             serviceOption(declaredName)
                         }
                     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/MessageContextCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/MessageContextCommandAutoBuilder.kt
@@ -10,6 +10,7 @@ import io.github.freya022.botcommands.api.commands.application.provider.Abstract
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GuildApplicationCommandManager
 import io.github.freya022.botcommands.api.core.config.BApplicationConfig
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.parameters.ResolverContainer
 import io.github.freya022.botcommands.internal.commands.SkipLogger
@@ -30,8 +31,9 @@ private val logger = KotlinLogging.logger { }
 internal class MessageContextCommandAutoBuilder(
     applicationConfig: BApplicationConfig,
     resolverContainer: ResolverContainer,
-    functionAnnotationsMap: FunctionAnnotationsMap
-) : ContextCommandAutoBuilder(applicationConfig, resolverContainer) {
+    functionAnnotationsMap: FunctionAnnotationsMap,
+    serviceContainer: ServiceContainer
+) : ContextCommandAutoBuilder(serviceContainer, applicationConfig, resolverContainer) {
     private val messageFunctions: List<MessageContextFunctionMetadata>
 
     init {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/MessageContextCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/MessageContextCommandAutoBuilder.kt
@@ -84,7 +84,7 @@ internal class MessageContextCommandAutoBuilder(
             isDefaultLocked = annotation.defaultLocked
             nsfw = annotation.nsfw
 
-            processOptions((manager as? GuildApplicationCommandManager)?.guild, func, instance, commandId)
+            processOptions((manager as? GuildApplicationCommandManager)?.guild, func, JDAMessageCommand::class, instance, commandId)
         }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/SlashCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/SlashCommandAutoBuilder.kt
@@ -302,7 +302,7 @@ internal class SlashCommandAutoBuilder(
                         if (resolverContainer.hasResolverOfType<ICustomResolver<*, *>>(kParameter.wrap())) {
                             customOption(declaredName)
                         } else {
-                            requireServiceOptionOrOptional(func, kParameter)
+                            requireServiceOptionOrOptional(func, kParameter, JDASlashCommand::class)
                             serviceOption(declaredName)
                         }
                     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/UserContextCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/UserContextCommandAutoBuilder.kt
@@ -10,6 +10,7 @@ import io.github.freya022.botcommands.api.commands.application.provider.Abstract
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GuildApplicationCommandManager
 import io.github.freya022.botcommands.api.core.config.BApplicationConfig
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.parameters.ResolverContainer
 import io.github.freya022.botcommands.internal.commands.SkipLogger
@@ -30,8 +31,9 @@ private val logger = KotlinLogging.logger { }
 internal class UserContextCommandAutoBuilder(
     applicationConfig: BApplicationConfig,
     resolverContainer: ResolverContainer,
-    functionAnnotationsMap: FunctionAnnotationsMap
-) : ContextCommandAutoBuilder(applicationConfig, resolverContainer) {
+    functionAnnotationsMap: FunctionAnnotationsMap,
+    serviceContainer: ServiceContainer
+) : ContextCommandAutoBuilder(serviceContainer, applicationConfig, resolverContainer) {
     private val userFunctions: List<UserContextFunctionMetadata>
 
     init {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/UserContextCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/UserContextCommandAutoBuilder.kt
@@ -84,7 +84,7 @@ internal class UserContextCommandAutoBuilder(
             isDefaultLocked = annotation.defaultLocked
             nsfw = annotation.nsfw
 
-            processOptions((manager as? GuildApplicationCommandManager)?.guild, func, instance, commandId)
+            processOptions((manager as? GuildApplicationCommandManager)?.guild, func, JDAUserCommand::class, instance, commandId)
         }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfo.kt
@@ -80,7 +80,7 @@ class MessageCommandInfo internal constructor(
 
                 option.getCheckedDefaultValue { it.generatedValueSupplier.getDefaultValue(event) }
             }
-            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.SERVICE -> (option as ServiceMethodOption).getService()
             OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")
         }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfo.kt
@@ -16,6 +16,7 @@ import io.github.freya022.botcommands.internal.core.options.OptionType
 import io.github.freya022.botcommands.internal.core.reflection.checkEventScope
 import io.github.freya022.botcommands.internal.core.reflection.toMemberParamFunction
 import io.github.freya022.botcommands.internal.parameters.CustomMethodOption
+import io.github.freya022.botcommands.internal.parameters.ServiceMethodOption
 import io.github.freya022.botcommands.internal.transform
 import io.github.freya022.botcommands.internal.utils.*
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
@@ -79,7 +80,8 @@ class MessageCommandInfo internal constructor(
 
                 option.getCheckedDefaultValue { it.generatedValueSupplier.getDefaultValue(event) }
             }
-            else -> throwInternal("${option.optionType} has not been implemented")
+            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")
         }
 
         return tryInsertNullableOption(value, option, optionMap)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfo.kt
@@ -16,6 +16,7 @@ import io.github.freya022.botcommands.internal.core.options.OptionType
 import io.github.freya022.botcommands.internal.core.reflection.checkEventScope
 import io.github.freya022.botcommands.internal.core.reflection.toMemberParamFunction
 import io.github.freya022.botcommands.internal.parameters.CustomMethodOption
+import io.github.freya022.botcommands.internal.parameters.ServiceMethodOption
 import io.github.freya022.botcommands.internal.transform
 import io.github.freya022.botcommands.internal.utils.*
 import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEvent
@@ -79,7 +80,8 @@ class UserCommandInfo internal constructor(
 
                 option.getCheckedDefaultValue { it.generatedValueSupplier.getDefaultValue(event) }
             }
-            else -> throwInternal("${option.optionType} has not been implemented")
+            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")
         }
 
         return tryInsertNullableOption(value, option, optionMap)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfo.kt
@@ -80,7 +80,7 @@ class UserCommandInfo internal constructor(
 
                 option.getCheckedDefaultValue { it.generatedValueSupplier.getDefaultValue(event) }
             }
-            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.SERVICE -> (option as ServiceMethodOption).getService()
             OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")
         }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandInfo.kt
@@ -135,7 +135,7 @@ abstract class SlashCommandInfo internal constructor(
 
                 option.getCheckedDefaultValue { it.generatedValueSupplier.getDefaultValue(event) }
             }
-            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.SERVICE -> (option as ServiceMethodOption).getService()
             OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")
         }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandInfo.kt
@@ -17,6 +17,7 @@ import io.github.freya022.botcommands.internal.core.options.isRequired
 import io.github.freya022.botcommands.internal.core.reflection.checkEventScope
 import io.github.freya022.botcommands.internal.core.reflection.toMemberParamFunction
 import io.github.freya022.botcommands.internal.parameters.CustomMethodOption
+import io.github.freya022.botcommands.internal.parameters.ServiceMethodOption
 import io.github.freya022.botcommands.internal.utils.*
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.events.Event
@@ -134,9 +135,8 @@ abstract class SlashCommandInfo internal constructor(
 
                 option.getCheckedDefaultValue { it.generatedValueSupplier.getDefaultValue(event) }
             }
-            else -> {
-                throwInternal("${option.optionType} has not been implemented")
-            }
+            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")
         }
 
         return tryInsertNullableOption(value, option, optionMap)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/autobuilder/AutoBuilderUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/autobuilder/AutoBuilderUtils.kt
@@ -24,6 +24,7 @@ import io.github.freya022.botcommands.internal.commands.ratelimit.readRateLimit
 import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.utils.*
 import io.github.freya022.botcommands.internal.utils.ReflectionMetadata.isNullable
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
@@ -183,9 +184,10 @@ internal fun ApplicationCommandBuilder<*>.fillApplicationCommandBuilder(func: KF
     }
 }
 
-internal fun CommandAutoBuilder.requireServiceOptionOrOptional(func: KFunction<*>, kParameter: KParameter) {
+internal fun CommandAutoBuilder.requireServiceOptionOrOptional(func: KFunction<*>, kParameter: KParameter, commandAnnotation: KClass<out Annotation>) {
     val isOptional = kParameter.isNullable || kParameter.isOptional
     requireUser(isOptional || serviceContainer.canCreateWrappedService(kParameter) == null, func) {
-        "Cannot determine usage of option '${kParameter.bestName}' (${kParameter.type.simpleNestedName}), if this is a Discord option, use @${optionAnnotation.simpleNestedName}, check the handler docs for more details"
+        "Cannot determine usage of option '${kParameter.bestName}' (${kParameter.type.simpleNestedName}), " +
+                "if this is a Discord option, use @${optionAnnotation.simpleNestedName}, check @${commandAnnotation.simpleNestedName} for more details"
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/autobuilder/CommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/autobuilder/CommandAutoBuilder.kt
@@ -1,0 +1,10 @@
+package io.github.freya022.botcommands.internal.commands.autobuilder
+
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
+import kotlin.reflect.KClass
+
+internal interface CommandAutoBuilder {
+    val serviceContainer: ServiceContainer
+    val optionAnnotation: KClass<out Annotation>
+}
+

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandVariation.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandVariation.kt
@@ -152,7 +152,7 @@ class TextCommandVariation internal constructor(
                 option.getCheckedDefaultValue { it.generatedValueSupplier.getDefaultValue(event) }
             }
 
-            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.SERVICE -> (option as ServiceMethodOption).getService()
 
             OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")
         }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandVariation.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandVariation.kt
@@ -17,6 +17,7 @@ import io.github.freya022.botcommands.internal.core.options.Option
 import io.github.freya022.botcommands.internal.core.options.OptionType
 import io.github.freya022.botcommands.internal.core.reflection.toMemberParamFunction
 import io.github.freya022.botcommands.internal.parameters.CustomMethodOption
+import io.github.freya022.botcommands.internal.parameters.ServiceMethodOption
 import io.github.freya022.botcommands.internal.transform
 import io.github.freya022.botcommands.internal.utils.*
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -151,7 +152,9 @@ class TextCommandVariation internal constructor(
                 option.getCheckedDefaultValue { it.generatedValueSupplier.getDefaultValue(event) }
             }
 
-            else -> throwInternal("${option.optionType} has not been implemented")
+            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+
+            OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")
         }
 
         return tryInsertNullableOption(value, option, optionMap)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/autobuilder/TextCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/autobuilder/TextCommandAutoBuilder.kt
@@ -224,7 +224,7 @@ internal class TextCommandAutoBuilder(
                         if (resolverContainer.hasResolverOfType<ICustomResolver<*, *>>(kParameter.wrap())) {
                             customOption(declaredName)
                         } else {
-                            requireServiceOptionOrOptional(func, kParameter)
+                            requireServiceOptionOrOptional(func, kParameter, JDATextCommandVariation::class)
                             serviceOption(declaredName)
                         }
                     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentTimeoutManager.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentTimeoutManager.kt
@@ -21,7 +21,7 @@ import io.github.freya022.botcommands.internal.components.timeout.TimeoutHandler
 import io.github.freya022.botcommands.internal.core.ExceptionHandler
 import io.github.freya022.botcommands.internal.core.options.Option
 import io.github.freya022.botcommands.internal.core.options.OptionType
-import io.github.freya022.botcommands.internal.parameters.CustomMethodOption
+import io.github.freya022.botcommands.internal.parameters.ServiceMethodOption
 import io.github.freya022.botcommands.internal.utils.*
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
@@ -29,7 +29,6 @@ import kotlinx.coroutines.Job
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.reflect.full.callSuspendBy
-import kotlin.reflect.jvm.jvmErasure
 
 private val logger = KotlinLogging.logger { }
 
@@ -130,14 +129,8 @@ internal class ComponentTimeoutManager(
 
                 userDataIterator.next()?.let { option.resolver.resolveSuspend(it) }
             }
-            OptionType.CUSTOM -> {
-                option as CustomMethodOption
-
-                //TODO add CONSTANT option type, make services use it
-                serviceContainer.getService(option.type.jvmErasure)
-//                option.resolver.resolveSuspend(descriptor, event)
-            }
-            else -> throwInternal("${option.optionType} has not been implemented")
+            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.CUSTOM, OptionType.CONSTANT, OptionType.GENERATED -> throwInternal("${option.optionType} has not been implemented")
         }
 
         return tryInsertNullableOption(value, option, optionMap)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentTimeoutManager.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentTimeoutManager.kt
@@ -129,7 +129,7 @@ internal class ComponentTimeoutManager(
 
                 userDataIterator.next()?.let { option.resolver.resolveSuspend(it) }
             }
-            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.SERVICE -> (option as ServiceMethodOption).getService()
             OptionType.CUSTOM, OptionType.CONSTANT, OptionType.GENERATED -> throwInternal("${option.optionType} has not been implemented")
         }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
@@ -246,7 +246,7 @@ internal class ComponentsListener(
 
                 option.resolver.resolveSuspend(descriptor, event)
             }
-            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.SERVICE -> (option as ServiceMethodOption).getService()
             OptionType.GENERATED, OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")
         }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
@@ -33,6 +33,7 @@ import io.github.freya022.botcommands.internal.core.options.Option
 import io.github.freya022.botcommands.internal.core.options.OptionType
 import io.github.freya022.botcommands.internal.core.options.isRequired
 import io.github.freya022.botcommands.internal.parameters.CustomMethodOption
+import io.github.freya022.botcommands.internal.parameters.ServiceMethodOption
 import io.github.freya022.botcommands.internal.utils.*
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.datetime.Clock
@@ -245,7 +246,8 @@ internal class ComponentsListener(
 
                 option.resolver.resolveSuspend(descriptor, event)
             }
-            else -> throwInternal("${option.optionType} has not been implemented")
+            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.GENERATED, OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")
         }
 
         return tryInsertNullableOption(value, option, optionMap)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
@@ -1,6 +1,12 @@
 package io.github.freya022.botcommands.internal.components.handler
 
+import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
 import io.github.freya022.botcommands.api.commands.builder.ServiceOptionBuilder
+import io.github.freya022.botcommands.api.components.annotations.ComponentData
+import io.github.freya022.botcommands.api.core.Logging.toUnwrappedLogger
+import io.github.freya022.botcommands.api.core.service.getService
+import io.github.freya022.botcommands.api.parameters.ResolverContainer
+import io.github.freya022.botcommands.api.parameters.hasCustomResolver
 import io.github.freya022.botcommands.internal.IExecutableInteractionInfo
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
@@ -8,7 +14,11 @@ import io.github.freya022.botcommands.internal.core.reflection.MemberParamFuncti
 import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
 import io.github.freya022.botcommands.internal.transformParameters
+import io.github.freya022.botcommands.internal.utils.ReflectionUtils.declaringClass
+import io.github.freya022.botcommands.internal.utils.annotationRef
+import io.github.freya022.botcommands.internal.utils.shortSignature
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
+import kotlin.reflect.full.hasAnnotation
 
 class ComponentDescriptor internal constructor(
     context: BContextImpl,
@@ -17,12 +27,23 @@ class ComponentDescriptor internal constructor(
     override val parameters: List<ComponentHandlerParameter>
 
     init {
+        val resolverContainer = context.getService<ResolverContainer>()
         parameters = eventFunction.transformParameters(
             builderBlock = { function, parameter, declaredName ->
-                when (context.serviceContainer.canCreateWrappedService(parameter)) {
-                    //No error => is a service
-                    null -> ServiceOptionBuilder(OptionParameter.fromSelfAggregate(function, declaredName))
-                    else -> ComponentHandlerOptionBuilder(OptionParameter.fromSelfAggregate(function, declaredName))
+                val optionParameter = OptionParameter.fromSelfAggregate(function, declaredName)
+                if (parameter.hasAnnotation<ComponentData>()) {
+                    ComponentHandlerOptionBuilder(optionParameter)
+                } else if (resolverContainer.hasCustomResolver(parameter)) {
+                    CustomOptionBuilder(optionParameter)
+                } else {
+                    if (context.serviceContainer.canCreateWrappedService(parameter) == null) {
+                        return@transformParameters ServiceOptionBuilder(optionParameter)
+                    }
+
+                    //TODO remove
+                    function.declaringClass.java.toUnwrappedLogger()
+                        .warn { "Component data parameter '$declaredName' must be annotated with ${annotationRef<ComponentData>()}, it will be enforced in a later release, in ${function.shortSignature}" }
+                    ComponentHandlerOptionBuilder(optionParameter)
                 }
             },
             aggregateBlock = { ComponentHandlerParameter(context, it) }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
@@ -13,7 +13,7 @@ import io.github.freya022.botcommands.internal.core.options.OptionType
 import io.github.freya022.botcommands.internal.core.reflection.MemberParamFunction
 import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
-import io.github.freya022.botcommands.internal.parameters.toServiceOrCustomOptionBuilder
+import io.github.freya022.botcommands.internal.parameters.toFallbackOptionBuilder
 import io.github.freya022.botcommands.internal.transformParameters
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.declaringClass
 import io.github.freya022.botcommands.internal.utils.annotationRef
@@ -45,7 +45,7 @@ class ComponentDescriptor internal constructor(
                         ComponentHandlerOptionBuilder(optionParameter)
                     }
                 } else {
-                    optionParameter.toServiceOrCustomOptionBuilder(context.serviceContainer)
+                    optionParameter.toFallbackOptionBuilder(context.serviceContainer, resolverContainer)
                 }
             },
             aggregateBlock = { ComponentHandlerParameter(context, it) }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
@@ -1,14 +1,14 @@
 package io.github.freya022.botcommands.internal.components.handler
 
-import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
+import io.github.freya022.botcommands.api.commands.builder.ServiceOptionBuilder
 import io.github.freya022.botcommands.internal.IExecutableInteractionInfo
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 import io.github.freya022.botcommands.internal.core.reflection.MemberParamFunction
+import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
 import io.github.freya022.botcommands.internal.transformParameters
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
-import kotlin.reflect.jvm.jvmErasure
 
 class ComponentDescriptor internal constructor(
     context: BContextImpl,
@@ -19,9 +19,9 @@ class ComponentDescriptor internal constructor(
     init {
         parameters = eventFunction.transformParameters(
             builderBlock = { function, parameter, declaredName ->
-                when (context.serviceContainer.canCreateService(parameter.type.jvmErasure)) {
+                when (context.serviceContainer.canCreateWrappedService(parameter)) {
                     //No error => is a service
-                    null -> CustomOptionBuilder(OptionParameter.fromSelfAggregate(function, declaredName))
+                    null -> ServiceOptionBuilder(OptionParameter.fromSelfAggregate(function, declaredName))
                     else -> ComponentHandlerOptionBuilder(OptionParameter.fromSelfAggregate(function, declaredName))
                 }
             },

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
@@ -1,18 +1,19 @@
 package io.github.freya022.botcommands.internal.components.handler
 
 import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
-import io.github.freya022.botcommands.api.commands.builder.ServiceOptionBuilder
 import io.github.freya022.botcommands.api.components.annotations.ComponentData
 import io.github.freya022.botcommands.api.core.Logging.toUnwrappedLogger
+import io.github.freya022.botcommands.api.core.reflect.wrap
 import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.parameters.ResolverContainer
-import io.github.freya022.botcommands.api.parameters.hasCustomResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
 import io.github.freya022.botcommands.internal.IExecutableInteractionInfo
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 import io.github.freya022.botcommands.internal.core.reflection.MemberParamFunction
 import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
+import io.github.freya022.botcommands.internal.parameters.toServiceOrCustomOptionBuilder
 import io.github.freya022.botcommands.internal.transformParameters
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.declaringClass
 import io.github.freya022.botcommands.internal.utils.annotationRef
@@ -33,17 +34,18 @@ class ComponentDescriptor internal constructor(
                 val optionParameter = OptionParameter.fromSelfAggregate(function, declaredName)
                 if (parameter.hasAnnotation<ComponentData>()) {
                     ComponentHandlerOptionBuilder(optionParameter)
-                } else if (resolverContainer.hasCustomResolver(parameter)) {
-                    CustomOptionBuilder(optionParameter)
-                } else {
-                    if (context.serviceContainer.canCreateWrappedService(parameter) == null) {
-                        return@transformParameters ServiceOptionBuilder(optionParameter)
-                    }
-
-                    //TODO remove
+                } else if (/* TODO remove */ context.serviceContainer.canCreateWrappedService(parameter) != null) {
+                    // Fallback to component data if no service is found
                     function.declaringClass.java.toUnwrappedLogger()
                         .warn { "Component data parameter '$declaredName' must be annotated with ${annotationRef<ComponentData>()}, it will be enforced in a later release, in ${function.shortSignature}" }
-                    ComponentHandlerOptionBuilder(optionParameter)
+
+                    if (resolverContainer.hasResolverOfType<ICustomResolver<*, *>>(parameter.wrap())) {
+                        CustomOptionBuilder(optionParameter)
+                    } else {
+                        ComponentHandlerOptionBuilder(optionParameter)
+                    }
+                } else {
+                    optionParameter.toServiceOrCustomOptionBuilder(context.serviceContainer)
                 }
             },
             aggregateBlock = { ComponentHandlerParameter(context, it) }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
@@ -1,14 +1,14 @@
 package io.github.freya022.botcommands.internal.components.timeout
 
-import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
+import io.github.freya022.botcommands.api.commands.builder.ServiceOptionBuilder
 import io.github.freya022.botcommands.internal.IExecutableInteractionInfo
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 import io.github.freya022.botcommands.internal.core.reflection.MemberParamFunction
+import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
 import io.github.freya022.botcommands.internal.transformParameters
 import kotlin.reflect.KClass
-import kotlin.reflect.jvm.jvmErasure
 
 internal class TimeoutDescriptor<T : Any> internal constructor(
     context: BContextImpl,
@@ -20,9 +20,9 @@ internal class TimeoutDescriptor<T : Any> internal constructor(
     init {
         parameters = eventFunction.transformParameters(
             builderBlock = { function, parameter, declaredName ->
-                when (context.serviceContainer.canCreateService(parameter.type.jvmErasure)) {
+                when (context.serviceContainer.canCreateWrappedService(parameter)) {
                     //No error => is a service
-                    null -> CustomOptionBuilder(OptionParameter.fromSelfAggregate(function, declaredName))
+                    null -> ServiceOptionBuilder(OptionParameter.fromSelfAggregate(function, declaredName))
                     else -> TimeoutHandlerOptionBuilder(OptionParameter.fromSelfAggregate(function, declaredName))
                 }
             },

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
@@ -1,6 +1,8 @@
 package io.github.freya022.botcommands.internal.components.timeout
 
 import io.github.freya022.botcommands.api.commands.builder.ServiceOptionBuilder
+import io.github.freya022.botcommands.api.components.annotations.TimeoutData
+import io.github.freya022.botcommands.api.core.Logging.toUnwrappedLogger
 import io.github.freya022.botcommands.internal.IExecutableInteractionInfo
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
@@ -8,7 +10,11 @@ import io.github.freya022.botcommands.internal.core.reflection.MemberParamFuncti
 import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
 import io.github.freya022.botcommands.internal.transformParameters
+import io.github.freya022.botcommands.internal.utils.ReflectionUtils.declaringClass
+import io.github.freya022.botcommands.internal.utils.annotationRef
+import io.github.freya022.botcommands.internal.utils.shortSignature
 import kotlin.reflect.KClass
+import kotlin.reflect.full.hasAnnotation
 
 internal class TimeoutDescriptor<T : Any> internal constructor(
     context: BContextImpl,
@@ -20,10 +26,22 @@ internal class TimeoutDescriptor<T : Any> internal constructor(
     init {
         parameters = eventFunction.transformParameters(
             builderBlock = { function, parameter, declaredName ->
-                when (context.serviceContainer.canCreateWrappedService(parameter)) {
-                    //No error => is a service
-                    null -> ServiceOptionBuilder(OptionParameter.fromSelfAggregate(function, declaredName))
-                    else -> TimeoutHandlerOptionBuilder(OptionParameter.fromSelfAggregate(function, declaredName))
+                val optionParameter = OptionParameter.fromSelfAggregate(function, declaredName)
+                if (parameter.hasAnnotation<TimeoutData>()) {
+                    TimeoutHandlerOptionBuilder(optionParameter)
+                } else if (/* TODO remove */ context.serviceContainer.canCreateWrappedService(parameter) != null) {
+                    // Fallback to timeout data if no service is found
+                    function.declaringClass.java.toUnwrappedLogger()
+                        .warn { "Timeout data parameter '$declaredName' must be annotated with ${annotationRef<TimeoutData>()}, it will be enforced in a later release, in ${function.shortSignature}" }
+
+                    TimeoutHandlerOptionBuilder(optionParameter)
+                } else {
+                    val serviceError = context.serviceContainer.canCreateWrappedService(parameter)
+                    require(serviceError == null) {
+                        "Could not get service parameter for '$declaredName', in ${function.shortSignature}, did you forget to use ${annotationRef<TimeoutData>()}?\n${serviceError!!.toDetailedString()}"
+                    }
+
+                    ServiceOptionBuilder(optionParameter)
                 }
             },
             aggregateBlock = { TimeoutHandlerParameter(context, it, aggregatorFirstParamType) }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/options/Option.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/options/Option.kt
@@ -17,6 +17,7 @@ enum class OptionType {
     OPTION,
     CUSTOM,
     CONSTANT, //TODO
+    SERVICE,
     GENERATED;
 
     override fun toString(): String {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
@@ -137,7 +137,7 @@ class ModalHandlerInfo internal constructor(
                 option.resolver.resolveSuspend(this, event)
             }
 
-            OptionType.SERVICE -> (option as ServiceMethodOption).lazyService.value
+            OptionType.SERVICE -> (option as ServiceMethodOption).getService()
 
             OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")
         }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
@@ -2,9 +2,11 @@ package io.github.freya022.botcommands.internal.modals
 
 import gnu.trove.map.TObjectLongMap
 import gnu.trove.map.hash.TObjectLongHashMap
+import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.modals.annotations.ModalHandler
 import io.github.freya022.botcommands.api.modals.annotations.ModalInput
+import io.github.freya022.botcommands.api.parameters.ResolverContainer
 import io.github.freya022.botcommands.internal.IExecutableInteractionInfo
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.Option
@@ -13,7 +15,7 @@ import io.github.freya022.botcommands.internal.core.reflection.MemberParamFuncti
 import io.github.freya022.botcommands.internal.parameters.CustomMethodOption
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
 import io.github.freya022.botcommands.internal.parameters.ServiceMethodOption
-import io.github.freya022.botcommands.internal.parameters.toServiceOrCustomOptionBuilder
+import io.github.freya022.botcommands.internal.parameters.toFallbackOptionBuilder
 import io.github.freya022.botcommands.internal.requireUser
 import io.github.freya022.botcommands.internal.throwUser
 import io.github.freya022.botcommands.internal.transformParameters
@@ -40,6 +42,7 @@ class ModalHandlerInfo internal constructor(
         val annotation = function.findAnnotation<ModalHandler>()!!
         handlerName = annotation.name
 
+        val resolverContainer = context.serviceContainer.getService<ResolverContainer>()
         parameters = eventFunction.transformParameters(
             builderBlock = { function, parameter, declaredName ->
                 val optionParameter = OptionParameter.fromSelfAggregate(function, declaredName)
@@ -48,7 +51,7 @@ class ModalHandlerInfo internal constructor(
                 } else if (parameter.hasAnnotation<ModalDataAnnotation>()) {
                     ModalHandlerDataOptionBuilder(optionParameter)
                 } else {
-                    optionParameter.toServiceOrCustomOptionBuilder(context.serviceContainer)
+                    optionParameter.toFallbackOptionBuilder(context.serviceContainer, resolverContainer)
                 }
             },
             aggregateBlock = { ModalHandlerParameter(context, it) }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/OptionParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/OptionParameter.kt
@@ -1,5 +1,10 @@
 package io.github.freya022.botcommands.internal.parameters
 
+import io.github.freya022.botcommands.api.commands.builder.CustomOptionBuilder
+import io.github.freya022.botcommands.api.commands.builder.ServiceOptionBuilder
+import io.github.freya022.botcommands.api.core.options.builder.OptionBuilder
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
+import io.github.freya022.botcommands.internal.core.service.provider.canCreateWrappedService
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.nonInstanceParameters
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.reflectReference
 import io.github.freya022.botcommands.internal.utils.findDeclarationName
@@ -25,5 +30,16 @@ class OptionParameter(
     companion object {
         fun fromSelfAggregate(commandFunction: KFunction<*>, parameterName: String) =
             SingleAggregatorParameter(commandFunction, parameterName).toOptionParameter(commandFunction, parameterName)
+    }
+}
+
+internal fun OptionParameter.toServiceOrCustomOptionBuilder(serviceContainer: ServiceContainer): OptionBuilder {
+    return if (serviceContainer.canCreateWrappedService(typeCheckingParameter) == null) {
+        ServiceOptionBuilder(this)
+    } else {
+        // Custom options being the fallback are important,
+        // as if the parameter has no compatible resolver,
+        // it will print both the required resolver AND the service error
+        CustomOptionBuilder(this)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ServiceMethodOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ServiceMethodOption.kt
@@ -1,0 +1,16 @@
+package io.github.freya022.botcommands.internal.parameters
+
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
+import io.github.freya022.botcommands.internal.core.options.OptionImpl
+import io.github.freya022.botcommands.internal.core.options.OptionType
+import io.github.freya022.botcommands.internal.core.service.tryGetWrappedService
+
+class ServiceMethodOption private constructor(
+    optionParameter: OptionParameter,
+    val lazyService: Lazy<*>
+) : OptionImpl(optionParameter, OptionType.SERVICE) {
+    internal constructor(
+        optionParameter: OptionParameter,
+        serviceContainer: ServiceContainer
+    ) : this(optionParameter, lazy { serviceContainer.tryGetWrappedService(optionParameter.typeCheckingParameter).getOrThrow() })
+}

--- a/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashSayAgainPersistent.kt
+++ b/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashSayAgainPersistent.kt
@@ -10,6 +10,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
 import io.github.freya022.botcommands.api.components.Buttons
+import io.github.freya022.botcommands.api.components.annotations.ComponentData
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.components.builder.bindTo
@@ -44,7 +45,7 @@ class SlashSayAgainPersistent : ApplicationCommand() {
     }
 
     @JDAButtonListener("SlashSayAgainPersistent: saySentenceButton")
-    suspend fun onSaySentenceClick(event: ButtonEvent, sentence: String) {
+    suspend fun onSaySentenceClick(event: ButtonEvent, @ComponentData sentence: String) {
         event.reply_(sentence, ephemeral = true).await()
     }
 }

--- a/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashSelectRolePersistent.kt
+++ b/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashSelectRolePersistent.kt
@@ -7,6 +7,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashE
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
 import io.github.freya022.botcommands.api.components.SelectMenus
+import io.github.freya022.botcommands.api.components.annotations.ComponentData
 import io.github.freya022.botcommands.api.components.annotations.JDASelectMenuListener
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.components.builder.bindTo
@@ -39,7 +40,7 @@ class SlashSelectRolePersistent : ApplicationCommand() {
     }
 
     @JDASelectMenuListener("SlashSelectRolePersistent: roleMenu")
-    suspend fun onRoleMenuSelect(event: EntitySelectEvent, randomNumber: Long) {
+    suspend fun onRoleMenuSelect(event: EntitySelectEvent, @ComponentData randomNumber: Long) {
         val role = event.values[0] as Role
         event.reply("You have been given " + role.asMention + ", and the random number is " + randomNumber)
             .setEphemeral(true)

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashDI.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashDI.kt
@@ -36,7 +36,7 @@ class SlashDI internal constructor(
         filters: List<ApplicationCommandFilter<*>>,
         databaseLazy: Lazy<BlockingDatabase>,
         unusableLazy: Lazy<UnusedInterfacedService?>,
-        @ServiceName("firstReadyListenerNope") inexistantListener: ReadyListener?,
+        @ServiceName("firstReadyListenerNope") inexistantListener: ReadyListener,
         @ServiceName("fakeDefaultEmbedSupplier") defaultService: DefaultEmbedSupplier = DefaultEmbedSupplier.Default()
     ) {
         event.reply_(

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashModal.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashModal.kt
@@ -82,7 +82,7 @@ class SlashModal(private val buttons: Buttons) : ApplicationCommand(), GlobalApp
 
     override fun declareGlobalApplicationCommands(manager: GlobalApplicationCommandManager) {
         manager.slashCommand("modal", function = ::onSlashModal) {
-            customOption("modals")
+            serviceOption("modals")
         }
     }
 }

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashMyCommand.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashMyCommand.kt
@@ -119,7 +119,7 @@ class SlashMyCommand : ApplicationCommand(), GlobalApplicationCommandProvider, A
 
                     option("channelOption")
 
-                    customOption("custom")
+                    serviceOption("custom")
 
                     option("autocompleteStr") {
                         description = "Autocomplete !"

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashNewButtons.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashNewButtons.kt
@@ -124,12 +124,12 @@ class SlashNewButtons(
     }
 
     @ComponentTimeoutHandler("SlashNewButtons: persistentButtonTimeout")
-    fun onTimeoutEdButtonTimeout(data: ComponentTimeoutData, nullObj: String?) {
+    fun onTimeoutEdButtonTimeout(data: ComponentTimeoutData, @TimeoutData nullObj: String?) {
         println("onTimeoutEdButtonTimeout: $data ; $nullObj")
     }
 
     @GroupTimeoutHandler("SlashNewButtons: persistentGroupTimeout")
-    fun onFirstGroupTimeout(data: GroupTimeoutData, nullObj: String?) {
+    fun onFirstGroupTimeout(data: GroupTimeoutData, @TimeoutData nullObj: String?) {
         println("onFirstGroupTimeout: $data ; $nullObj")
     }
 

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashNewButtons.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashNewButtons.kt
@@ -11,10 +11,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashE
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.components.Button
 import io.github.freya022.botcommands.api.components.Buttons
-import io.github.freya022.botcommands.api.components.annotations.ComponentTimeoutHandler
-import io.github.freya022.botcommands.api.components.annotations.GroupTimeoutHandler
-import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
-import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
+import io.github.freya022.botcommands.api.components.annotations.*
 import io.github.freya022.botcommands.api.components.builder.bindTo
 import io.github.freya022.botcommands.api.components.builder.filter
 import io.github.freya022.botcommands.api.components.builder.timeout
@@ -122,7 +119,7 @@ class SlashNewButtons(
     }
 
     @JDAButtonListener("SlashNewButtons: persistentButton")
-    fun onFirstButtonClicked(event: ButtonEvent, double: Double, inputUser: InputUser, nullValue: Member?) {
+    fun onFirstButtonClicked(event: ButtonEvent, @ComponentData double: Double, @ComponentData inputUser: InputUser, @ComponentData nullValue: Member?) {
         event.reply_("Persistent button clicked, double: $double, member: ${inputUser.asTag}, null: $nullValue", ephemeral = true).queue()
     }
 

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashResolveMentions.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashResolveMentions.kt
@@ -9,6 +9,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashE
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
 import io.github.freya022.botcommands.api.components.Buttons
+import io.github.freya022.botcommands.api.components.annotations.ComponentData
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.components.builder.bindTo
@@ -44,10 +45,10 @@ class SlashResolveMentions(private val buttons: Buttons) : ApplicationCommand() 
     @JDAButtonListener("SlashResolveMentions: ResolveChannelsButton")
     suspend fun onResolveChannelsClick(
         event: ButtonEvent,
-        postContainer: IPostContainer,
-        forumChannel: ForumChannel,
-        threadChannel: ThreadChannel,
-        archivedThreadChannel: ThreadChannel
+        @ComponentData postContainer: IPostContainer,
+        @ComponentData forumChannel: ForumChannel,
+        @ComponentData threadChannel: ThreadChannel,
+        @ComponentData archivedThreadChannel: ThreadChannel
     ) {
         event.reply_(
             """

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashServiceOption.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashServiceOption.kt
@@ -12,6 +12,7 @@ import io.github.freya022.botcommands.api.components.Buttons
 import io.github.freya022.botcommands.api.components.annotations.ComponentData
 import io.github.freya022.botcommands.api.components.annotations.ComponentTimeoutHandler
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
+import io.github.freya022.botcommands.api.components.annotations.TimeoutData
 import io.github.freya022.botcommands.api.components.data.ComponentTimeoutData
 import io.github.freya022.botcommands.api.components.event.ButtonEvent
 import io.github.freya022.botcommands.api.core.service.LazyService
@@ -49,7 +50,7 @@ class SlashServiceOption : ApplicationCommand() {
     @ComponentTimeoutHandler("SlashServiceOption: button")
     fun onButtonTimeout(
         data: ComponentTimeoutData,
-        randomNumber: Double,
+        @TimeoutData randomNumber: Double,
         jda: LazyService<JDA>,
     ) {
         if (jda.canCreateService()) {

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashServiceOption.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashServiceOption.kt
@@ -9,6 +9,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashE
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
 import io.github.freya022.botcommands.api.components.Buttons
+import io.github.freya022.botcommands.api.components.annotations.ComponentData
 import io.github.freya022.botcommands.api.components.annotations.ComponentTimeoutHandler
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
 import io.github.freya022.botcommands.api.components.data.ComponentTimeoutData
@@ -61,8 +62,8 @@ class SlashServiceOption : ApplicationCommand() {
     @JDAButtonListener("SlashServiceOption: button")
     suspend fun onButtonClick(
         event: ButtonEvent,
-        slashInput: String,
-        randomNum: Double,
+        @ComponentData slashInput: String,
+        @ComponentData randomNum: Double,
         modals: Modals,
         // Not supported yet
 //        @LocalizationBundle("MyCommands") localizationContext: AppLocalizationContext,

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashServiceOption.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashServiceOption.kt
@@ -1,0 +1,99 @@
+package io.github.freya022.botcommands.test.commands.slash
+
+import dev.minn.jda.ktx.coroutines.await
+import dev.minn.jda.ktx.messages.into
+import dev.minn.jda.ktx.messages.reply_
+import io.github.freya022.botcommands.api.commands.annotations.Command
+import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
+import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
+import io.github.freya022.botcommands.api.components.Buttons
+import io.github.freya022.botcommands.api.components.annotations.ComponentTimeoutHandler
+import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
+import io.github.freya022.botcommands.api.components.data.ComponentTimeoutData
+import io.github.freya022.botcommands.api.components.event.ButtonEvent
+import io.github.freya022.botcommands.api.core.service.LazyService
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
+import io.github.freya022.botcommands.api.localization.annotations.LocalizationBundle
+import io.github.freya022.botcommands.api.localization.context.AppLocalizationContext
+import io.github.freya022.botcommands.api.modals.Modals
+import io.github.freya022.botcommands.api.modals.annotations.ModalData
+import io.github.freya022.botcommands.api.modals.annotations.ModalHandler
+import io.github.freya022.botcommands.api.modals.annotations.ModalInput
+import io.github.freya022.botcommands.api.modals.create
+import io.github.freya022.botcommands.api.modals.shortTextInput
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.seconds
+
+@Command
+class SlashServiceOption : ApplicationCommand() {
+    @JDASlashCommand(name = "service_option")
+    suspend fun onSlashServiceOption(
+        event: GuildSlashEvent,
+        buttons: Buttons,
+        @SlashOption option: String,
+        @LocalizationBundle("MyCommands") localizationContext: AppLocalizationContext,
+    ) {
+        val button = buttons.primary("Click me").persistent {
+            timeout(5.seconds, "SlashServiceOption: button", Random.nextDouble())
+            bindTo("SlashServiceOption: button", option, 1)
+        }
+
+        event.reply_(components = button.into(), ephemeral = true).await()
+    }
+
+    @ComponentTimeoutHandler("SlashServiceOption: button")
+    fun onButtonTimeout(
+        data: ComponentTimeoutData,
+        randomNumber: Double,
+        jda: LazyService<JDA>,
+    ) {
+        if (jda.canCreateService()) {
+            println("Deleting old components (not really tho)")
+        } else {
+            println("Missing JDA, cannot delete old components")
+        }
+    }
+
+    @JDAButtonListener("SlashServiceOption: button")
+    suspend fun onButtonClick(
+        event: ButtonEvent,
+        slashInput: String,
+        randomNum: Double,
+        modals: Modals,
+        // Not supported yet
+//        @LocalizationBundle("MyCommands") localizationContext: AppLocalizationContext,
+    ) {
+        val modal = modals.create("Title") {
+            shortTextInput("input", "Sample text")
+
+            bindTo("SlashServiceOption: modal", slashInput, randomNum, Random.nextDouble())
+        }
+
+        event.replyModal(modal).await()
+    }
+
+    @ModalHandler("SlashServiceOption: modal")
+    suspend fun onModalSubmit(
+        event: ModalInteractionEvent,
+        @ModalData slashInput: String,
+        @ModalData buttonRandomNum: Double,
+        @ModalData randomNum: Double,
+        @ModalInput("input") input: String,
+        service: ServiceContainer,
+        @LocalizationBundle("MyCommands") localizationContext: AppLocalizationContext,
+    ) {
+        event.reply_(
+            """
+                Slash command option: $slashInput
+                Button random number: $buttonRandomNum
+                Random number: $randomNum
+                Input: $input
+            """.trimIndent(),
+            ephemeral = true
+        ).await()
+    }
+}

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashTimeUnit.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashTimeUnit.kt
@@ -8,6 +8,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashE
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
 import io.github.freya022.botcommands.api.components.Buttons
+import io.github.freya022.botcommands.api.components.annotations.ComponentData
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.components.builder.bindTo
@@ -32,7 +33,7 @@ class SlashTimeUnit(private val buttons: Buttons) : ApplicationCommand() {
     }
 
     @JDAButtonListener("SlashTimeUnit: timeUnit")
-    fun onTimeUnitClicked(event: ButtonEvent, unit: TimeUnit) {
+    fun onTimeUnitClicked(event: ButtonEvent, @ComponentData unit: TimeUnit) {
         event.reply_("Time unit is ${unit.name}!", ephemeral = true).queue()
     }
 }

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/text/TextTest.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/text/TextTest.kt
@@ -86,7 +86,7 @@ class TextTest : TextCommand(), TextCommandProvider {
 
                 option("text")
 
-                customOption("context")
+                serviceOption("context")
 
                 generatedOption("userName") {
                     it.author.name
@@ -96,7 +96,7 @@ class TextTest : TextCommand(), TextCommandProvider {
             variation(::onTextTestFallback) {
                 description = "Fallback variation description"
 
-                customOption("context")
+                serviceOption("context")
 
                 generatedOption("userName") {
                     it.author.name


### PR DESCRIPTION
- Added `serviceOption` to code-declared commands
  - Deprecated usages of `customOption` **if the parameter is a service**
- Refresh method-injected `List` and `Lazy` until they are stable
  - Still recommended to retrieve them from a constructor-injected `ServiceContainer`
- Added `@ComponentData` and `@TimeoutData`
  - Add it on data passed in `bindTo`/`timeout`
  - Logs a warning if annotation is not found