### PR TITLE
Allow anonymous handlers if type-safe binding exists

### DIFF
--- a/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashButton.kt
+++ b/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashButton.kt
@@ -44,7 +44,7 @@ class SlashButton(private val buttons: Buttons) : ApplicationCommand() {
             .queue()
     }
 
-    @JDAButtonListener("SlashButton: persistentButton") //ClassName: theButtonPurpose
+    @JDAButtonListener
     suspend fun onPersistentButtonClick(event: ButtonEvent) {
         event.editButton(event.button.asDisabled()).await()
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/autocomplete/annotations/AutocompleteHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/autocomplete/annotations/AutocompleteHandler.kt
@@ -7,6 +7,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.autocomplet
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.AutocompleteTransformer
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.builder.AutocompleteInfoBuilder
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.declaration.AutocompleteHandlerProvider
+import io.github.freya022.botcommands.api.commands.application.slash.builder.SlashCommandOptionBuilder
 import io.github.freya022.botcommands.api.core.annotations.Handler
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
@@ -17,6 +18,9 @@ import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInterac
  *
  * The name must be unique; I recommend naming them similarly to:
  * `YourClassSimpleName: AutocompletedField` (for example, `SlashTag: tagName`).
+ *
+ * If a name is unset, the handler is anonymous and can only be referenced on code-declared commands,
+ * using [SlashCommandOptionBuilder.autocompleteByFunction].
  *
  * Requirements:
  *  - The declaring class must be annotated with [@Handler][Handler] or be an existing [@Command][Command] class.
@@ -60,8 +64,11 @@ annotation class AutocompleteHandler(
      * Sets the name of the autocomplete handler, **it must be the same as what you set in [SlashOption.autocomplete]**.
      *
      * The name must be unique, another handler cannot share it.
+     *
+     * If this is omitted, the handler is anonymous and can only be referenced on code-declared commands,
+     * using [SlashCommandOptionBuilder.autocompleteByFunction].
      */
-    @get:JvmName("value") val name: String,
+    @get:JvmName("value") val name: String = "",
 
     /**
      * Sets the [autocomplete mode][AutocompleteMode].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandOptionBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/builder/SlashCommandOptionBuilder.kt
@@ -99,7 +99,7 @@ class SlashCommandOptionBuilder internal constructor(
     /**
      * Uses an existing autocomplete handler with the specified [name][AutocompleteHandler.name].
      *
-     * Must match an autocomplete handler created from [@AutocompleteHandler][AutocompleteHandler]
+     * Must match an autocomplete handler created from a named [@AutocompleteHandler][AutocompleteHandler]
      * or [AutocompleteManager.autocomplete].
      *
      * @see AutocompleteHandler @AutocompleteHandler
@@ -111,7 +111,8 @@ class SlashCommandOptionBuilder internal constructor(
     /**
      * Uses an existing autocomplete handler with the specified function.
      *
-     * Must match an autocomplete handler created from [AutocompleteManager.autocomplete].
+     * Must match an autocomplete handler created from [@AutocompleteHandler][AutocompleteHandler]
+     * or [AutocompleteManager.autocomplete].
      */
     fun autocompleteByFunction(function: KFunction<*>) {
         autocompleteInfo = context.getService<AutocompleteInfoContainer>()[function]

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/Buttons.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/Buttons.kt
@@ -40,7 +40,7 @@ import javax.annotation.CheckReturnValue
  *             .await()
  *     }
  *
- *     @JDAButtonListener("SlashSayAgainPersistent: saySentenceButton")
+ *     @JDAButtonListener // No need for a name if you use the type-safe bindTo extensions
  *     suspend fun onSaySentenceClick(event: ButtonEvent, sentence: String) {
  *         event.reply_(sentence, ephemeral = true).await()
  *     }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/SelectMenus.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/SelectMenus.kt
@@ -34,7 +34,7 @@ import javax.annotation.CheckReturnValue
  *             .await()
  *     }
  *
- *     @JDASelectMenuListener("SlashSelectRolePersistent: roleMenu")
+ *     @JDASelectMenuListener // No need for a name if you use the type-safe bindTo extensions
  *     suspend fun onRoleMenuSelect(event: EntitySelectEvent, randomNumber: Long) {
  *         val role = event.values[0] as Role
  *         event.reply("You have been given " + role.asMention + ", and the random number is " + randomNumber)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/ComponentTimeoutHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/ComponentTimeoutHandler.kt
@@ -1,12 +1,15 @@
 package io.github.freya022.botcommands.api.components.annotations
 
 import io.github.freya022.botcommands.api.components.builder.IPersistentTimeoutableComponent
+import io.github.freya022.botcommands.api.components.builder.timeout
 import io.github.freya022.botcommands.api.components.data.ComponentTimeoutData
 import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder
 import io.github.freya022.botcommands.api.core.options.annotations.Aggregate
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
+import io.github.freya022.botcommands.internal.utils.ReflectionUtils.declaringClass
+import kotlin.reflect.KFunction
 
 /**
  * Declares this function as a component timeout handler with the given name.
@@ -14,7 +17,8 @@ import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterR
  * ### Requirements
  * - The declaring class must be annotated with [@BService][BService]
  * or [any annotation that enables your class for dependency injection][BServiceConfigBuilder.serviceAnnotations].
- * - The annotation value to have same name as the one given to [IPersistentTimeoutableComponent.timeout].
+ * - The annotation value to have same name as the one given to [IPersistentTimeoutableComponent.timeout], however,
+ * it can be omitted if you use the type-safe [timeout] extensions.
  * - First parameter must be [ComponentTimeoutData].
  *
  * ### Option types
@@ -28,4 +32,17 @@ import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterR
  * @see Aggregate @Aggregate
  */
 @Target(AnnotationTarget.FUNCTION)
-annotation class ComponentTimeoutHandler(@get:JvmName("value") val name: String)
+annotation class ComponentTimeoutHandler(
+    /**
+     * Name of the timeout handler, referenced by [IPersistentTimeoutableComponent.timeout].
+     *
+     * This can be omitted if you use the type-safe [timeout] extensions.
+     *
+     * Defaults to `FullyQualifiedClassName.methodName`.
+     */
+    @get:JvmName("value") val name: String = ""
+)
+
+internal fun ComponentTimeoutHandler.getEffectiveName(func: KFunction<*>): String {
+    return name.ifBlank { "${func.declaringClass.qualifiedName}.${func.name}" }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/GroupTimeoutHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/GroupTimeoutHandler.kt
@@ -1,12 +1,15 @@
 package io.github.freya022.botcommands.api.components.annotations
 
 import io.github.freya022.botcommands.api.components.builder.group.ComponentGroupBuilder
+import io.github.freya022.botcommands.api.components.builder.timeout
 import io.github.freya022.botcommands.api.components.data.GroupTimeoutData
 import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder
 import io.github.freya022.botcommands.api.core.options.annotations.Aggregate
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
+import io.github.freya022.botcommands.internal.utils.ReflectionUtils.declaringClass
+import kotlin.reflect.KFunction
 
 /**
  * Declares this function as a component group timeout handler with the given name.
@@ -14,7 +17,8 @@ import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterR
  * ### Requirements
  * - The declaring class must be annotated with [@BService][BService]
  * or [any annotation that enables your class for dependency injection][BServiceConfigBuilder.serviceAnnotations].
- * - The annotation value to have same name as the one given to [ComponentGroupBuilder.timeout].
+ * - The annotation value to have same name as the one given to [ComponentGroupBuilder.timeout], however,
+ * it can be omitted if you use the type-safe [timeout] extensions.
  * - First parameter must be [GroupTimeoutData].
  *
  * ### Option types
@@ -28,4 +32,17 @@ import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterR
  * @see Aggregate @Aggregate
  */
 @Target(AnnotationTarget.FUNCTION)
-annotation class GroupTimeoutHandler(@get:JvmName("value") val name: String)
+annotation class GroupTimeoutHandler(
+    /**
+     * Name of the timeout handler, referenced by [ComponentGroupBuilder.timeout].
+     *
+     * This can be omitted if you use the type-safe [timeout] extensions.
+     *
+     * Defaults to `FullyQualifiedClassName.methodName`.
+     */
+    @get:JvmName("value") val name: String = ""
+)
+
+internal fun GroupTimeoutHandler.getEffectiveName(func: KFunction<*>): String {
+    return name.ifBlank { "${func.declaringClass.qualifiedName}.${func.name}" }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/IActionableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/IActionableComponent.kt
@@ -8,6 +8,7 @@ import io.github.freya022.botcommands.api.components.ComponentInteractionFilter
 import io.github.freya022.botcommands.api.components.annotations.ComponentData
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
 import io.github.freya022.botcommands.api.components.annotations.JDASelectMenuListener
+import io.github.freya022.botcommands.api.components.annotations.getEffectiveName
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
@@ -541,15 +542,15 @@ private fun <T : IPersistentActionableComponent<T>> T.bindToCallable(func: KFunc
 }
 
 private fun findHandlerName(func: KFunction<*>): String {
-    val buttonName = func.findAnnotation<JDAButtonListener>()?.name
-    val selectMenuName = func.findAnnotation<JDASelectMenuListener>()?.name
+    val buttonAnnotation = func.findAnnotation<JDAButtonListener>()
+    val selectMenuAnnotation = func.findAnnotation<JDASelectMenuListener>()
 
-    if (buttonName != null && selectMenuName != null)
+    if (buttonAnnotation != null && selectMenuAnnotation != null)
         throwUser(func, "Cannot have the same function with the two annotation")
-    else if (buttonName != null)
-        return buttonName
-    else if (selectMenuName != null)
-        return selectMenuName
+    else if (buttonAnnotation != null)
+        return buttonAnnotation.getEffectiveName(func)
+    else if (selectMenuAnnotation != null)
+        return selectMenuAnnotation.getEffectiveName(func)
 
     throwUser(func, "Could not find ${annotationRef<JDAButtonListener>()} or ${annotationRef<JDASelectMenuListener>()}")
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/ITimeoutableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/ITimeoutableComponent.kt
@@ -4,6 +4,7 @@ import dev.minn.jda.ktx.util.ref
 import io.github.freya022.botcommands.api.components.annotations.ComponentTimeoutHandler
 import io.github.freya022.botcommands.api.components.annotations.GroupTimeoutHandler
 import io.github.freya022.botcommands.api.components.annotations.TimeoutData
+import io.github.freya022.botcommands.api.components.annotations.getEffectiveName
 import io.github.freya022.botcommands.api.components.data.ComponentTimeout
 import io.github.freya022.botcommands.api.components.data.ITimeoutData
 import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
@@ -847,15 +848,15 @@ private fun <T : IPersistentTimeoutableComponent<T>> T.bindToCallable(duration: 
 }
 
 private fun findHandlerName(func: KFunction<*>): String {
-    val componentTimeoutName = func.findAnnotation<ComponentTimeoutHandler>()?.name
-    val groupTimeoutName = func.findAnnotation<GroupTimeoutHandler>()?.name
+    val componentTimeoutAnnotation = func.findAnnotation<ComponentTimeoutHandler>()
+    val groupTimeoutAnnotation = func.findAnnotation<GroupTimeoutHandler>()
 
-    if (componentTimeoutName != null && groupTimeoutName != null)
+    if (componentTimeoutAnnotation != null && groupTimeoutAnnotation != null)
         throwUser(func, "Cannot have the same function with the two annotation")
-    else if (componentTimeoutName != null)
-        return componentTimeoutName
-    else if (groupTimeoutName != null)
-        return groupTimeoutName
+    else if (componentTimeoutAnnotation != null)
+        return componentTimeoutAnnotation.getEffectiveName(func)
+    else if (groupTimeoutAnnotation != null)
+        return groupTimeoutAnnotation.getEffectiveName(func)
 
     throwUser(func, "Could not find ${annotationRef<ComponentTimeoutHandler>()} or ${annotationRef<GroupTimeoutHandler>()}")
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/AutocompleteInfoAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/AutocompleteInfoAutoBuilder.kt
@@ -7,6 +7,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.autocomplet
 import io.github.freya022.botcommands.api.commands.builder.DeclarationSite
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.service.getService
+import io.github.freya022.botcommands.api.core.utils.nullIfBlank
 import io.github.freya022.botcommands.internal.core.requiredFilter
 import io.github.freya022.botcommands.internal.core.service.FunctionAnnotationsMap
 import io.github.freya022.botcommands.internal.utils.FunctionFilter
@@ -28,7 +29,7 @@ internal class AutocompleteInfoAutoBuilder internal constructor() : Autocomplete
                 val autocompleteFunction = it.function as KFunction<Collection<Any>>
                 val autocompleteHandlerAnnotation = autocompleteFunction.findAnnotation<AutocompleteHandler>()!!
 
-                manager.autocomplete(autocompleteFunction, autocompleteHandlerAnnotation.name) {
+                manager.autocomplete(autocompleteFunction, autocompleteHandlerAnnotation.name.nullIfBlank()) {
                     declarationSite = DeclarationSite.fromFunctionSignature(autocompleteFunction)
 
                     mode = autocompleteHandlerAnnotation.mode

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerContainer.kt
@@ -3,6 +3,7 @@ package io.github.freya022.botcommands.internal.components.handler
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
 import io.github.freya022.botcommands.api.components.annotations.JDASelectMenuListener
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
+import io.github.freya022.botcommands.api.components.annotations.getEffectiveName
 import io.github.freya022.botcommands.api.components.event.ButtonEvent
 import io.github.freya022.botcommands.api.components.event.EntitySelectEvent
 import io.github.freya022.botcommands.api.components.event.StringSelectEvent
@@ -27,7 +28,7 @@ internal class ComponentHandlerContainer(context: BContextImpl, functionAnnotati
             .requiredFilter(FunctionFilter.nonStatic())
             .requiredFilter(FunctionFilter.firstArg(ButtonEvent::class))
             .forEach {
-                val handlerName = it.function.findAnnotation<JDAButtonListener>()!!.name
+                val handlerName = it.function.findAnnotation<JDAButtonListener>()!!.getEffectiveName(it.function)
 
                 val oldDescriptor = buttonMap.put(handlerName, ComponentDescriptor(context, it.toMemberParamFunction()))
                 if (oldDescriptor != null) {
@@ -39,7 +40,7 @@ internal class ComponentHandlerContainer(context: BContextImpl, functionAnnotati
             .requiredFilter(FunctionFilter.nonStatic())
             .requiredFilter(FunctionFilter.firstArg(StringSelectEvent::class, EntitySelectEvent::class))
             .forEach {
-                val handlerName = it.function.findAnnotation<JDASelectMenuListener>()!!.name
+                val handlerName = it.function.findAnnotation<JDASelectMenuListener>()!!.getEffectiveName(it.function)
 
                 val oldDescriptor = selectMap.put(handlerName, ComponentDescriptor(context, it.toMemberParamFunction()))
                 if (oldDescriptor != null) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/ComponentTimeoutHandlers.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/ComponentTimeoutHandlers.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.internal.components.timeout
 
 import io.github.freya022.botcommands.api.components.annotations.ComponentTimeoutHandler
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
+import io.github.freya022.botcommands.api.components.annotations.getEffectiveName
 import io.github.freya022.botcommands.api.components.data.ComponentTimeoutData
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.internal.core.BContextImpl
@@ -19,7 +20,9 @@ internal class ComponentTimeoutHandlers(context: BContextImpl, functionAnnotatio
             .requiredFilter(FunctionFilter.nonStatic())
             .requiredFilter(FunctionFilter.firstArg(ComponentTimeoutData::class))
             .associate {
-                it.function.findAnnotation<ComponentTimeoutHandler>()!!.name to TimeoutDescriptor(context, it.toMemberParamFunction(), ComponentTimeoutData::class)
+                val function = it.function
+                val annotation = function.findAnnotation<ComponentTimeoutHandler>()!!
+                annotation.getEffectiveName(function) to TimeoutDescriptor(context, it.toMemberParamFunction(), ComponentTimeoutData::class)
             }
 
     override operator fun get(handlerName: String) = map[handlerName]

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/GroupTimeoutHandlers.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/GroupTimeoutHandlers.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.internal.components.timeout
 
 import io.github.freya022.botcommands.api.components.annotations.GroupTimeoutHandler
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
+import io.github.freya022.botcommands.api.components.annotations.getEffectiveName
 import io.github.freya022.botcommands.api.components.data.GroupTimeoutData
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.internal.core.BContextImpl
@@ -19,7 +20,9 @@ internal class GroupTimeoutHandlers(context: BContextImpl, functionAnnotationsMa
             .requiredFilter(FunctionFilter.nonStatic())
             .requiredFilter(FunctionFilter.firstArg(GroupTimeoutData::class))
             .associate {
-                it.function.findAnnotation<GroupTimeoutHandler>()!!.name to TimeoutDescriptor(context, it.toMemberParamFunction(), GroupTimeoutData::class)
+                val function = it.function
+                val annotation = function.findAnnotation<GroupTimeoutHandler>()!!
+                annotation.getEffectiveName(function) to TimeoutDescriptor(context, it.toMemberParamFunction(), GroupTimeoutData::class)
             }
 
     override operator fun get(handlerName: String) = map[handlerName]

--- a/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashSayAgainPersistent.kt
+++ b/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashSayAgainPersistent.kt
@@ -44,7 +44,7 @@ class SlashSayAgainPersistent : ApplicationCommand() {
             .await()
     }
 
-    @JDAButtonListener("SlashSayAgainPersistent: saySentenceButton")
+    @JDAButtonListener
     suspend fun onSaySentenceClick(event: ButtonEvent, @ComponentData sentence: String) {
         event.reply_(sentence, ephemeral = true).await()
     }

--- a/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashSelectRolePersistent.kt
+++ b/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashSelectRolePersistent.kt
@@ -39,7 +39,7 @@ class SlashSelectRolePersistent : ApplicationCommand() {
             .await()
     }
 
-    @JDASelectMenuListener("SlashSelectRolePersistent: roleMenu")
+    @JDASelectMenuListener
     suspend fun onRoleMenuSelect(event: EntitySelectEvent, @ComponentData randomNumber: Long) {
         val role = event.values[0] as Role
         event.reply("You have been given " + role.asMention + ", and the random number is " + randomNumber)

--- a/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashTypeSafeButtons.kt
+++ b/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashTypeSafeButtons.kt
@@ -25,7 +25,7 @@ class SlashTypeSafeButtons(private val buttons: Buttons) : ApplicationCommand() 
         event.replyComponents(button.into()).await()
     }
 
-    @JDAButtonListener("SlashTypeSafeButtons: testButton")
+    @JDAButtonListener
     suspend fun onTestClick(event: ButtonEvent, @ComponentData argument: String) {
         event.reply_("The argument was: $argument", ephemeral = true).await()
     }

--- a/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashTypeSafeSelectMenus.kt
+++ b/src/test/kotlin/doc/kotlin/examples/commands/slash/SlashTypeSafeSelectMenus.kt
@@ -26,7 +26,7 @@ class SlashTypeSafeSelectMenus(private val selectMenus: SelectMenus) : Applicati
         event.replyComponents(selectMenu.into()).await()
     }
 
-    @JDASelectMenuListener("SlashTypeSafeSelectMenus: testSelectMenu")
+    @JDASelectMenuListener
     suspend fun onTestSelect(event: EntitySelectEvent, @ComponentData argument: String) {
         event.reply_("The argument was: $argument", ephemeral = true).await()
     }

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashGenerateComponents.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashGenerateComponents.kt
@@ -58,7 +58,7 @@ class SlashGenerateComponents(private val buttons: Buttons) : ApplicationCommand
         event.hook.sendMessage("Done in $duration").queue()
     }
 
-    @ComponentTimeoutHandler("SlashGenerateComponents: persistent")
+    @ComponentTimeoutHandler
     fun onPersistentTimeout(data: ComponentTimeoutData) {
         println("Persistent timeout")
     }

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashNewButtons.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashNewButtons.kt
@@ -118,17 +118,17 @@ class SlashNewButtons(
         return firstButton
     }
 
-    @JDAButtonListener("SlashNewButtons: persistentButton")
+    @JDAButtonListener
     fun onFirstButtonClicked(event: ButtonEvent, @ComponentData double: Double, @ComponentData inputUser: InputUser, @ComponentData nullValue: Member?) {
         event.reply_("Persistent button clicked, double: $double, member: ${inputUser.asMention}, null: $nullValue", ephemeral = true).queue()
     }
 
-    @ComponentTimeoutHandler("SlashNewButtons: persistentButtonTimeout")
+    @ComponentTimeoutHandler
     fun onTimeoutEdButtonTimeout(data: ComponentTimeoutData, @TimeoutData nullObj: String?) {
         println("onTimeoutEdButtonTimeout: $data ; $nullObj")
     }
 
-    @GroupTimeoutHandler("SlashNewButtons: persistentGroupTimeout")
+    @GroupTimeoutHandler
     fun onFirstGroupTimeout(data: GroupTimeoutData, @TimeoutData nullObj: String?) {
         println("onFirstGroupTimeout: $data ; $nullObj")
     }

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashNewSelects.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashNewSelects.kt
@@ -104,12 +104,12 @@ class SlashNewSelects(
         return firstSelect
     }
 
-    @JDASelectMenuListener("SlashNewSelects: persistentSelect")
+    @JDASelectMenuListener
     fun onFirstSelectClicked(event: StringSelectEvent) {
         event.reply_("Persistent select menu clicked", ephemeral = true).queue()
     }
 
-    @GroupTimeoutHandler("SlashNewSelects: persistentGroupTimeout")
+    @GroupTimeoutHandler
     fun onFirstGroupTimeout(data: GroupTimeoutData) {
         println(data)
     }


### PR DESCRIPTION
Allows setting no name on:
- `JDAButtonListener` (defaults to `FullyQualifiedClassName.methodName`)
- `JDASelectMenuListener` (defaults to `FullyQualifiedClassName.methodName`)
- `ComponentTimeoutHandler` (defaults to `FullyQualifiedClassName.methodName`)
- `GroupTimeoutHandler` (defaults to `FullyQualifiedClassName.methodName`)
- `AutocompleteHandler` (defaults to `null`)