### PR TITLE
Improve text mention resolvers

### DIFF
--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
@@ -8,6 +8,7 @@ import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver;
+import io.github.freya022.botcommands.internal.utils.ExceptionsKt;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -29,7 +30,7 @@ public class RoleResolver
                    SlashParameterResolver<RoleResolver, Role>,
                    ComponentParameterResolver<RoleResolver, Role> {
 
-    private static final Pattern PATTERN = Pattern.compile("(?:<@&)?(\\d+)>?");
+    private static final Pattern PATTERN = Pattern.compile("<@&(\\d+)>|(\\d+)");
 
     public RoleResolver() {
         super(Role.class);
@@ -37,10 +38,15 @@ public class RoleResolver
 
     @Nullable
     @Override
-    public Role resolve(@NotNull TextCommandVariation variation, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
-        if (event.getGuild().getId().equals(args[0])) return null; //@everyone role
+    public Role resolve(@NotNull TextCommandVariation variation, @NotNull MessageReceivedEvent event, @Nullable String @NotNull [] args) {
+        final var id = args[0] != null ? args[0] : args[1];
+        if (id == null) {
+            ExceptionsKt.throwInternal("How can it not have either");
+            return null; //Nope
+        }
+        if (event.getGuild().getId().equals(id)) return null; //@everyone role
 
-        return event.getGuild().getRoleById(args[0]);
+        return event.getGuild().getRoleById(id);
     }
 
     @Override

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TextParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TextParameterResolver.kt
@@ -58,6 +58,7 @@ interface TextParameterResolver<T, R : Any> : IParameterResolver<T>
      * This may be overridden if your pattern provides more groups than it actually needs to match a string,
      * such as patterns with `|`.
      */
+    @Deprecated("No longer required")
     val requiredGroups: Int get() = preferredPattern.matcher("").groupCount()
 
     /**

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/CommandPattern.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/CommandPattern.kt
@@ -126,7 +126,7 @@ internal object CommandPattern {
 
             return when {
                 optional -> "(?:$paddedPatternWithFlags)?"
-                else -> paddedPatternWithFlags
+                else -> "(?:$paddedPatternWithFlags)"
             }
         }
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandOptionImpl.kt
@@ -25,7 +25,6 @@ internal class TextCommandOptionImpl internal constructor(
         get() = resolver is QuotableTextParameterResolver
 
     val groupCount = resolver.preferredPattern.matcher("").groupCount()
-    val requiredGroups = resolver.requiredGroups
 
     override fun getResolverHelpExample(event: BaseCommandEvent) =
         resolver.getHelpExample(this, event)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
@@ -219,7 +219,7 @@ internal class TextCommandsListener internal constructor(
         variation: TextCommandVariationImpl,
         matchResult: MatchResult?
     ): ExecutionResult {
-        val optionValues = variation.tryParseOptionValues(event, args, matchResult)
+        val optionValues = variation.tryParseOptionValues(event, matchResult)
             ?: return ExecutionResult.CONTINUE //Go to next variation
 
         // At this point, we're sure that the command is executable

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
@@ -16,8 +16,8 @@ import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterRes
 import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.UserContextParameterResolver
 import io.github.freya022.botcommands.internal.commands.text.TextUtils.findEntity
+import io.github.freya022.botcommands.internal.utils.ifNullThrowInternal
 import io.github.freya022.botcommands.internal.utils.throwArgument
-import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
@@ -59,7 +59,9 @@ internal sealed class AbstractUserSnowflakeResolver<T : AbstractUserSnowflakeRes
         event: MessageReceivedEvent,
         args: Array<String?>
     ): R? {
-        val id = args[0]?.toLong() ?: throwInternal("Required pattern group is missing")
+        val id = args.filterNotNull()
+            .singleOrNull().ifNullThrowInternal { "Pattern matched but no args were present" }
+            .toLongOrNull().ifNullThrowInternal { "ID matched but was not a Long" }
         return retrieveOrNull(id, event.message)
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
@@ -105,6 +105,6 @@ internal sealed class AbstractUserSnowflakeResolver<T : AbstractUserSnowflakeRes
     protected abstract fun transformEntities(user: User, member: Member?): R?
 
     internal companion object {
-        internal val userMentionPattern = Pattern.compile("(?:<@!?)?(\\d+)>?")
+        internal val userMentionPattern = Pattern.compile("<@(\\d+)>|(\\d+)")
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -22,6 +22,7 @@ import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParamete
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver
 import io.github.freya022.botcommands.internal.parameters.resolvers.ChannelResolverFactory.ChannelResolver
+import io.github.freya022.botcommands.internal.utils.ifNullThrowInternal
 import io.github.freya022.botcommands.internal.utils.throwArgument
 import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -74,7 +75,9 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
             event: MessageReceivedEvent,
             args: Array<String?>
         ): GuildChannel? {
-            val channelId = args[0]!!.toLong()
+            val channelId = args.filterNotNull()
+                .singleOrNull().ifNullThrowInternal { "Pattern matched but no args were present" }
+                .toLongOrNull().ifNullThrowInternal { "ID matched but was not a Long" }
             val channel = event.guild.getChannelById(type, channelId)
             if (channel == null) {
                 if (ThreadChannel::class.java.isAssignableFrom(type))

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -160,7 +160,7 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
         }
 
         private companion object {
-            private val channelPattern = Pattern.compile("(?:<#)?(\\d+)>?")
+            private val channelPattern = Pattern.compile("<#(\\d+)>|(\\d+)")
             private val logger = KotlinLogging.logger { }
         }
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IMentionableResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IMentionableResolver.kt
@@ -26,7 +26,7 @@ internal object IMentionableResolver : ClassParameterResolver<IMentionableResolv
     //region Text
     override val pattern: Pattern =
         enumSetOf(MentionType.CHANNEL, MentionType.USER, MentionType.ROLE, MentionType.EMOJI, MentionType.SLASH_COMMAND)
-            .joinToString(separator = "|") { "(?:${it.pattern.pattern()})" }
+            .joinToString(separator = "|") { it.pattern.pattern() }
             .toPattern()
     override val testExample: String = "</name group sub:1234>"
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IMentionableResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IMentionableResolver.kt
@@ -30,8 +30,6 @@ internal object IMentionableResolver : ClassParameterResolver<IMentionableResolv
             .toPattern()
     override val testExample: String = "</name group sub:1234>"
 
-    override val requiredGroups: Int = 1 //1 group minimum
-
     override fun getHelpExample(option: TextCommandOption, event: BaseCommandEvent): String {
         return event.member.asMention
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
@@ -11,6 +11,7 @@ import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParamete
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.UserContextParameterResolver
+import io.github.freya022.botcommands.internal.utils.ifNullThrowInternal
 import net.dv8tion.jda.api.entities.UserSnowflake
 import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
@@ -49,7 +50,12 @@ internal object UserSnowflakeResolver :
         variation: TextCommandVariation,
         event: MessageReceivedEvent,
         args: Array<String?>,
-    ): UserSnowflake = UserSnowflake.fromId(args[0]!!)
+    ): UserSnowflake {
+        val id = args.filterNotNull()
+            .singleOrNull().ifNullThrowInternal { "Pattern matched but no args were present" }
+            .toLongOrNull().ifNullThrowInternal { "ID matched but was not a Long" }
+        return UserSnowflake.fromId(id)
+    }
 
     override suspend fun resolveSuspend(info: UserCommandInfo, event: UserContextInteractionEvent): UserSnowflake =
         event.target

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ExecutionUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ExecutionUtils.kt
@@ -36,7 +36,7 @@ internal fun tryInsertNullableOption(value: Any?, option: OptionImpl, optionMap:
         }
     } else {
         //Value is null and is required
-        throwArgument(option.typeCheckingFunction, "Option #${option.index} (${option.declaredName}) couldn't be resolved, this could be due to a faulty ICustomResolver")
+        throwArgument(option.typeCheckingFunction, "Option #${option.index} (${option.declaredName}) couldn't be resolved")
     }
 
     return InsertOptionResult.SKIP

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/utils/InternalUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/utils/InternalUtils.kt
@@ -103,6 +103,12 @@ internal fun Duration.toTimestampIfFinite(): Instant? =
 internal fun Duration.takeIfFinite(): Duration? =
     takeIf { it.isFinite() && it.isPositive() }
 
+internal inline fun <reified T : Any> T?.ifNullThrowInternal(message: () -> String): T {
+    if (this == null)
+        throwInternal(message())
+    return this
+}
+
 internal class WriteOnce<T : Any>(private val wait: Boolean) : ReadWriteProperty<Any?, T> {
     private val lock = ReentrantLock()
     private val condition = lock.newCondition()

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/text/TextHelpTesting.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/text/TextHelpTesting.kt
@@ -26,6 +26,19 @@ class TextHelpTesting : TextCommand() {
                           @TextOption role: Role,
                           @TextOption string: String,
     ) {
-        event.respond("testing").queue()
+        event.respond("""
+            testing
+            $boolean
+            $double
+            ${emoji.formatted}
+            ${guild.name}
+            $int
+            $long
+            ${member.asMention}
+            ${user.asMention}
+            ${role.asMention}
+            $string
+            """.trimIndent()
+        ).setAllowedMentions(emptyList()).queue()
     }
 }


### PR DESCRIPTION
* No longer check how many groups were parsed
  * Was a thing from when text commands were reworked 3 years ago, but empty groups just show up as `null` in the array, so it should be safe
  * Deprecates `TextParameterResolver#requiredGroups`
* Wrap every pattern in a non-capturing group to prevent conflicts with other patterns
* Improved detection of mentions
  * Now reads either the full mention or the ID