### PR TITLE
Add annotated application command declaration filters

### DIFF
--- a/src/main/java/io/github/freya022/botcommands/api/commands/CommandList.java
+++ b/src/main/java/io/github/freya022/botcommands/api/commands/CommandList.java
@@ -1,5 +1,8 @@
 package io.github.freya022.botcommands.api.commands;
 
+import io.github.freya022.botcommands.api.commands.application.CommandDeclarationFilter;
+import io.github.freya022.botcommands.api.commands.application.annotations.DeclarationFilter;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
@@ -8,7 +11,10 @@ import java.util.stream.Collectors;
 /**
  * Represents a list of enabled commands, the enabled commands are only qualified by their base name.
  * <br><b>Keep in mind you cannot disable global commands on a per-guild basis.</b>
+ *
+ * @deprecated Replaced by {@link DeclarationFilter @DeclarationFilter} with {@link CommandDeclarationFilter}
  */
+@Deprecated
 public class CommandList {
     private final Predicate<CommandPath> filter;
 

--- a/src/main/java/io/github/freya022/botcommands/api/commands/application/CommandScope.java
+++ b/src/main/java/io/github/freya022/botcommands/api/commands/application/CommandScope.java
@@ -1,10 +1,8 @@
 package io.github.freya022.botcommands.api.commands.application;
 
-import io.github.freya022.botcommands.api.commands.CommandPath;
+import io.github.freya022.botcommands.api.commands.application.annotations.DeclarationFilter;
 import io.github.freya022.botcommands.api.commands.application.annotations.Test;
-import io.github.freya022.botcommands.api.core.SettingsProvider;
 import io.github.freya022.botcommands.api.core.config.BApplicationConfigBuilder;
-import net.dv8tion.jda.api.entities.Guild;
 
 /**
  * Defines command scopes for application commands.
@@ -12,7 +10,7 @@ import net.dv8tion.jda.api.entities.Guild;
 public enum CommandScope {
     /**
      * The guild command scope, only pushes application commands to the guilds
-     * <br>Can be filtered with {@link ApplicationCommand#getGuildsForCommandId(String, CommandPath)} and {@link SettingsProvider#getGuildCommands(Guild)}
+     * <br>Can be filtered with {@link DeclarationFilter @DeclarationFilter}.
      * <br>Can be forced with {@link BApplicationConfigBuilder#forceGuildCommands(boolean)} and {@link Test @Test}
      */
     GUILD(false, true),

--- a/src/main/java/io/github/freya022/botcommands/api/core/SettingsProvider.java
+++ b/src/main/java/io/github/freya022/botcommands/api/core/SettingsProvider.java
@@ -53,7 +53,7 @@ public interface SettingsProvider {
      * @see CommandList#notOf(Collection)
      * @see CommandList#filter(Predicate)
      *
-     * @deprecated Replaced by {@link DeclarationFilter} with {@link CommandDeclarationFilter}
+     * @deprecated Replaced by {@link DeclarationFilter @DeclarationFilter} with {@link CommandDeclarationFilter}
      */
     @NotNull
     @Deprecated

--- a/src/main/java/io/github/freya022/botcommands/api/core/SettingsProvider.java
+++ b/src/main/java/io/github/freya022/botcommands/api/core/SettingsProvider.java
@@ -1,6 +1,8 @@
 package io.github.freya022.botcommands.api.core;
 
 import io.github.freya022.botcommands.api.commands.CommandList;
+import io.github.freya022.botcommands.api.commands.application.CommandDeclarationFilter;
+import io.github.freya022.botcommands.api.commands.application.annotations.DeclarationFilter;
 import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder;
 import io.github.freya022.botcommands.api.core.service.annotations.BService;
 import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService;
@@ -50,8 +52,11 @@ public interface SettingsProvider {
      * @see CommandList#of(Collection)
      * @see CommandList#notOf(Collection)
      * @see CommandList#filter(Predicate)
+     *
+     * @deprecated Replaced by {@link DeclarationFilter} with {@link CommandDeclarationFilter}
      */
     @NotNull
+    @Deprecated
     default CommandList getGuildCommands(@NotNull Guild guild) {
         return CommandList.all();
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommand.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommand.kt
@@ -63,6 +63,7 @@ abstract class ApplicationCommand {
      *
      * @see CommandId @CommandId
      */
+    @Deprecated(message = "Replaced by DeclarationFilter and CommandDeclarationFilter")
     open fun getGuildsForCommandId(commandId: String, commandPath: CommandPath): Collection<Long>? {
         return null
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandsContext.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandsContext.kt
@@ -1,9 +1,11 @@
 package io.github.freya022.botcommands.api.commands.application
 
-import io.github.freya022.botcommands.api.commands.CommandList
 import io.github.freya022.botcommands.api.commands.CommandPath
+import io.github.freya022.botcommands.api.commands.application.annotations.DeclarationFilter
 import io.github.freya022.botcommands.api.commands.application.context.message.MessageCommandInfo
 import io.github.freya022.botcommands.api.commands.application.context.user.UserCommandInfo
+import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
+import io.github.freya022.botcommands.api.commands.application.provider.GuildApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService
 import kotlinx.coroutines.Deferred
@@ -82,6 +84,9 @@ interface ApplicationCommandsContext {
     /**
      * Updates the application commands for the global scope.
      *
+     * This will redeclare all [code-declared][GlobalApplicationCommandProvider]
+     * and annotated application commands.
+     *
      * @param force Whether the commands should be updated no matter what
      *
      * @return A [CompletableFuture]&lt;[CommandUpdateResult]&gt;
@@ -94,8 +99,8 @@ interface ApplicationCommandsContext {
     /**
      * Updates the application commands in the specified guild.
      *
-     * A use case may be to remove a command from a guild while the bot is running
-     * (either by filtering with [CommandList] or not running a DSL declaration).
+     * This will redeclare all [code-declared][GuildApplicationCommandProvider]
+     * and annotated application commands (after [filtering][DeclarationFilter]).
      *
      * @param guild The guild which needs to be updated
      * @param force Whether the commands should be updated no matter what

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/CommandDeclarationFilter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/CommandDeclarationFilter.kt
@@ -1,0 +1,27 @@
+package io.github.freya022.botcommands.api.commands.application
+
+import io.github.freya022.botcommands.api.commands.CommandPath
+import io.github.freya022.botcommands.api.commands.application.annotations.CommandId
+import io.github.freya022.botcommands.api.commands.application.annotations.DeclarationFilter
+import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import net.dv8tion.jda.api.entities.Guild
+
+/**
+ * A filter determining if an application command needs to be registered.
+ *
+ * **Usage**: Register your instance as a service with [@BService][BService]
+ * or [any annotation that enables your class for dependency injection][BServiceConfigBuilder.serviceAnnotations].
+ *
+ * @see DeclarationFilter @DeclarationFilter
+ */
+interface CommandDeclarationFilter {
+    /**
+     * Returns whether the provided command can be used in the provided guild.
+     *
+     * @param guild     The guild the command is going to be registered at
+     * @param path      The complete path of the command
+     * @param commandId The command ID set by [@CommandId][CommandId]
+     */
+    fun filter(guild: Guild, path: CommandPath, commandId: String?): Boolean
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/CommandDeclarationFilter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/CommandDeclarationFilter.kt
@@ -10,6 +10,8 @@ import net.dv8tion.jda.api.entities.Guild
 /**
  * A filter determining if an application command needs to be registered.
  *
+ * Needs to be referenced by a [@DeclarationFilter][DeclarationFilter].
+ *
  * **Usage**: Register your instance as a service with [@BService][BService]
  * or [any annotation that enables your class for dependency injection][BServiceConfigBuilder.serviceAnnotations].
  *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/annotations/CommandId.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/annotations/CommandId.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.commands.application.annotations
 
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
 
 /**
@@ -9,7 +8,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
  * **Note:** This only applies to top-level commands, for slash commands,
  * this means the annotation needs to be used alongside [@TopLevelSlashCommandData][TopLevelSlashCommandData].
  *
- * @see ApplicationCommand.getGuildsForCommandId
+ * @see DeclarationFilter @DeclarationFilter
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/annotations/DeclarationFilter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/annotations/DeclarationFilter.kt
@@ -1,0 +1,16 @@
+package io.github.freya022.botcommands.api.commands.application.annotations
+
+import io.github.freya022.botcommands.api.commands.application.CommandDeclarationFilter
+import io.github.freya022.botcommands.api.commands.application.CommandScope
+import kotlin.reflect.KClass
+
+/**
+ * Runs the following filters before declaring the annotated application command.
+ *
+ * Only works on [guild][CommandScope.GUILD] commands.
+ *
+ * @see CommandDeclarationFilter
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DeclarationFilter(@get:JvmName("value") vararg val filters: KClass<out CommandDeclarationFilter>)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/MessageContextCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/MessageContextCommandAutoBuilder.kt
@@ -56,17 +56,17 @@ internal class MessageContextCommandAutoBuilder(
     override fun declareGuildApplicationCommands(manager: GuildApplicationCommandManager) = declareMessage(manager)
 
     private fun declareMessage(manager: AbstractApplicationCommandManager) {
-        val skipLogger = SkipLogger(logger)
-        messageFunctions.forEachWithDelayedExceptions { metadata ->
-            runFiltered(
-                manager,
-                skipLogger,
-                forceGuildCommands,
-                metadata,
-                metadata.annotation.scope
-            ) { processMessageCommand(manager, metadata) }
+        with(SkipLogger(logger)) {
+            messageFunctions.forEachWithDelayedExceptions { metadata ->
+                runFiltered(
+                    manager,
+                    forceGuildCommands,
+                    metadata,
+                    metadata.annotation.scope
+                ) { processMessageCommand(manager, metadata) }
+            }
+            log((manager as? GuildApplicationCommandManager)?.guild, CommandType.MESSAGE)
         }
-        skipLogger.log((manager as? GuildApplicationCommandManager)?.guild, CommandType.MESSAGE)
     }
 
     private fun processMessageCommand(manager: AbstractApplicationCommandManager, metadata: MessageContextFunctionMetadata) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/SlashCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/SlashCommandAutoBuilder.kt
@@ -211,22 +211,22 @@ internal class SlashCommandAutoBuilder(
     override fun declareGuildApplicationCommands(manager: GuildApplicationCommandManager) = declare(manager)
 
     private fun declare(manager: AbstractApplicationCommandManager) {
-        val skipLogger = SkipLogger(logger)
-        topLevelMetadata
-            .values
-            .forEachWithDelayedExceptions loop@{ topLevelMetadata ->
-                val metadata = topLevelMetadata.metadata
-                runFiltered(
-                    manager,
-                    skipLogger,
-                    forceGuildCommands,
-                    metadata,
-                    topLevelMetadata.annotation.scope
-                ) {
-                    processCommand(manager, topLevelMetadata)
+        with(SkipLogger(logger)) {
+            topLevelMetadata
+                .values
+                .forEachWithDelayedExceptions loop@{ topLevelMetadata ->
+                    val metadata = topLevelMetadata.metadata
+                    runFiltered(
+                        manager,
+                        forceGuildCommands,
+                        metadata,
+                        topLevelMetadata.annotation.scope
+                    ) {
+                        processCommand(manager, topLevelMetadata)
+                    }
                 }
-            }
-        skipLogger.log((manager as? GuildApplicationCommandManager)?.guild, JDACommand.Type.SLASH)
+            log((manager as? GuildApplicationCommandManager)?.guild, JDACommand.Type.SLASH)
+        }
     }
 
     private fun processCommand(manager: AbstractApplicationCommandManager, topLevelMetadata: TopLevelSlashCommandMetadata) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/UserContextCommandAutoBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/UserContextCommandAutoBuilder.kt
@@ -56,17 +56,17 @@ internal class UserContextCommandAutoBuilder(
     override fun declareGuildApplicationCommands(manager: GuildApplicationCommandManager) = declareUser(manager)
 
     private fun declareUser(manager: AbstractApplicationCommandManager) {
-        val skipLogger = SkipLogger(logger)
-        userFunctions.forEachWithDelayedExceptions { metadata ->
-            runFiltered(
-                manager,
-                skipLogger,
-                forceGuildCommands,
-                metadata,
-                metadata.annotation.scope
-            ) { processUserCommand(manager, metadata) }
+        with(SkipLogger(logger)) {
+            userFunctions.forEachWithDelayedExceptions { metadata ->
+                runFiltered(
+                    manager,
+                    forceGuildCommands,
+                    metadata,
+                    metadata.annotation.scope
+                ) { processUserCommand(manager, metadata) }
+            }
+            log((manager as? GuildApplicationCommandManager)?.guild, CommandType.USER)
         }
-        skipLogger.log((manager as? GuildApplicationCommandManager)?.guild, CommandType.USER)
     }
 
     private fun processUserCommand(manager: AbstractApplicationCommandManager, metadata: UserContextFunctionMetadata) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/autobuilder/AutoBuilderUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/autobuilder/AutoBuilderUtils.kt
@@ -51,9 +51,9 @@ internal inline fun <T : MetadataFunctionHolder> Iterable<T>.forEachWithDelayedE
     }
 }
 
+context(CommandAutoBuilder, SkipLogger)
 internal fun runFiltered(
     manager: AbstractApplicationCommandManager,
-    skipLogger: SkipLogger,
     forceGuildCommands: Boolean,
     applicationFunctionMetadata: ApplicationFunctionMetadata<*>,
     scope: CommandScope,
@@ -73,14 +73,14 @@ internal fun runFiltered(
     if (!forceGuildCommands && !manager.isValidScope(scope)) return
 
     if (commandId != null && !checkCommandId(manager, instance, commandId, path))
-        return skipLogger.skip(path, "Guild does not support that command ID")
+        return skip(path, "Guild does not support that command ID")
 
     val testState = checkTestCommand(manager, func, scope, manager.context)
     if (scope.isGlobal && testState != TestState.NO_ANNOTATION)
         throwInternal("Test commands on a global scope should have thrown in ${::checkTestCommand.shortSignatureNoSrc}")
 
     if (testState == TestState.EXCLUDE)
-        return skipLogger.skip(path, "Is a test command while this guild isn't a test guild")
+        return skip(path, "Is a test command while this guild isn't a test guild")
 
     block()
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/utils/Exceptions.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/utils/Exceptions.kt
@@ -54,6 +54,12 @@ internal fun throwState(message: String, declarationSite: DeclarationSite? = nul
         else -> throw IllegalStateException("$message\n    Declared at: $declarationSite")
     }
 
+internal fun throwState(message: String, function: KFunction<*>): Nothing =
+    throw IllegalStateException("$message\n    Function: ${function.shortSignature}")
+
+internal fun throwState(message: String): Nothing =
+    throw IllegalStateException(message)
+
 @OptIn(ExperimentalContracts::class)
 internal inline fun requireAt(value: Boolean, function: KFunction<*>? = null, lazyMessage: () -> String) {
     contract {
@@ -87,6 +93,20 @@ internal inline fun checkAt(value: Boolean, declarationSite: DeclarationSite? = 
 
     if (!value) {
         throwState(lazyMessage(), declarationSite)
+    }
+}
+
+@OptIn(ExperimentalContracts::class)
+internal inline fun checkAt(value: Boolean, function: KFunction<*>? = null, lazyMessage: () -> String) {
+    contract {
+        returns() implies value
+    }
+
+    if (!value) {
+        if (function != null)
+            throwState(lazyMessage(), function)
+        else
+            throwState(lazyMessage())
     }
 }
 

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashDeclarationFilter.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashDeclarationFilter.kt
@@ -1,0 +1,36 @@
+package io.github.freya022.botcommands.test.commands.slash
+
+import dev.minn.jda.ktx.coroutines.await
+import dev.minn.jda.ktx.messages.reply_
+import io.github.freya022.botcommands.api.commands.CommandPath
+import io.github.freya022.botcommands.api.commands.annotations.Command
+import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
+import io.github.freya022.botcommands.api.commands.application.CommandDeclarationFilter
+import io.github.freya022.botcommands.api.commands.application.CommandScope
+import io.github.freya022.botcommands.api.commands.application.annotations.DeclarationFilter
+import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
+import io.github.freya022.botcommands.api.core.conditions.RequiredIntents
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.requests.GatewayIntent
+
+@BService
+@RequiredIntents(GatewayIntent.GUILD_MEMBERS)
+class BigGuildDeclarationFilter : CommandDeclarationFilter {
+    override fun filter(guild: Guild, path: CommandPath, commandId: String?): Boolean {
+        return guild.memberCount > 10 // not big, for testing yk
+    }
+}
+
+@Command
+@RequiredIntents(GatewayIntent.GUILD_MEMBERS)
+class SlashDeclarationFilter : ApplicationCommand() {
+    @JDASlashCommand(name = "declaration_filter")
+    @DeclarationFilter(BigGuildDeclarationFilter::class)
+    @TopLevelSlashCommandData(scope = CommandScope.GUILD)
+    suspend fun onSlashDeclarationFilter(event: GuildSlashEvent) {
+        event.reply_("Works, guild members: ${event.guild.memberCount}", ephemeral = true).await()
+    }
+}


### PR DESCRIPTION
- Added `@DeclarationFilter` and `CommandDeclarationFilter`
  - Gets run on **annotated** application commands when pushed **to a guild**
- Deprecated `CommandList`, `SettingsProvider#getGuildCommands` and `ApplicationCommand#getGuildsForCommandId`