### PR TITLE
spring: Don't construct configurations separately

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/ConfigProvider.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/ConfigProvider.kt
@@ -10,71 +10,62 @@ import org.springframework.context.annotation.Primary
 internal open class ConfigProvider {
     @Bean
     @Primary
-    internal open fun bConfig(configuration: BotCommandsCoreConfiguration, configurers: List<BConfigConfigurer>): BConfig =
+    internal open fun bConfig(
+        coreConfiguration: BotCommandsCoreConfiguration, coreConfigurers: List<BConfigConfigurer>,
+        debugConfiguration: BotCommandsDebugConfiguration, debugConfigurers: List<BDebugConfigConfigurer>,
+        serviceConfiguration: BotCommandsServiceConfiguration, serviceConfigurers: List<BServiceConfigConfigurer>,
+        databaseConfiguration: BotCommandsDatabaseConfiguration, databaseConfigurers: List<BDatabaseConfigConfigurer>,
+        textConfiguration: BotCommandsTextConfiguration, textConfigurers: List<BTextConfigConfigurer>,
+        localizationConfiguration: BotCommandsLocalizationConfiguration, localizationConfigurers: List<BLocalizationConfigConfigurer>,
+        applicationConfiguration: BotCommandsApplicationConfiguration, applicationConfigurers: List<BApplicationConfigConfigurer>,
+        componentsConfiguration: BotCommandsComponentsConfiguration, componentsConfigurers: List<BComponentsConfigConfigurer>,
+        coroutineConfigurers: List<BCoroutineScopesConfigConfigurer>
+    ): BConfig =
         BConfigBuilder()
-            .applyConfig(configuration)
-            .configure(configurers)
+            .applyConfig(coreConfiguration)
+            .apply {
+                debugConfig.applyConfig(debugConfiguration).configure(debugConfigurers)
+                serviceConfig.applyConfig(serviceConfiguration).configure(serviceConfigurers)
+                databaseConfig.applyConfig(databaseConfiguration).configure(databaseConfigurers)
+                textConfig.applyConfig(textConfiguration).configure(textConfigurers)
+                localizationConfig.applyConfig(localizationConfiguration).configure(localizationConfigurers)
+                applicationConfig.applyConfig(applicationConfiguration).configure(applicationConfigurers)
+                componentsConfig.applyConfig(componentsConfiguration).configure(componentsConfigurers)
+                coroutineScopesConfig.configure(coroutineConfigurers)
+            }
+            .configure(coreConfigurers)
             .build()
 
     @Bean
     @Primary
-    internal open fun bDebugConfig(configuration: BotCommandsDebugConfiguration, configurers: List<BDebugConfigConfigurer>): BDebugConfig =
-        BDebugConfigBuilder()
-            .applyConfig(configuration)
-            .configure(configurers)
-            .build()
+    internal open fun bDebugConfig(config: BConfig): BDebugConfig = config.debugConfig
 
     @Bean
     @Primary
-    internal open fun bServiceConfig(configuration: BotCommandsServiceConfiguration, configurers: List<BServiceConfigConfigurer>): BServiceConfig =
-        BServiceConfigBuilder()
-            .applyConfig(configuration)
-            .configure(configurers)
-            .build()
+    internal open fun bServiceConfig(config: BConfig): BServiceConfig = config.serviceConfig
 
     @Bean
     @Primary
-    internal open fun bDatabaseConfig(configuration: BotCommandsDatabaseConfiguration, configurers: List<BDatabaseConfigConfigurer>): BDatabaseConfig =
-        BDatabaseConfigBuilder()
-            .applyConfig(configuration)
-            .configure(configurers)
-            .build()
+    internal open fun bDatabaseConfig(config: BConfig): BDatabaseConfig = config.databaseConfig
 
     @Bean
     @Primary
-    internal open fun bTextConfig(configuration: BotCommandsTextConfiguration, configurers: List<BTextConfigConfigurer>): BTextConfig =
-        BTextConfigBuilder()
-            .applyConfig(configuration)
-            .configure(configurers)
-            .build()
+    internal open fun bTextConfig(config: BConfig): BTextConfig = config.textConfig
 
     @Bean
     @Primary
-    internal open fun bLocalizationConfig(configuration: BotCommandsLocalizationConfiguration, configurers: List<BLocalizationConfigConfigurer>): BLocalizationConfig =
-        BLocalizationConfigBuilder()
-            .applyConfig(configuration)
-            .configure(configurers)
-            .build()
+    internal open fun bLocalizationConfig(config: BConfig): BLocalizationConfig = config.localizationConfig
 
     @Bean
     @Primary
-    internal open fun bApplicationConfig(configuration: BotCommandsApplicationConfiguration, configurers: List<BApplicationConfigConfigurer>): BApplicationConfig =
-        BApplicationConfigBuilder()
-            .applyConfig(configuration)
-            .configure(configurers)
-            .build()
+    internal open fun bApplicationConfig(config: BConfig): BApplicationConfig = config.applicationConfig
 
     @Bean
     @Primary
-    internal open fun bComponentsConfig(configuration: BotCommandsComponentsConfiguration, configurers: List<BComponentsConfigConfigurer>): BComponentsConfig =
-        BComponentsConfigBuilder()
-            .applyConfig(configuration)
-            .configure(configurers)
-            .build()
+    internal open fun bComponentsConfig(config: BConfig): BComponentsConfig = config.componentsConfig
 
     @Bean
-    internal open fun bCoroutineScopesConfig(configurers: List<BCoroutineScopesConfigConfigurer>): BCoroutineScopesConfig =
-        BCoroutineScopesConfigBuilder().configure(configurers).build()
+    internal open fun bCoroutineScopesConfig(config: BConfig): BCoroutineScopesConfig = config.coroutineScopesConfig
 
     private fun <T : Any> T.configure(configurers: List<BConfigurer<T>>) = apply {
         configurers.forEach { configConfigurer -> configConfigurer.configure(this) }


### PR DESCRIPTION
Now injects the children configs from the root config

Fixes default values being read if config getters were used