### PR TITLE
Add `BotOwners` service

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandInfo.kt
@@ -3,7 +3,7 @@ package io.github.freya022.botcommands.api.commands.text
 import io.github.freya022.botcommands.api.commands.CommandInfo
 import io.github.freya022.botcommands.api.commands.Usability
 import io.github.freya022.botcommands.api.commands.text.builder.TextCommandBuilder
-import io.github.freya022.botcommands.api.core.config.BConfig
+import io.github.freya022.botcommands.api.core.BotOwners
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.channel.attribute.IAgeRestrictedChannel
@@ -47,7 +47,7 @@ interface TextCommandInfo : CommandInfo {
     val nsfw: Boolean
 
     /**
-     * Whether this command can only be run by the [bot owners][BConfig.ownerIds].
+     * Whether this command can only be run by the [bot owners][BotOwners].
      *
      * Owner-only commands are hidden in the built-in help content,
      * but will still be responded to if a user tries to use it,
@@ -59,7 +59,7 @@ interface TextCommandInfo : CommandInfo {
      * Whether this command is hidden.
      *
      * This command and its subcommands are hidden from help content and cannot run,
-     * except for [bot owners][BConfig.ownerIds].
+     * except for [bot owners][BotOwners].
      */
     val hidden: Boolean
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/Hidden.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/Hidden.kt
@@ -5,7 +5,7 @@ import io.github.freya022.botcommands.api.core.config.BConfigBuilder
 
 /**
  * Hides a command and its subcommands from help content and execution,
- * except for [bot owners][BConfigBuilder.ownerIds].
+ * except for [bot owners][BConfigBuilder.predefinedOwnerIds].
  *
  * **Note:** This applies to the command itself, not only this variation,
  * in other words, this applies to all commands with the same path.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/Hidden.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/Hidden.kt
@@ -1,11 +1,11 @@
 package io.github.freya022.botcommands.api.commands.text.annotations
 
 import io.github.freya022.botcommands.api.commands.text.builder.TextCommandBuilder
-import io.github.freya022.botcommands.api.core.config.BConfigBuilder
+import io.github.freya022.botcommands.api.core.BotOwners
 
 /**
  * Hides a command and its subcommands from help content and execution,
- * except for [bot owners][BConfigBuilder.predefinedOwnerIds].
+ * except for [bot owners][BotOwners].
  *
  * **Note:** This applies to the command itself, not only this variation,
  * in other words, this applies to all commands with the same path.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/builder/TextCommandBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/builder/TextCommandBuilder.kt
@@ -12,7 +12,7 @@ import io.github.freya022.botcommands.api.commands.text.annotations.NSFW
 import io.github.freya022.botcommands.api.commands.text.annotations.RequireOwner
 import io.github.freya022.botcommands.api.commands.text.annotations.TextCommandData
 import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.core.config.BConfigBuilder
+import io.github.freya022.botcommands.api.core.BotOwners
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.internal.utils.Checks
 import java.util.function.Consumer
@@ -58,7 +58,7 @@ abstract class TextCommandBuilder internal constructor(context: BContext, name: 
 
     /**
      * Hides a command and its subcommands from help content and execution,
-     * except for [bot owners][BConfigBuilder.ownerIds].
+     * except for [bot owners][BotOwners].
      *
      * @see Hidden
      */

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/ComponentInteractionFilter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/ComponentInteractionFilter.kt
@@ -51,9 +51,9 @@ import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteract
  * ### Example - Rejecting component interactions from non-owners
  * ```kt
  * @BService
- * class MyComponentFilter(private val context: BContext) : ComponentInteractionFilter<String> {
+ * class MyComponentFilter(private val botOwners: BotOwners) : ComponentInteractionFilter<String> {
  *     override suspend fun checkSuspend(event: GenericComponentInteractionCreateEvent, handlerName: String?): String? {
- *         if (event.channel.idLong == 932902082724380744 && event.user.idLong !in context.ownerIds) {
+ *         if (event.channel.idLong == 932902082724380744 && event.user !in botOwners) {
  *             return "Only owners are allowed to use components in <#932902082724380744>"
  *         }
  *         return null
@@ -66,16 +66,16 @@ import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteract
  * ```java
  * @BService
  * public class MyComponentFilter implements ComponentInteractionFilter<String> {
- *     private final BContext context;
+ *     private final BotOwners botOwners;
  *
- *     public MyComponentFilter(BContext context) {
- *         this.context = context;
+ *     public MyComponentFilter(BotOwners botOwners) {
+ *         this.botOwners = botOwners;
  *     }
  *
  *     @Nullable
  *     @Override
  *     public String check(@NotNull GenericComponentInteractionCreateEvent event, @Nullable String handlerName) {
- *         if (event.getChannel().getIdLong() == 932902082724380744L && context.isOwner(event.getUser().getIdLong())) {
+ *         if (event.getChannel().getIdLong() == 932902082724380744L && !botOwners.isOwner(event.getUser())) {
  *             return "Only owners are allowed to use components in <#932902082724380744>";
  *         }
  *         return null;

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/BContext.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/BContext.kt
@@ -16,6 +16,7 @@ import io.github.freya022.botcommands.api.localization.DefaultMessagesFactory
 import io.github.freya022.botcommands.internal.core.exceptions.ServiceException
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.UserSnowflake
 import net.dv8tion.jda.api.interactions.DiscordLocale
 import net.dv8tion.jda.api.interactions.Interaction
 import kotlin.reflect.KFunction
@@ -118,9 +119,13 @@ interface BContext {
     /**
      * Returns the IDs of the bot owners.
      *
-     * @see BConfig.ownerIds
+     * @see BotOwners.ownerIds
      */
-    val ownerIds: Collection<Long> get() = config.ownerIds
+    @Deprecated(
+        message = "Get from BotOwners directly",
+        replaceWith = ReplaceWith("botOwners.ownerIds")
+    )
+    val ownerIds: Collection<Long> get() = botOwners.ownerIds
 
     /**
      * Returns the [SettingsProvider] service, or `null` if none exists.
@@ -144,7 +149,14 @@ interface BContext {
      *
      * @return `true` if the user is an owner
      */
-    fun isOwner(userId: Long): Boolean = userId in ownerIds
+    @Deprecated(
+        message = "Prefer using BotOwners#isOwner/contains",
+        replaceWith = ReplaceWith(
+            expression = "UserSnowflake.fromId(userId) in botOwners",
+            imports = ["net.dv8tion.jda.api.entities.UserSnowflake"]
+        )
+    )
+    fun isOwner(userId: Long): Boolean = UserSnowflake.fromId(userId) in botOwners
 
     /**
      * Returns the [DefaultMessages] instance for the provided Discord locale.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/BContext.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/BContext.kt
@@ -109,6 +109,13 @@ interface BContext {
     val status: Status
 
     /**
+     * Returns the [BotOwners] service.
+     *
+     * @see BotOwners
+     */
+    val botOwners: BotOwners
+
+    /**
      * Returns the IDs of the bot owners.
      *
      * @see BConfig.ownerIds

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwners.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwners.kt
@@ -13,7 +13,7 @@ import net.dv8tion.jda.api.entities.UserSnowflake
 @InterfacedService(acceptMultiple = false)
 interface BotOwners {
     /**
-     * The owners of this bot, uses [BConfigBuilder.ownerIds] if configured,
+     * The owners of this bot, uses [BConfigBuilder.predefinedOwnerIds] if configured,
      * else retrieve the owners from Discord, where only owners, admin and developers are taken.
      *
      * Allows bypassing cooldowns, user permission checks,

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwners.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwners.kt
@@ -1,0 +1,27 @@
+package io.github.freya022.botcommands.api.core
+
+import io.github.freya022.botcommands.api.core.config.BConfigBuilder
+import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService
+import net.dv8tion.jda.api.entities.UserSnowflake
+
+@InterfacedService(acceptMultiple = false)
+interface BotOwners {
+    /**
+     * The owners of this bot, uses [BConfigBuilder.ownerIds] if configured,
+     * else retrieve the owners from Discord, where only owners, admin and developers are taken.
+     *
+     * Allows bypassing cooldowns, user permission checks,
+     * and having hidden commands shown.
+     */
+    val ownerIds: Collection<Long>
+
+    /**
+     * Whether this user is one of the bot owners.
+     *
+     * Allows bypassing cooldowns, user permission checks,
+     * and having hidden commands shown.
+     *
+     * @see UserSnowflake.fromId
+     */
+    fun isOwner(user: UserSnowflake): Boolean
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwners.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwners.kt
@@ -4,6 +4,12 @@ import io.github.freya022.botcommands.api.core.config.BConfigBuilder
 import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService
 import net.dv8tion.jda.api.entities.UserSnowflake
 
+/**
+ * Holds owners of this bot.
+ *
+ * Bot owners are allowed to bypass cooldowns, user permission checks,
+ * and have hidden commands shown.
+ */
 @InterfacedService(acceptMultiple = false)
 interface BotOwners {
     /**
@@ -24,4 +30,6 @@ interface BotOwners {
      * @see UserSnowflake.fromId
      */
     fun isOwner(user: UserSnowflake): Boolean
+
+    operator fun contains(user: UserSnowflake): Boolean = isOwner(user)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwnersImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwnersImpl.kt
@@ -35,7 +35,7 @@ class BotOwnersImpl internal constructor(
     }
 
     init {
-        val ownerIds = config.ownerIds
+        val ownerIds = config.predefinedOwnerIds
         if (ownerIds.isNotEmpty()) {
             logger.debug { "Using predefined bot owners, IDs: ${ownerIds.joinToString()}" }
             owners = TLongHashSet(ownerIds)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwnersImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwnersImpl.kt
@@ -27,7 +27,7 @@ private val notifiedRoles = setOf("admin", "developer")
 class BotOwnersImpl internal constructor(
     config: BConfig,
 ) : BotOwners {
-    private val ownerWriter = WriteOnce<TLongSet>()
+    private val ownerWriter = WriteOnce<TLongSet>(wait = true)
     private var owners: TLongSet by ownerWriter
 
     override val ownerIds: Collection<Long> by lazy {

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwnersImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwnersImpl.kt
@@ -1,0 +1,85 @@
+package io.github.freya022.botcommands.api.core
+
+import dev.minn.jda.ktx.coroutines.await
+import gnu.trove.set.TLongSet
+import gnu.trove.set.hash.TLongHashSet
+import io.github.freya022.botcommands.api.core.annotations.BEventListener
+import io.github.freya022.botcommands.api.core.config.BConfig
+import io.github.freya022.botcommands.api.core.events.InjectedJDAEvent
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.core.utils.joinAsList
+import io.github.freya022.botcommands.api.core.utils.unmodifiableView
+import io.github.freya022.botcommands.internal.utils.WriteOnce
+import io.github.oshai.kotlinlogging.KotlinLogging
+import net.dv8tion.jda.api.entities.UserSnowflake
+import net.dv8tion.jda.api.requests.Route
+import net.dv8tion.jda.api.utils.data.DataObject
+import net.dv8tion.jda.api.utils.data.DataPath
+import net.dv8tion.jda.internal.JDAImpl
+import net.dv8tion.jda.internal.requests.RestActionImpl
+
+private val logger = KotlinLogging.logger { }
+
+//private val notifiedRoles = enumSetOf(RoleType.OWNER, RoleType.ADMIN, RoleType.DEVELOPER)
+private val notifiedRoles = setOf("admin", "developer")
+
+@BService
+class BotOwnersImpl internal constructor(
+    config: BConfig,
+) : BotOwners {
+    private val ownerWriter = WriteOnce<TLongSet>()
+    private var owners: TLongSet by ownerWriter
+
+    override val ownerIds: Collection<Long> by lazy {
+        owners.toArray().toHashSet().unmodifiableView()
+    }
+
+    init {
+        val ownerIds = config.ownerIds
+        if (ownerIds.isNotEmpty()) {
+            logger.debug { "Using predefined bot owners, IDs: ${ownerIds.joinToString()}" }
+            owners = TLongHashSet(ownerIds)
+        }
+
+        logger.debug { "Reminder that bot owners will bypass cooldowns, user permissions checks, and will have hidden and owner-only commands be displayed and usable" }
+    }
+
+    @BEventListener
+    internal suspend fun onInjectedJDA(event: InjectedJDAEvent) {
+        if (ownerWriter.isInitialized()) return
+
+        lateinit var rawAppInfo: DataObject
+        val appInfo = RestActionImpl(event.jda, Route.Applications.GET_BOT_APPLICATION.compile()) { response, _ ->
+            rawAppInfo = response.`object`
+            (event.jda as JDAImpl).entityBuilder.createApplicationInfo(response.`object`)
+        }.await()
+
+        val owners = when (val team = appInfo.team) {
+            null -> listOf(appInfo.owner)
+            else -> {
+                team.members.filterIndexed { index, _ ->
+                    DataPath.getString(rawAppInfo, "team.members[$index].role") in notifiedRoles
+                }.map { it.user }
+            }
+        }
+        this.owners = owners.map { it.idLong }.let(::TLongHashSet)
+
+        //TODO once JDA merges PR
+//        val owners = when (val team = appInfo.team) {
+//            null -> listOf(appInfo.owner)
+//            else -> team.members.filter { it.roleType in notifiedRoles }.map { it.user }
+//        }
+//        this.owners = owners.map { it.idLong }.let(::TLongHashSet)
+
+        if (logger.isTraceEnabled()) {
+            logger.trace {
+                val ownerList = owners.joinAsList { "${it.name} (${it.id})" }
+                "Registered ${owners.size} bot owners:\n${ownerList.prependIndent()}"
+            }
+        } else {
+            logger.debug { "Registered ${owners.size} bot owners: ${owners.joinToString { it.name }}" }
+        }
+    }
+
+    override fun isOwner(user: UserSnowflake): Boolean = user.idLong in owners
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwnersImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/BotOwnersImpl.kt
@@ -44,6 +44,8 @@ class BotOwnersImpl internal constructor(
         logger.debug { "Reminder that bot owners will bypass cooldowns, user permissions checks, and will have hidden and owner-only commands be displayed and usable" }
     }
 
+    override fun isOwner(user: UserSnowflake): Boolean = user.idLong in owners
+
     @BEventListener
     internal suspend fun onInjectedJDA(event: InjectedJDAEvent) {
         if (ownerWriter.isInitialized()) return
@@ -80,6 +82,4 @@ class BotOwnersImpl internal constructor(
             logger.debug { "Registered ${owners.size} bot owners: ${owners.joinToString { it.name }}" }
         }
     }
-
-    override fun isOwner(user: UserSnowflake): Boolean = user.idLong in owners
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandInfoImpl.kt
@@ -71,7 +71,7 @@ internal abstract class ApplicationCommandInfoImpl internal constructor(
         val guild = channel.guild
         if (!guild.selfMember.hasPermission(channel, botPermissions)) add(UnusableReason.BOT_PERMISSIONS)
 
-        val isNotOwner = !context.isOwner(inputUser.idLong)
+        val isNotOwner = inputUser !in context.botOwners
         if (isNotOwner && !member.hasPermission(channel, userPermissions)) add(UnusableReason.USER_PERMISSIONS)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandListener.kt
@@ -63,7 +63,7 @@ internal class ApplicationCommandListener internal constructor(
                     ?: return@launch onCommandNotFound(event, "A slash command could not be found: ${event.fullCommandName}")
             } as SlashCommandInfoImpl
 
-            val isNotOwner = !context.isOwner(event.user.idLong)
+            val isNotOwner = event.user !in context.botOwners
             slashCommand.withRateLimit(context, event, isNotOwner) { cancellableRateLimit ->
                 if (!canRun(event, slashCommand)) {
                     false
@@ -89,7 +89,7 @@ internal class ApplicationCommandListener internal constructor(
                     ?: return@launch onCommandNotFound(event, "A user context command could not be found: ${event.name}")
             } as UserCommandInfoImpl
 
-            val isNotOwner = !context.isOwner(event.user.idLong)
+            val isNotOwner = event.user !in context.botOwners
             userCommand.withRateLimit(context, event, isNotOwner) { cancellableRateLimit ->
                 if (!canRun(event, userCommand)) {
                     false
@@ -115,7 +115,7 @@ internal class ApplicationCommandListener internal constructor(
                     ?: return@launch onCommandNotFound(event, "A message context command could not be found: ${event.name}")
             } as MessageCommandInfoImpl
 
-            val isNotOwner = !context.isOwner(event.user.idLong)
+            val isNotOwner = event.user !in context.botOwners
             messageCommand.withRateLimit(context, event, isNotOwner) { cancellableRateLimit ->
                 if (!canRun(event, messageCommand)) {
                     false

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandInfoImpl.kt
@@ -51,7 +51,7 @@ internal sealed class TextCommandInfoImpl(
     }
 
     final override fun getUsability(member: Member, channel: GuildMessageChannel) = UsabilityImpl.build {
-        val isNotOwner = !context.isOwner(member.idLong)
+        val isNotOwner = member !in context.botOwners
         if (isNotOwner && hidden) add(UnusableReason.HIDDEN)
         if (isNotOwner && isOwnerRequired) add(UnusableReason.OWNER_ONLY)
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
@@ -75,12 +75,12 @@ internal class TextCommandsListener internal constructor(
 
         scope.launchCatching({ handleException(event, it, msg) }) launch@{
             val member = event.member ?: throwInternal("Command caller member is null ! This shouldn't happen if the message isn't a webhook, or is the docs wrong ?")
-            val isNotOwner = !context.config.isOwner(member.idLong)
+            val isNotOwner = member !in context.botOwners
 
             val (commandInfo: TextCommandInfoImpl, args: String) = findCommandWithArgs(content, isNotOwner) ?: let {
                 // At this point no top level command was found,
                 // if a subcommand wasn't matched, it would simply appear in the args
-                onCommandNotFound(event, content.substringBefore(' '), isNotOwner)
+                onCommandNotFound(event, content.substringBefore(' '))
                 return@launch
             }
 
@@ -244,7 +244,7 @@ internal class TextCommandsListener internal constructor(
         }
     }
 
-    private suspend fun onCommandNotFound(event: MessageReceivedEvent, commandName: String, isNotOwner: Boolean) {
+    private suspend fun onCommandNotFound(event: MessageReceivedEvent, commandName: String) {
         if (!context.textConfig.showSuggestions) return
 
         val candidates = context.textCommandsContext.rootCommands

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
@@ -102,7 +102,7 @@ internal class ComponentsListener(
                 }
             }
 
-            component.withRateLimit(context, event, !context.isOwner(event.user.idLong)) { cancellableRateLimit ->
+            component.withRateLimit(context, event, event.user !in context.botOwners) { cancellableRateLimit ->
                 if (!component.constraints.isAllowed(event)) {
                     event.reply_(defaultMessagesFactory.get(event).componentNotAllowedErrorMsg, ephemeral = true).queue()
                     return@withRateLimit false

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/BContextImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/BContextImpl.kt
@@ -1,11 +1,8 @@
 package io.github.freya022.botcommands.internal.core
 
 import io.github.freya022.botcommands.api.BCInfo
-import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.*
 import io.github.freya022.botcommands.api.core.BContext.Status
-import io.github.freya022.botcommands.api.core.EventDispatcher
-import io.github.freya022.botcommands.api.core.GlobalExceptionHandler
-import io.github.freya022.botcommands.api.core.SettingsProvider
 import io.github.freya022.botcommands.api.core.config.BConfig
 import io.github.freya022.botcommands.api.core.events.BStatusChangeEvent
 import io.github.freya022.botcommands.api.core.service.ServiceContainer
@@ -28,7 +25,11 @@ import kotlin.time.Duration.Companion.minutes
 private val logger = KotlinLogging.loggerOf<BContext>()
 
 @BService
-internal class BContextImpl internal constructor(override val config: BConfig, override val serviceContainer: ServiceContainer) : BContext {
+internal class BContextImpl internal constructor(
+    override val config: BConfig,
+    override val serviceContainer: ServiceContainer,
+    override val botOwners: BotOwners
+) : BContext {
     override val eventDispatcher: EventDispatcher by serviceContainer.lazy()
 
     override var status: Status = Status.PRE_LOAD

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
@@ -13,7 +13,7 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @ConfigurationProperties(prefix = "botcommands.core", ignoreUnknownFields = false)
 internal class BotCommandsCoreConfiguration(
-    override val ownerIds: Set<Long> = emptySet(),
+    override val predefinedOwnerIds: Set<Long> = emptySet(),
     override val packages: Set<String> = emptySet(),
     override val classes: Set<Class<*>> = emptySet(),
     override val disableExceptionsInDMs: Boolean = false,
@@ -21,6 +21,8 @@ internal class BotCommandsCoreConfiguration(
     override val ignoredIntents: Set<GatewayIntent> = emptySet(),
     override val ignoredEventIntents: Set<Class<out Event>> = emptySet(),
 ) : BConfig {
+    @Suppress("OVERRIDE_DEPRECATION")
+    override val ownerIds: Set<Long> get() = predefinedOwnerIds
     override val classGraphProcessors: Nothing get() = unusable()
     override val debugConfig: Nothing get() = unusable()
     override val serviceConfig: Nothing get() = unusable()
@@ -34,7 +36,7 @@ internal class BotCommandsCoreConfiguration(
 
 @OptIn(DevConfig::class)
 internal fun BConfigBuilder.applyConfig(configuration: BotCommandsCoreConfiguration) = apply {
-    ownerIds += configuration.ownerIds
+    predefinedOwnerIds += configuration.predefinedOwnerIds
     packages += configuration.packages
     classes += configuration.classes
     disableExceptionsInDMs = configuration.disableExceptionsInDMs

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/AbstractBotCommandsBootstrap.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/AbstractBotCommandsBootstrap.kt
@@ -24,16 +24,12 @@ internal abstract class AbstractBotCommandsBootstrap(protected val config: BConf
         logger.debug { "Loading BotCommands ${BCInfo.VERSION} (${BCInfo.BUILD_TIME}) ; Compiled with JDA ${BCInfo.BUILD_JDA_VERSION} ; Running with JDA ${JDAInfo.VERSION}" }
         Version.checkVersions()
 
-        if (config.ownerIds.isEmpty())
-            logger.info { "No owner ID specified, exceptions won't be sent to owners" }
         if (config.disableExceptionsInDMs)
             logger.info { "Configuration disabled sending exception in bot owners DMs" }
         if (config.disableAutocompleteCache)
             logger.info { "Configuration disabled autocomplete cache, except forced caches" }
         if (!config.textConfig.usePingAsPrefix && config.textConfig.prefixes.isEmpty())
             logger.info { "Text commands will not work as ping-as-prefix is disabled and no prefix has been added" }
-
-        logger.debug { "Reminder that bot owners will bypass cooldowns, user permissions checks, and will have hidden and owner-only commands be displayed and usable" }
 
         measure("Scanned reflection metadata") {
             ReflectionMetadata.runScan(config, this)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/utils/InternalUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/utils/InternalUtils.kt
@@ -8,6 +8,8 @@ import kotlinx.datetime.Instant
 import net.dv8tion.jda.api.entities.Guild
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
 import kotlin.time.Duration
 
 internal fun String.toDiscordString(): String {
@@ -98,3 +100,20 @@ internal fun Duration.toTimestampIfFinite(): Instant? =
 
 internal fun Duration.takeIfFinite(): Duration? =
     takeIf { it.isFinite() && it.isPositive() }
+
+internal class WriteOnce<T : Any> : ReadWriteProperty<Any?, T> {
+    private var value: T? = null
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        return value ?: throwState("Property ${property.name} must be initialized before getting it.")
+    }
+
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+        check(this.value == null) {
+            "Cannot set value twice"
+        }
+        this.value = value
+    }
+
+    internal fun isInitialized(): Boolean = value != null
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/utils/InternalUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/utils/InternalUtils.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.*
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import net.dv8tion.jda.api.entities.Guild
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import kotlin.properties.ReadWriteProperty
@@ -101,18 +103,29 @@ internal fun Duration.toTimestampIfFinite(): Instant? =
 internal fun Duration.takeIfFinite(): Duration? =
     takeIf { it.isFinite() && it.isPositive() }
 
-internal class WriteOnce<T : Any> : ReadWriteProperty<Any?, T> {
+internal class WriteOnce<T : Any>(private val wait: Boolean) : ReadWriteProperty<Any?, T> {
+    private val lock = ReentrantLock()
+    private val condition = lock.newCondition()
     private var value: T? = null
 
-    override fun getValue(thisRef: Any?, property: KProperty<*>): T {
-        return value ?: throwState("Property ${property.name} must be initialized before getting it.")
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T = lock.withLock {
+        val value = value
+        if (value != null) return value
+
+        if (wait)
+            condition.await()
+        else
+            throwState("Property ${property.name} must be initialized before getting it.")
+
+        return getValue(thisRef, property)
     }
 
-    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) = lock.withLock {
         check(this.value == null) {
             "Cannot set value twice"
         }
         this.value = value
+        condition.signalAll()
     }
 
     internal fun isInitialized(): Boolean = value != null

--- a/src/test/java/doc/java/examples/filters/MyComponentFilter.java
+++ b/src/test/java/doc/java/examples/filters/MyComponentFilter.java
@@ -1,7 +1,7 @@
 package doc.java.examples.filters;
 
 import io.github.freya022.botcommands.api.components.ComponentInteractionFilter;
-import io.github.freya022.botcommands.api.core.BContext;
+import io.github.freya022.botcommands.api.core.BotOwners;
 import io.github.freya022.botcommands.api.core.service.annotations.BService;
 import io.github.freya022.botcommands.test.switches.TestLanguage;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
@@ -11,16 +11,16 @@ import org.jetbrains.annotations.Nullable;
 @BService
 @TestLanguage(TestLanguage.Language.JAVA)
 public class MyComponentFilter implements ComponentInteractionFilter<String> {
-    private final BContext context;
+    private final BotOwners botOwners;
 
-    public MyComponentFilter(BContext context) {
-        this.context = context;
+    public MyComponentFilter(BotOwners botOwners) {
+        this.botOwners = botOwners;
     }
 
     @Nullable
     @Override
     public String check(@NotNull GenericComponentInteractionCreateEvent event, @Nullable String handlerName) {
-        if (event.getChannel().getIdLong() == 932902082724380744L && context.isOwner(event.getUser().getIdLong())) {
+        if (event.getChannel().getIdLong() == 932902082724380744L && !botOwners.isOwner(event.getUser())) {
             return "Only owners are allowed to use components in <#932902082724380744>";
         }
         return null;

--- a/src/test/kotlin/doc/kotlin/examples/filters/MyComponentFilter.kt
+++ b/src/test/kotlin/doc/kotlin/examples/filters/MyComponentFilter.kt
@@ -4,7 +4,7 @@ import dev.minn.jda.ktx.coroutines.await
 import dev.minn.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.components.ComponentInteractionFilter
 import io.github.freya022.botcommands.api.components.ComponentInteractionRejectionHandler
-import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.BotOwners
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.test.switches.TestLanguage
 import io.github.freya022.botcommands.test.switches.TestService
@@ -13,9 +13,9 @@ import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteract
 @BService
 @TestService
 @TestLanguage(TestLanguage.Language.KOTLIN)
-class MyComponentFilter(private val context: BContext) : ComponentInteractionFilter<String> {
+class MyComponentFilter(private val botOwners: BotOwners) : ComponentInteractionFilter<String> {
     override suspend fun checkSuspend(event: GenericComponentInteractionCreateEvent, handlerName: String?): String? {
-        if (event.channel.idLong == 932902082724380744 && event.user.idLong !in context.ownerIds) {
+        if (event.channel.idLong == 932902082724380744 && event.user !in botOwners) {
             return "Only owners are allowed to use components in <#932902082724380744>"
         }
         return null

--- a/src/test/kotlin/io/github/freya022/botcommands/test/filters/ComplexFilter.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/filters/ComplexFilter.kt
@@ -95,7 +95,7 @@ class IsGuildOwner(private val context: BContext) : ApplicationCommandFilter<Str
     ): String? = check(event.user)
 
     private fun check(userSnowflake: UserSnowflake): String? {
-        if (!context.isOwner(userSnowflake.idLong)) {
+        if (userSnowflake !in context.botOwners) {
             return "You must be the bot owner"
         }
         return null

--- a/src/test/kotlin/io/github/freya022/botcommands/test/filters/ComplexFilter.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/filters/ComplexFilter.kt
@@ -5,7 +5,7 @@ import io.github.freya022.botcommands.api.commands.application.ApplicationComman
 import io.github.freya022.botcommands.api.commands.text.TextCommandFilter
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.components.ComponentInteractionFilter
-import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.BotOwners
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.test.switches.TestService
 import net.dv8tion.jda.api.entities.Guild
@@ -75,7 +75,7 @@ class IsBotOwner : ApplicationCommandFilter<String>, TextCommandFilter<String>, 
 
 @BService
 @TestService
-class IsGuildOwner(private val context: BContext) : ApplicationCommandFilter<String>, TextCommandFilter<String>, ComponentInteractionFilter<String> {
+class IsGuildOwner(private val botOwners: BotOwners) : ApplicationCommandFilter<String>, TextCommandFilter<String>, ComponentInteractionFilter<String> {
     override val global: Boolean = false
 
     override suspend fun checkSuspend(
@@ -95,7 +95,7 @@ class IsGuildOwner(private val context: BContext) : ApplicationCommandFilter<Str
     ): String? = check(event.user)
 
     private fun check(userSnowflake: UserSnowflake): String? {
-        if (userSnowflake !in context.botOwners) {
+        if (userSnowflake !in botOwners) {
             return "You must be the bot owner"
         }
         return null


### PR DESCRIPTION
This service retrieves the bot owners from Discord if not configured.

Special rules applies when bot owners run commands, and get notified when the bot encounters an exception.

Use native feature once released: https://github.com/discord-jda/JDA/pull/2703