### PR TITLE
Add usability getters for text/application commands

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/Usability.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/Usability.kt
@@ -1,9 +1,16 @@
 package io.github.freya022.botcommands.api.commands
 
 /**
- * Represents whether a command is usable (and if it is visible).
+ * Represents whether a command can be used, and if it should be visible.
  */
 interface Usability {
+    /**
+     * All reasons this command might be unusable/invisible.
+     *
+     * The set is not sorted in any specific order.
+     *
+     * @see bestReason
+     */
     val unusableReasons: Set<UnusableReason>
 
     /**

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/Usability.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/Usability.kt
@@ -1,0 +1,47 @@
+package io.github.freya022.botcommands.api.commands
+
+/**
+ * Represents whether a command is usable (and if it is visible).
+ */
+interface Usability {
+    val unusableReasons: Set<UnusableReason>
+
+    /**
+     * Returns `true` if the command can be executed.
+     */
+    val isUsable: Boolean
+
+    /**
+     * Returns `true` if the command cannot be executed.
+     */
+    val isNotUsable: Boolean
+
+    /**
+     * Returns `true` if the command should be visible, even if unusable (in help content, for example).
+     */
+    val isVisible: Boolean
+
+    /**
+     * Returns `true` if the command should **not** be visible (in help content, for example).
+     */
+    val isNotVisible: Boolean
+
+    /**
+     * Returns the most important un-usability reason.
+     */
+    val bestReason: UnusableReason
+
+    enum class UnusableReason(
+        internal val priority: Int,
+        /**
+         * Returns `true` if the command should be visible, even if unusable (in help content, for example).
+         */
+        val isVisible: Boolean,
+    ) {
+        HIDDEN          (priority = 4, isVisible = false),
+        OWNER_ONLY      (priority = 3, isVisible = false),
+        USER_PERMISSIONS(priority = 2, isVisible = false),
+        BOT_PERMISSIONS (priority = 1, isVisible = true),
+        NSFW_ONLY       (priority = 0, isVisible = false)
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandInfo.kt
@@ -30,7 +30,7 @@ interface ApplicationCommandInfo : CommandInfo, Executable,
     val fullCommandName: String get() = path.getFullPath(' ')
 
     /**
-     * Checks the usability (and visibility) of this application command.
+     * Returns a [Usability] instance, representing whether this application command can be used.
      */
     fun getUsability(inputUser: InputUser, channel: MessageChannel): Usability
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandInfo.kt
@@ -1,15 +1,11 @@
 package io.github.freya022.botcommands.api.commands.application
 
-import io.github.freya022.botcommands.api.commands.CommandInfo
-import io.github.freya022.botcommands.api.commands.ICommandOptionContainer
-import io.github.freya022.botcommands.api.commands.ICommandParameterContainer
-import io.github.freya022.botcommands.api.commands.IFilterContainer
+import io.github.freya022.botcommands.api.commands.*
 import io.github.freya022.botcommands.api.commands.application.slash.SlashSubcommandGroupInfo
 import io.github.freya022.botcommands.api.commands.application.slash.SlashSubcommandInfo
 import io.github.freya022.botcommands.api.commands.application.slash.TopLevelSlashCommandInfo
 import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.api.core.entities.InputUser
-import io.github.freya022.botcommands.internal.commands.Usability
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 
 /**

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandInfo.kt
@@ -8,6 +8,9 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashSubcom
 import io.github.freya022.botcommands.api.commands.application.slash.SlashSubcommandInfo
 import io.github.freya022.botcommands.api.commands.application.slash.TopLevelSlashCommandInfo
 import io.github.freya022.botcommands.api.core.Executable
+import io.github.freya022.botcommands.api.core.entities.InputUser
+import io.github.freya022.botcommands.internal.commands.Usability
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 
 /**
  * Represents an application command of any kind.
@@ -29,4 +32,9 @@ interface ApplicationCommandInfo : CommandInfo, Executable,
      * - [SlashSubcommandGroupInfo] == `docs search`
      */
     val fullCommandName: String get() = path.getFullPath(' ')
+
+    /**
+     * Checks the usability (and visibility) of this application command.
+     */
+    fun getUsability(inputUser: InputUser, channel: MessageChannel): Usability
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandInfo.kt
@@ -3,8 +3,11 @@ package io.github.freya022.botcommands.api.commands.text
 import io.github.freya022.botcommands.api.commands.CommandInfo
 import io.github.freya022.botcommands.api.commands.text.builder.TextCommandBuilder
 import io.github.freya022.botcommands.api.core.config.BConfig
+import io.github.freya022.botcommands.internal.commands.Usability
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.channel.attribute.IAgeRestrictedChannel
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
 import java.util.function.Consumer
 
 /**
@@ -64,4 +67,9 @@ interface TextCommandInfo : CommandInfo {
      * Consumer of an [EmbedBuilder], runs after generating the built-in help content.
      */
     val detailedDescription: Consumer<EmbedBuilder>?
+
+    /**
+     * Checks the usability (and visibility) of this text command.
+     */
+    fun getUsability(member: Member, channel: GuildMessageChannel): Usability
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandInfo.kt
@@ -1,9 +1,9 @@
 package io.github.freya022.botcommands.api.commands.text
 
 import io.github.freya022.botcommands.api.commands.CommandInfo
+import io.github.freya022.botcommands.api.commands.Usability
 import io.github.freya022.botcommands.api.commands.text.builder.TextCommandBuilder
 import io.github.freya022.botcommands.api.core.config.BConfig
-import io.github.freya022.botcommands.internal.commands.Usability
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.channel.attribute.IAgeRestrictedChannel

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandInfo.kt
@@ -69,7 +69,8 @@ interface TextCommandInfo : CommandInfo {
     val detailedDescription: Consumer<EmbedBuilder>?
 
     /**
-     * Checks the usability (and visibility) of this text command.
+     * Returns a [Usability] instance, representing whether this text command can be used,
+     * and if it is visible, for example, in the help content.
      */
     fun getUsability(member: Member, channel: GuildMessageChannel): Usability
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/Usability.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/Usability.kt
@@ -21,20 +21,26 @@ class Usability private constructor(val unusableReasons: Set<UnusableReason>) {
         get() = !isUsable
 
     /**
-     * Returns `true` if the command should be visible, even if unusable (in help content, for example)
+     * Returns `true` if the command should be visible, even if unusable (in help content, for example).
      */
     val isVisible: Boolean = unusableReasons.all { it.isVisible }
 
     /**
-     * @return `true` if the command should **not** be visible (in help content, for example)
+     * @return `true` if the command should **not** be visible (in help content, for example).
      */
     val isNotVisible: Boolean
         get() = !isVisible
 
+    /**
+     * Returns the most important un-usability reason.
+     */
+    val bestReason: UnusableReason
+        get() = unusableReasons.maxBy { it.priority }
+
     enum class UnusableReason(
         internal val priority: Int,
         /**
-         * Returns `true` if the command should be visible, even if unusable (in help content, for example)
+         * Returns `true` if the command should be visible, even if unusable (in help content, for example).
          */
         val isVisible: Boolean
     ) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/Usability.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/Usability.kt
@@ -1,115 +1,56 @@
 package io.github.freya022.botcommands.internal.commands
 
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommandInfo
-import io.github.freya022.botcommands.api.commands.text.TextCommandInfo
-import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.utils.enumSetOf
-import io.github.freya022.botcommands.internal.commands.Usability.UnusableReason.*
-import io.github.freya022.botcommands.internal.utils.throwInternal
-import net.dv8tion.jda.api.entities.Member
-import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
-import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
-import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildMessageChannel
-import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent
+import io.github.freya022.botcommands.api.core.utils.unmodifiableView
 import java.util.*
 
-class Usability private constructor(val unusableReasons: EnumSet<UnusableReason>) {
+/**
+ * Represents whether a command can be used, and if it should be visible.
+ */
+class Usability private constructor(val unusableReasons: Set<UnusableReason>) {
     /**
-     * @return `true` if the command is **not** executable
-     */
-    val isUnusable: Boolean by lazy {
-        unusableReasons.any { !it.isUsable }
-    }
-
-    /**
-     * @return `true` if the command is executable
+     * Returns `true` if the command can be executed.
      */
     val isUsable: Boolean
-        get() = !isUnusable
+        get() = unusableReasons.isEmpty()
 
     /**
-     * @return `true` if the command is **not** showable (in help command for example)
+     * Returns `true` if the command cannot be executed.
      */
-    val isNotShowable: Boolean by lazy {
-        unusableReasons.any { !it.isShowable }
-    }
+    val isNotUsable: Boolean
+        get() = !isUsable
 
     /**
-     * @return `true` if the command is showable (in help command for example)
+     * Returns `true` if the command should be visible, even if unusable (in help content, for example)
      */
-    val isShowable: Boolean
-        get() = !isNotShowable
+    val isVisible: Boolean = unusableReasons.all { it.isVisible }
+
+    /**
+     * @return `true` if the command should **not** be visible (in help content, for example)
+     */
+    val isNotVisible: Boolean
+        get() = !isVisible
 
     enum class UnusableReason(
+        internal val priority: Int,
         /**
-         * @return `true` if the command is showable (in help command for example)
+         * Returns `true` if the command should be visible, even if unusable (in help content, for example)
          */
-        val isShowable: Boolean,
-        /**
-         * @return `true` if the command is executable
-         */
-        val isUsable: Boolean
+        val isVisible: Boolean
     ) {
-        HIDDEN(false, false),
-        OWNER_ONLY(false, false),
-        USER_PERMISSIONS(false, false),
-        BOT_PERMISSIONS(true, false),
-        NSFW_ONLY(false, false)
+        HIDDEN          (priority = 4, isVisible = false),
+        OWNER_ONLY      (priority = 3, isVisible = false),
+        USER_PERMISSIONS(priority = 2, isVisible = false),
+        BOT_PERMISSIONS (priority = 1, isVisible = true),
+        NSFW_ONLY       (priority = 0, isVisible = false)
     }
 
-    companion object {
-        private fun checkNSFW(
-            context: BContext,
-            unusableReasons: EnumSet<UnusableReason>,
-            channel: GuildMessageChannel,
-            cmdInfo: TextCommandInfo
-        ) {
-            // Do not run if command is not NSFW
-            if (!cmdInfo.nsfw) return
-
-            if (channel is ThreadChannel) {
-               checkNSFW(context, unusableReasons, channel.parentMessageChannel, cmdInfo)
-               return
-            }
-
-            if (channel is StandardGuildMessageChannel) {
-                if (!channel.isNSFW) {
-                    unusableReasons.add(NSFW_ONLY)
-                }
-            } else {
-                throwInternal("Unsupported channel: $channel")
-            }
-        }
-
-        @JvmStatic
-        fun of(context: BContext, cmdInfo: TextCommandInfo, member: Member, channel: GuildMessageChannel, isNotOwner: Boolean): Usability {
-            enumSetOf<UnusableReason>().apply {
-                if (isNotOwner && cmdInfo.hidden) add(HIDDEN)
-                if (isNotOwner && cmdInfo.isOwnerRequired) add(OWNER_ONLY)
-
-                checkNSFW(context, this, channel, cmdInfo)
-
-                if (isNotOwner && !member.hasPermission(channel, cmdInfo.userPermissions)) add(USER_PERMISSIONS)
-                if (!channel.guild.selfMember.hasPermission(channel, cmdInfo.botPermissions)) add(BOT_PERMISSIONS)
-
-                return Usability(this)
-            }
-        }
-
-        @JvmStatic
-        fun of(event: GenericCommandInteractionEvent, cmdInfo: ApplicationCommandInfo, isNotOwner: Boolean): Usability {
-            enumSetOf<UnusableReason>().apply {
-                if (!event.isFromGuild) return Usability(this)
-
-                val channel = event.guildChannel
-                val guild = event.guild ?: throwInternal("Guild shouldn't be null as this code path is guild-only")
-                val member = event.member ?: throwInternal("Member shouldn't be null as this code path is guild-only")
-
-                if (!guild.selfMember.hasPermission(channel, cmdInfo.botPermissions)) add(BOT_PERMISSIONS)
-                if (isNotOwner && !member.hasPermission(channel, cmdInfo.userPermissions)) add(USER_PERMISSIONS)
-
-                return Usability(this)
-            }
-        }
+    internal companion object {
+        @JvmSynthetic
+        internal inline fun build(crossinline block: EnumSet<UnusableReason>.() -> Unit) =
+            enumSetOf<UnusableReason>()
+                .apply(block)
+                .unmodifiableView()
+                .let(::Usability)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/UsabilityImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/UsabilityImpl.kt
@@ -1,5 +1,7 @@
 package io.github.freya022.botcommands.internal.commands
 
+import io.github.freya022.botcommands.api.commands.Usability
+import io.github.freya022.botcommands.api.commands.Usability.UnusableReason
 import io.github.freya022.botcommands.api.core.utils.enumSetOf
 import io.github.freya022.botcommands.api.core.utils.unmodifiableView
 import java.util.*
@@ -7,56 +9,41 @@ import java.util.*
 /**
  * Represents whether a command can be used, and if it should be visible.
  */
-class Usability private constructor(val unusableReasons: Set<UnusableReason>) {
+internal class UsabilityImpl private constructor(override val unusableReasons: Set<UnusableReason>) : Usability {
     /**
      * Returns `true` if the command can be executed.
      */
-    val isUsable: Boolean
+    override val isUsable: Boolean
         get() = unusableReasons.isEmpty()
 
     /**
      * Returns `true` if the command cannot be executed.
      */
-    val isNotUsable: Boolean
+    override val isNotUsable: Boolean
         get() = !isUsable
 
     /**
      * Returns `true` if the command should be visible, even if unusable (in help content, for example).
      */
-    val isVisible: Boolean = unusableReasons.all { it.isVisible }
+    override val isVisible: Boolean = unusableReasons.all { it.isVisible }
 
     /**
      * @return `true` if the command should **not** be visible (in help content, for example).
      */
-    val isNotVisible: Boolean
+    override val isNotVisible: Boolean
         get() = !isVisible
 
     /**
      * Returns the most important un-usability reason.
      */
-    val bestReason: UnusableReason
+    override val bestReason: UnusableReason
         get() = unusableReasons.maxBy { it.priority }
 
-    enum class UnusableReason(
-        internal val priority: Int,
-        /**
-         * Returns `true` if the command should be visible, even if unusable (in help content, for example).
-         */
-        val isVisible: Boolean
-    ) {
-        HIDDEN          (priority = 4, isVisible = false),
-        OWNER_ONLY      (priority = 3, isVisible = false),
-        USER_PERMISSIONS(priority = 2, isVisible = false),
-        BOT_PERMISSIONS (priority = 1, isVisible = true),
-        NSFW_ONLY       (priority = 0, isVisible = false)
-    }
-
     internal companion object {
-        @JvmSynthetic
         internal inline fun build(crossinline block: EnumSet<UnusableReason>.() -> Unit) =
             enumSetOf<UnusableReason>()
                 .apply(block)
                 .unmodifiableView()
-                .let(::Usability)
+                .let(::UsabilityImpl)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/UsabilityImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/UsabilityImpl.kt
@@ -6,36 +6,18 @@ import io.github.freya022.botcommands.api.core.utils.enumSetOf
 import io.github.freya022.botcommands.api.core.utils.unmodifiableView
 import java.util.*
 
-/**
- * Represents whether a command can be used, and if it should be visible.
- */
 internal class UsabilityImpl private constructor(override val unusableReasons: Set<UnusableReason>) : Usability {
-    /**
-     * Returns `true` if the command can be executed.
-     */
     override val isUsable: Boolean
         get() = unusableReasons.isEmpty()
 
-    /**
-     * Returns `true` if the command cannot be executed.
-     */
     override val isNotUsable: Boolean
         get() = !isUsable
 
-    /**
-     * Returns `true` if the command should be visible, even if unusable (in help content, for example).
-     */
     override val isVisible: Boolean = unusableReasons.all { it.isVisible }
 
-    /**
-     * @return `true` if the command should **not** be visible (in help content, for example).
-     */
     override val isNotVisible: Boolean
         get() = !isVisible
 
-    /**
-     * Returns the most important un-usability reason.
-     */
     override val bestReason: UnusableReason
         get() = unusableReasons.maxBy { it.priority }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandInfoImpl.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.internal.commands.application
 
+import io.github.freya022.botcommands.api.commands.Usability.UnusableReason
 import io.github.freya022.botcommands.api.commands.application.ApplicationCommandFilter
 import io.github.freya022.botcommands.api.commands.application.ApplicationCommandInfo
 import io.github.freya022.botcommands.api.commands.application.builder.ApplicationCommandBuilder
@@ -11,8 +12,7 @@ import io.github.freya022.botcommands.api.core.utils.loggerOf
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.internal.ExecutableMixin
 import io.github.freya022.botcommands.internal.commands.AbstractCommandInfoImpl
-import io.github.freya022.botcommands.internal.commands.Usability
-import io.github.freya022.botcommands.internal.commands.Usability.UnusableReason
+import io.github.freya022.botcommands.internal.commands.UsabilityImpl
 import io.github.freya022.botcommands.internal.commands.application.slash.SlashUtils.isFakeSlashFunction
 import io.github.freya022.botcommands.internal.core.reflection.MemberParamFunction
 import io.github.freya022.botcommands.internal.utils.classRef
@@ -61,7 +61,7 @@ internal abstract class ApplicationCommandInfoImpl internal constructor(
         }
     }
 
-    final override fun getUsability(inputUser: InputUser, channel: MessageChannel): Usability = Usability.build {
+    final override fun getUsability(inputUser: InputUser, channel: MessageChannel): UsabilityImpl = UsabilityImpl.build {
         // Nothing to check outside a guild
         val member = inputUser.member
             ?: return@build logger.trace { "Skipping usability checks for non-members" }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandInfoImpl.kt
@@ -5,18 +5,27 @@ import io.github.freya022.botcommands.api.commands.application.ApplicationComman
 import io.github.freya022.botcommands.api.commands.application.builder.ApplicationCommandBuilder
 import io.github.freya022.botcommands.api.core.Filter
 import io.github.freya022.botcommands.api.core.Logging
+import io.github.freya022.botcommands.api.core.entities.InputUser
 import io.github.freya022.botcommands.api.core.utils.isSubclassOf
+import io.github.freya022.botcommands.api.core.utils.loggerOf
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.internal.ExecutableMixin
 import io.github.freya022.botcommands.internal.commands.AbstractCommandInfoImpl
+import io.github.freya022.botcommands.internal.commands.Usability
+import io.github.freya022.botcommands.internal.commands.Usability.UnusableReason
 import io.github.freya022.botcommands.internal.commands.application.slash.SlashUtils.isFakeSlashFunction
 import io.github.freya022.botcommands.internal.core.reflection.MemberParamFunction
 import io.github.freya022.botcommands.internal.utils.classRef
 import io.github.freya022.botcommands.internal.utils.reference
 import io.github.freya022.botcommands.internal.utils.shortSignature
 import io.github.freya022.botcommands.internal.utils.throwArgument
+import io.github.oshai.kotlinlogging.KotlinLogging
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent
 import kotlin.reflect.jvm.jvmErasure
+
+private val logger = KotlinLogging.loggerOf<ApplicationCommandInfo>()
 
 internal abstract class ApplicationCommandInfoImpl internal constructor(
     builder: ApplicationCommandBuilder<*>
@@ -50,5 +59,19 @@ internal abstract class ApplicationCommandInfoImpl internal constructor(
         } else if (eventType.isSubclassOf<GUILD_T>()) {
             throwArgument(kFunction, "Cannot use ${classRef<GUILD_T>()} on a global application command")
         }
+    }
+
+    final override fun getUsability(inputUser: InputUser, channel: MessageChannel): Usability = Usability.build {
+        // Nothing to check outside a guild
+        val member = inputUser.member
+            ?: return@build logger.trace { "Skipping usability checks for non-members" }
+        if (channel !is GuildMessageChannel)
+            return@build logger.warn { "Cannot get usability outside of a ${classRef<GuildMessageChannel>()}" }
+
+        val guild = channel.guild
+        if (!guild.selfMember.hasPermission(channel, botPermissions)) add(UnusableReason.BOT_PERMISSIONS)
+
+        val isNotOwner = !context.isOwner(inputUser.idLong)
+        if (isNotOwner && !member.hasPermission(channel, userPermissions)) add(UnusableReason.USER_PERMISSIONS)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/HelpCommand.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/HelpCommand.kt
@@ -14,7 +14,6 @@ import io.github.freya022.botcommands.api.core.service.getInterfacedServices
 import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.*
 import io.github.freya022.botcommands.api.localization.DefaultMessagesFactory
-import io.github.freya022.botcommands.internal.commands.Usability
 import io.github.freya022.botcommands.internal.commands.text.TextUtils.getSpacedPath
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.utils.reference
@@ -100,8 +99,8 @@ internal class HelpCommand internal constructor(
 
     private suspend fun sendCommandHelp(event: BaseCommandEvent, commandInfo: TextCommandInfo, temporary: Boolean) {
         val member = event.member
-        val usability = Usability.of(commandInfo, member, event.guildChannel, !context.isOwner(member.idLong))
-        if (usability.isNotShowable) {
+        val usability = commandInfo.getUsability(member, event.guildChannel)
+        if (usability.isNotVisible) {
             return event.respond("Command '" + commandInfo.path.getSpacedPath() + "' does not exist").awaitUnit()
         }
 
@@ -122,9 +121,8 @@ internal class HelpCommand internal constructor(
         builder.setTimestamp(Instant.now())
         builder.setColor(member.colorRaw)
 
-        val isNotOwner = !context.isOwner(member.idLong)
         textCommandsContext.rootCommands
-            .filter { Usability.of(it, member, channel, isNotOwner).isShowable }
+            .filter { it.getUsability(member, channel).isVisible }
             .groupByTo(TreeMap(String.CASE_INSENSITIVE_ORDER)) { it.category }
             .forEach { (category, commands) ->
                 val commandListStr =

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandInfoImpl.kt
@@ -5,8 +5,16 @@ import io.github.freya022.botcommands.api.commands.text.builder.TextCommandBuild
 import io.github.freya022.botcommands.api.core.utils.toImmutableList
 import io.github.freya022.botcommands.api.core.utils.unmodifiableView
 import io.github.freya022.botcommands.internal.commands.AbstractCommandInfoImpl
+import io.github.freya022.botcommands.internal.commands.Usability
+import io.github.freya022.botcommands.internal.commands.Usability.UnusableReason
 import io.github.freya022.botcommands.internal.utils.putIfAbsentOrThrow
+import io.github.freya022.botcommands.internal.utils.throwInternal
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
+import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildMessageChannel
+import java.util.*
 import java.util.function.Consumer
 
 internal sealed class TextCommandInfoImpl(
@@ -39,6 +47,35 @@ internal sealed class TextCommandInfoImpl(
                     }
                 }
             }
+        }
+    }
+
+    final override fun getUsability(member: Member, channel: GuildMessageChannel) = Usability.build {
+        val isNotOwner = !context.isOwner(member.idLong)
+        if (isNotOwner && hidden) add(UnusableReason.HIDDEN)
+        if (isNotOwner && isOwnerRequired) add(UnusableReason.OWNER_ONLY)
+
+        checkNSFW(channel)
+
+        if (isNotOwner && !member.hasPermission(channel, userPermissions)) add(UnusableReason.USER_PERMISSIONS)
+        if (!channel.guild.selfMember.hasPermission(channel, botPermissions)) add(UnusableReason.BOT_PERMISSIONS)
+    }
+
+    context(EnumSet<UnusableReason>)
+    private fun checkNSFW(channel: GuildMessageChannel) {
+        // Do not run if command is not NSFW
+        if (!nsfw) return
+
+        if (channel is ThreadChannel) {
+            return checkNSFW(channel.parentMessageChannel)
+        }
+
+        if (channel is StandardGuildMessageChannel) {
+            if (!channel.isNSFW) {
+                add(UnusableReason.NSFW_ONLY)
+            }
+        } else {
+            throwInternal("Unsupported channel: $channel")
         }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandInfoImpl.kt
@@ -1,12 +1,12 @@
 package io.github.freya022.botcommands.internal.commands.text
 
+import io.github.freya022.botcommands.api.commands.Usability.UnusableReason
 import io.github.freya022.botcommands.api.commands.text.TextCommandInfo
 import io.github.freya022.botcommands.api.commands.text.builder.TextCommandBuilder
 import io.github.freya022.botcommands.api.core.utils.toImmutableList
 import io.github.freya022.botcommands.api.core.utils.unmodifiableView
 import io.github.freya022.botcommands.internal.commands.AbstractCommandInfoImpl
-import io.github.freya022.botcommands.internal.commands.Usability
-import io.github.freya022.botcommands.internal.commands.Usability.UnusableReason
+import io.github.freya022.botcommands.internal.commands.UsabilityImpl
 import io.github.freya022.botcommands.internal.utils.putIfAbsentOrThrow
 import io.github.freya022.botcommands.internal.utils.throwInternal
 import net.dv8tion.jda.api.EmbedBuilder
@@ -50,7 +50,7 @@ internal sealed class TextCommandInfoImpl(
         }
     }
 
-    final override fun getUsability(member: Member, channel: GuildMessageChannel) = Usability.build {
+    final override fun getUsability(member: Member, channel: GuildMessageChannel) = UsabilityImpl.build {
         val isNotOwner = !context.isOwner(member.idLong)
         if (isNotOwner && hidden) add(UnusableReason.HIDDEN)
         if (isNotOwner && isOwnerRequired) add(UnusableReason.OWNER_ONLY)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandInfoImpl.kt
@@ -11,9 +11,9 @@ import io.github.freya022.botcommands.internal.utils.putIfAbsentOrThrow
 import io.github.freya022.botcommands.internal.utils.throwInternal
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.channel.attribute.IAgeRestrictedChannel
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
 import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
-import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildMessageChannel
 import java.util.*
 import java.util.function.Consumer
 
@@ -70,7 +70,7 @@ internal sealed class TextCommandInfoImpl(
             return checkNSFW(channel.parentMessageChannel)
         }
 
-        if (channel is StandardGuildMessageChannel) {
+        if (channel is IAgeRestrictedChannel) {
             if (!channel.isNSFW) {
                 add(UnusableReason.NSFW_ONLY)
             }


### PR DESCRIPTION
- Made `Usability` a public API, you can get one by using `getUsability` on `TextCommandInfo`/`ApplicationCommandInfo`
  - Allows checking if a given command is visible and/or usable
- Added support any NSFW channel in text commands (previous was only text and news)