### PR TITLE
Improve command diff and their logs

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/diff/DiffEngine.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/diff/DiffEngine.kt
@@ -1,0 +1,31 @@
+package io.github.freya022.botcommands.api.commands.application.diff
+
+import io.github.freya022.botcommands.api.core.config.BApplicationConfig
+import io.github.freya022.botcommands.internal.commands.application.diff.ApplicationCommandDiffEngine
+import io.github.freya022.botcommands.internal.commands.application.diff.NewApplicationCommandDiffEngine
+import io.github.freya022.botcommands.internal.commands.application.diff.OldApplicationCommandDiffEngine
+import io.github.freya022.botcommands.internal.commands.application.diff.OldRefactoredApplicationCommandDiffEngine
+
+/**
+ * Represents predefined implementation of an application command diff engine.
+ *
+ * @see BApplicationConfig.diffEngine
+ */
+enum class DiffEngine(@get:JvmSynthetic internal val instance: ApplicationCommandDiffEngine) {
+    /**
+     * Good ol' engine.
+     */
+    @Deprecated(message = "Only use this if there is a bug with the new engine, may be removed in a future release.")
+    OLD(OldApplicationCommandDiffEngine),
+
+    /**
+     * Provides even more logs.
+     */
+    @Deprecated(message = "Only use this if there is a bug with the new engine, may be removed in a future release.")
+    OLD_REFACTORED(OldRefactoredApplicationCommandDiffEngine),
+
+    /**
+     * Cleaner logs with what exactly changed.
+     */
+    NEW(NewApplicationCommandDiffEngine)
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
@@ -93,6 +93,16 @@ interface BApplicationConfig {
     val diffEngine: DiffEngine
 
     /**
+     * Whether the raw JSON of the application commands should be logged when an update is required.
+     *
+     * Default: `false`
+     *
+     * Spring property: `botcommands.application.logApplicationCommandData`
+     */
+    @ConfigurationValue(path = "botcommands.application.logApplicationCommandData", defaultValue = "false")
+    val logApplicationCommandData: Boolean
+
+    /**
      * Sets whether all application commands should be guild-only, regardless of the command scope on the annotation.
      *
      * **Beware**: This also means that your global application commands will **not** be registered.
@@ -137,6 +147,7 @@ class BApplicationConfigBuilder internal constructor() : BApplicationConfig {
     override var onlineAppCommandCheckEnabled: Boolean = false
     @set:DevConfig
     override var diffEngine: DiffEngine = DiffEngine.NEW
+    override var logApplicationCommandData: Boolean = false
     @set:DevConfig
     @set:JvmName("forceGuildCommands")
     override var forceGuildCommands: Boolean = false
@@ -208,6 +219,7 @@ class BApplicationConfigBuilder internal constructor() : BApplicationConfig {
         override val disableAutocompleteCache = this@BApplicationConfigBuilder.disableAutocompleteCache
         override val onlineAppCommandCheckEnabled = this@BApplicationConfigBuilder.onlineAppCommandCheckEnabled
         override val diffEngine = this@BApplicationConfigBuilder.diffEngine
+        override val logApplicationCommandData = this@BApplicationConfigBuilder.logApplicationCommandData
         override val forceGuildCommands = this@BApplicationConfigBuilder.forceGuildCommands
         override val baseNameToLocalesMap =
             this@BApplicationConfigBuilder.baseNameToLocalesMap.mapValues { (_, v) -> v.toImmutableList() }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
@@ -1,6 +1,7 @@
 package io.github.freya022.botcommands.api.core.config
 
 import io.github.freya022.botcommands.api.commands.application.annotations.Test
+import io.github.freya022.botcommands.api.commands.application.diff.DiffEngine
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.annotations.CacheAutocomplete
 import io.github.freya022.botcommands.api.core.service.annotations.InjectedService
 import io.github.freya022.botcommands.api.core.utils.toImmutableList
@@ -79,6 +80,19 @@ interface BApplicationConfig {
     val onlineAppCommandCheckEnabled: Boolean
 
     /**
+     * The diff engine to use when comparing old and new application commands,
+     * to determine if commands needs to be updated.
+     *
+     * Only change this if necessary.
+     *
+     * Default: [DiffEngine.NEW]
+     *
+     * Spring property: `botcommands.application.diffEngine`
+     */
+    @ConfigurationValue(path = "botcommands.application.diffEngine", defaultValue = "new")
+    val diffEngine: DiffEngine
+
+    /**
      * Sets whether all application commands should be guild-only, regardless of the command scope on the annotation.
      *
      * **Beware**: This also means that your global application commands will **not** be registered.
@@ -121,6 +135,8 @@ class BApplicationConfigBuilder internal constructor() : BApplicationConfig {
     @set:DevConfig
     @set:JvmName("enableOnlineAppCommandChecks")
     override var onlineAppCommandCheckEnabled: Boolean = false
+    @set:DevConfig
+    override var diffEngine: DiffEngine = DiffEngine.NEW
     @set:DevConfig
     @set:JvmName("forceGuildCommands")
     override var forceGuildCommands: Boolean = false
@@ -191,6 +207,7 @@ class BApplicationConfigBuilder internal constructor() : BApplicationConfig {
         override val testGuildIds = this@BApplicationConfigBuilder.testGuildIds.toImmutableList()
         override val disableAutocompleteCache = this@BApplicationConfigBuilder.disableAutocompleteCache
         override val onlineAppCommandCheckEnabled = this@BApplicationConfigBuilder.onlineAppCommandCheckEnabled
+        override val diffEngine = this@BApplicationConfigBuilder.diffEngine
         override val forceGuildCommands = this@BApplicationConfigBuilder.forceGuildCommands
         override val baseNameToLocalesMap =
             this@BApplicationConfigBuilder.baseNameToLocalesMap.mapValues { (_, v) -> v.toImmutableList() }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BDebugConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BDebugConfig.kt
@@ -1,19 +1,25 @@
 package io.github.freya022.botcommands.api.core.config
 
+import io.github.freya022.botcommands.api.commands.application.diff.DiffEngine
 import io.github.freya022.botcommands.api.core.service.annotations.InjectedService
 import io.github.freya022.botcommands.internal.core.config.ConfigDSL
 import io.github.freya022.botcommands.internal.core.config.ConfigurationValue
+import io.github.freya022.botcommands.internal.core.config.DeprecatedValue
 
 @InjectedService
 interface BDebugConfig {
     /**
-     * Whether the differences between old and new application commands data should be logged
+     * Whether the differences between old and new application commands data should be logged.
+     *
+     * This will always be on for [DiffEngine.NEW].
      *
      * Default: `false`
      *
      * Spring property: `botcommands.debug.enableApplicationDiffsLogs`
      */
+    @Deprecated(message = "Always on with the default diff engine")
     @ConfigurationValue(path = "botcommands.debug.enableApplicationDiffsLogs", defaultValue = "false")
+    @DeprecatedValue(reason = "Always on with the default diff engine")
     val enableApplicationDiffsLogs: Boolean
 
     /**
@@ -29,6 +35,7 @@ interface BDebugConfig {
 
 @ConfigDSL
 class BDebugConfigBuilder internal constructor() : BDebugConfig {
+    @Deprecated("Always on with the default diff engine")
     @set:JvmName("enableApplicationDiffsLogs")
     override var enableApplicationDiffsLogs: Boolean = false
     @set:JvmName("enabledMissingLocalizationLogs")
@@ -36,6 +43,7 @@ class BDebugConfigBuilder internal constructor() : BDebugConfig {
 
     @JvmSynthetic
     internal fun build() = object : BDebugConfig {
+        @Suppress("OVERRIDE_DEPRECATION")
         override val enableApplicationDiffsLogs = this@BDebugConfigBuilder.enableApplicationDiffsLogs
         override val enabledMissingLocalizationLogs = this@BDebugConfigBuilder.enabledMissingLocalizationLogs
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/application/diff/DiffLogger.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/application/diff/DiffLogger.kt
@@ -38,3 +38,23 @@ internal class DiffLoggerImpl : DiffLogger() {
 
     override fun printLogs() = logItems.forEach(logger::trace)
 }
+
+internal fun DiffLogger.logSame(indent: Int, message: () -> Any?): Boolean {
+    log {
+        "\t".repeat(indent) + message()
+    }
+    return true
+}
+
+internal fun DiffLogger.logDifferent(indent: Int, message: () -> Any?): Boolean {
+    log {
+        "\t".repeat(indent) + message()
+    }
+    return false
+}
+
+internal inline fun DiffLogger.withKey(key: String, block: DiffLogger.() -> Unit) {
+    block(this)
+}
+
+internal inline fun <R> DiffLogger.ignoreLogs(block: DiffLogger.() -> R): R = block(DiffLoggerNoop)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/application/diff/DiffLogger.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/application/diff/DiffLogger.kt
@@ -1,36 +1,55 @@
 package io.github.freya022.botcommands.internal.application.diff
 
-import io.github.freya022.botcommands.internal.application.diff.DiffLogger.Companion.logger
-import io.github.freya022.botcommands.internal.core.BContextImpl
+import io.github.freya022.botcommands.api.core.BContext
 import io.github.oshai.kotlinlogging.KotlinLogging
 
-internal interface DiffLogger {
-    fun trace(indent: Int, formatStr: String, vararg objects: Any?)
+internal sealed class DiffLogger {
+    internal abstract fun copyWithKey(key: String): DiffLogger
 
-    fun printLogs()
+    internal abstract fun log(formatStr: String, vararg objects: Any?)
 
-    companion object {
+    internal abstract fun printLogs()
+
+    internal companion object {
         internal val logger = KotlinLogging.logger {  }
 
-        fun getLogger(context: BContextImpl): DiffLogger = when {
-            !logger.isTraceEnabled() -> DiffLoggerNoop()
-            context.debugConfig.enableApplicationDiffsLogs -> DiffLoggerImpl()
-            else -> DiffLoggerNoop()
+        internal fun getLogger(context: BContext): DiffLogger = when {
+            logger.isTraceEnabled() && context.debugConfig.enableApplicationDiffsLogs -> DiffLoggerImpl(emptyList())
+            else -> DiffLoggerNoop
         }
     }
 }
 
-internal class DiffLoggerNoop : DiffLogger {
-    override fun trace(indent: Int, formatStr: String, vararg objects: Any?) {}
+internal data object DiffLoggerNoop : DiffLogger() {
+    override fun copyWithKey(key: String): DiffLogger = DiffLoggerNoop
+
+    override fun log(formatStr: String, vararg objects: Any?) {}
+
     override fun printLogs() {}
 }
 
-internal class DiffLoggerImpl : DiffLogger {
-    private val logItems: MutableList<String> = arrayListOf()
+internal class DiffLoggerImpl(private val keys: List<String>, private val logItems: MutableList<String> = arrayListOf()) : DiffLogger() {
+    override fun copyWithKey(key: String): DiffLogger = DiffLoggerImpl(keys + key, logItems)
 
-    override fun trace(indent: Int, formatStr: String, vararg objects: Any?) {
-        logItems += "\t".repeat(indent) + String.format(formatStr, *objects)
+    override fun log(formatStr: String, vararg objects: Any?) {
+        logItems += "\t".repeat(keys.size - 1) + "${keys.joinToString(".")} - " + String.format(formatStr, *objects)
     }
 
     override fun printLogs() = logItems.forEach { logger.trace { it } }
 }
+
+internal fun DiffLogger.logSame(formatStr: String, vararg objects: Any?): Boolean {
+    log(formatStr, *objects)
+    return true
+}
+
+internal fun DiffLogger.logDifferent(formatStr: String, vararg objects: Any?): Boolean {
+    log(formatStr, *objects)
+    return false
+}
+
+internal inline fun DiffLogger.withKey(key: String, block: DiffLogger.() -> Unit) {
+    block(copyWithKey(key))
+}
+
+internal inline fun <R> DiffLogger.ignoreLogs(block: DiffLogger.() -> R): R = block(DiffLoggerNoop)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/application/diff/DiffLogger.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/application/diff/DiffLogger.kt
@@ -3,53 +3,38 @@ package io.github.freya022.botcommands.internal.application.diff
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.oshai.kotlinlogging.KotlinLogging
 
-internal sealed class DiffLogger {
-    internal abstract fun copyWithKey(key: String): DiffLogger
+private val logger = KotlinLogging.logger { }
 
-    internal abstract fun log(formatStr: String, vararg objects: Any?)
+internal sealed class DiffLogger {
+    internal abstract fun log(message: () -> Any?)
 
     internal abstract fun printLogs()
 
     internal companion object {
-        internal val logger = KotlinLogging.logger {  }
-
-        internal fun getLogger(context: BContext): DiffLogger = when {
-            logger.isTraceEnabled() && context.debugConfig.enableApplicationDiffsLogs -> DiffLoggerImpl(emptyList())
-            else -> DiffLoggerNoop
+        internal fun <R> withLogger(context: BContext, block: DiffLogger.() -> R): R = when {
+            logger.isTraceEnabled() && context.debugConfig.enableApplicationDiffsLogs -> {
+                val diffLogger = DiffLoggerImpl()
+                val value = diffLogger.block()
+                diffLogger.printLogs()
+                value
+            }
+            else -> DiffLoggerNoop.block()
         }
     }
 }
 
 internal data object DiffLoggerNoop : DiffLogger() {
-    override fun copyWithKey(key: String): DiffLogger = DiffLoggerNoop
-
-    override fun log(formatStr: String, vararg objects: Any?) {}
+    override fun log(message: () -> Any?) {}
 
     override fun printLogs() {}
 }
 
-internal class DiffLoggerImpl(private val keys: List<String>, private val logItems: MutableList<String> = arrayListOf()) : DiffLogger() {
-    override fun copyWithKey(key: String): DiffLogger = DiffLoggerImpl(keys + key, logItems)
+internal class DiffLoggerImpl : DiffLogger() {
+    private val logItems: MutableList<() -> Any?> = arrayListOf()
 
-    override fun log(formatStr: String, vararg objects: Any?) {
-        logItems += "\t".repeat(keys.size - 1) + "${keys.joinToString(".")} - " + String.format(formatStr, *objects)
+    override fun log(message: () -> Any?) {
+        logItems += message
     }
 
-    override fun printLogs() = logItems.forEach { logger.trace { it } }
+    override fun printLogs() = logItems.forEach(logger::trace)
 }
-
-internal fun DiffLogger.logSame(formatStr: String, vararg objects: Any?): Boolean {
-    log(formatStr, *objects)
-    return true
-}
-
-internal fun DiffLogger.logDifferent(formatStr: String, vararg objects: Any?): Boolean {
-    log(formatStr, *objects)
-    return false
-}
-
-internal inline fun DiffLogger.withKey(key: String, block: DiffLogger.() -> Unit) {
-    block(copyWithKey(key))
-}
-
-internal inline fun <R> DiffLogger.ignoreLogs(block: DiffLogger.() -> R): R = block(DiffLoggerNoop)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsCache.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsCache.kt
@@ -2,13 +2,8 @@ package io.github.freya022.botcommands.internal.commands.application
 
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.service.annotations.Lazy
-import io.github.freya022.botcommands.api.core.utils.DefaultObjectMapper
-import io.github.freya022.botcommands.internal.application.diff.DiffLogger
-import io.github.freya022.botcommands.internal.core.BContextImpl
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
-import net.dv8tion.jda.api.interactions.commands.build.CommandData
-import net.dv8tion.jda.api.utils.data.DataArray
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
@@ -38,21 +33,5 @@ internal class ApplicationCommandsCache(jda: JDA) {
 
     internal fun getGuildCommandsMetadataPath(guild: Guild): Path {
         return cachePath.resolve(guild.id).resolve("commands_metadata.json")
-    }
-
-    internal companion object {
-        internal fun Collection<CommandData>.toJsonBytes(): ByteArray = DataArray.fromCollection(this).toJson()
-
-        @Suppress("UNCHECKED_CAST")
-        internal fun isJsonContentSame(context: BContextImpl, oldContentBytes: ByteArray, newContentBytes: ByteArray): Boolean {
-            val oldCommands = DefaultObjectMapper.readList(oldContentBytes) as List<Map<String, *>>
-            val newCommands = DefaultObjectMapper.readList(newContentBytes) as List<Map<String, *>>
-
-            val isSame = DiffLogger.withLogger(context) {
-                context.applicationConfig.diffEngine.instance.checkCommands(oldCommands, newCommands)
-            }
-
-            return isSame
-        }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsCache.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsCache.kt
@@ -3,7 +3,8 @@ package io.github.freya022.botcommands.internal.commands.application
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.service.annotations.Lazy
 import io.github.freya022.botcommands.api.core.utils.DefaultObjectMapper
-import io.github.freya022.botcommands.internal.application.diff.*
+import io.github.freya022.botcommands.internal.application.diff.DiffLogger
+import io.github.freya022.botcommands.internal.commands.application.diff.NewApplicationCommandDiffEngine
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
@@ -43,105 +44,16 @@ internal class ApplicationCommandsCache(jda: JDA) {
     companion object {
         fun Collection<CommandData>.toJsonBytes(): ByteArray = DataArray.empty().addAll(this).toJson()
 
+        @Suppress("UNCHECKED_CAST")
         fun isJsonContentSame(context: BContextImpl, oldContentBytes: ByteArray, newContentBytes: ByteArray): Boolean {
-            val oldMap = DefaultObjectMapper.readList(oldContentBytes)
-            val newMap = DefaultObjectMapper.readList(newContentBytes)
+            val oldCommands = DefaultObjectMapper.readList(oldContentBytes) as List<Map<String, *>>
+            val newCommands = DefaultObjectMapper.readList(newContentBytes) as List<Map<String, *>>
 
-            val isSame: Boolean
-            DiffLogger.getLogger(context).apply {
-                isSame = checkDiff(oldMap, newMap)
-                printLogs()
+            val isSame = DiffLogger.withLogger(context) {
+                NewApplicationCommandDiffEngine.checkCommands(oldCommands, newCommands)
             }
 
             return isSame
-        }
-
-        context(DiffLogger)
-        internal fun checkDiff(oldObj: Any?, newObj: Any?): Boolean {
-            if (oldObj == null && newObj == null) {
-                return logSame("Both null")
-            }
-
-            if (oldObj == null) {
-                return logDifferent("oldObj is null")
-            } else if (newObj == null) {
-                return logDifferent("newObj is null")
-            }
-
-            if (oldObj.javaClass != newObj.javaClass) {
-                return logDifferent("Class type not equal: %s to %s", oldObj.javaClass.simpleName, newObj.javaClass.simpleName)
-            }
-
-            return if (oldObj is Map<*, *> && newObj is Map<*, *>) {
-                checkMap(oldObj, newObj)
-            } else if (oldObj is List<*> && newObj is List<*>) {
-                checkList(oldObj, newObj)
-            } else {
-                return when (oldObj == newObj) {
-                    true -> logSame("Same object: %s to %s", oldObj, newObj)
-                    false -> logDifferent("Not same object: %s to %s", oldObj, newObj)
-                }
-            }
-        }
-
-        context(DiffLogger)
-        private fun checkList(oldList: List<*>, newList: List<*>): Boolean {
-            if (oldList.size != newList.size)
-                return logDifferent("List is not of the same size")
-
-            oldList.indices.forEach { i ->
-                withKey(i.toString()) {
-                    // Try to find an object with the same content but at a different index
-                    // Whether it is effectively different depends on the type of the object
-                    val index = newList.indexOfFirst { ignoreLogs { checkDiff(oldList[i], it) } }
-                    if (index == -1)
-                        return logDifferent("List item not found: %s to %s", oldList[i], newList[i])
-
-                    if (index != i) {
-                        // Found the obj somewhere else, let's see if the object is an option
-                        val oldObj = oldList[index]
-                        if (oldObj is Map<*, *> && "autocomplete" in oldObj) {
-                            // Is an option
-                            return logDifferent("Final command option has changed place from index %s to %s : %s",
-                                i,
-                                index,
-                                oldList[i]
-                            )
-                        } else {
-                            // Is not an option
-                            logSame("Found exact object at index %s (original object at %s) : %s", index, i, oldList[i])
-                            return@forEach // Look at other options
-                        }
-                    } else {
-                        // Same index
-                        logSame("Found exact object at same index : %s", i, oldList[i])
-                        return@forEach // Look at other options
-                    }
-                }
-            }
-
-            return true
-        }
-
-        context(DiffLogger)
-        private fun checkMap(oldMap: Map<*, *>, newMap: Map<*, *>): Boolean {
-            val missingKeys = oldMap.keys - newMap.keys
-            if (missingKeys.isNotEmpty())
-                return logDifferent("Missing keys: %s", missingKeys)
-
-            val addedKeys = newMap.keys - oldMap.keys
-            if (addedKeys.isNotEmpty())
-                return logDifferent("Added keys: %s", addedKeys)
-
-            for (key in oldMap.keys) {
-                withKey(key.toString()) {
-                    if (!checkDiff(oldMap[key], newMap[key])) {
-                        return logDifferent("Map value not equal for key '%s': %s to %s", key, oldMap[key], newMap[key])
-                    }
-                }
-            }
-
-            return true
         }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsCache.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsCache.kt
@@ -4,7 +4,6 @@ import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.service.annotations.Lazy
 import io.github.freya022.botcommands.api.core.utils.DefaultObjectMapper
 import io.github.freya022.botcommands.internal.application.diff.DiffLogger
-import io.github.freya022.botcommands.internal.commands.application.diff.NewApplicationCommandDiffEngine
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
@@ -30,27 +29,27 @@ internal class ApplicationCommandsCache(jda: JDA) {
             .createDirectories()
     }
 
-    val globalCommandsPath: Path = cachePath.resolve("globalCommands.json")
-    val globalCommandsMetadataPath: Path = cachePath.resolve("globalCommands_metadata.json")
+    internal val globalCommandsPath: Path = cachePath.resolve("globalCommands.json")
+    internal val globalCommandsMetadataPath: Path = cachePath.resolve("globalCommands_metadata.json")
 
-    fun getGuildCommandsPath(guild: Guild): Path {
+    internal fun getGuildCommandsPath(guild: Guild): Path {
         return cachePath.resolve(guild.id).resolve("commands.json")
     }
 
-    fun getGuildCommandsMetadataPath(guild: Guild): Path {
+    internal fun getGuildCommandsMetadataPath(guild: Guild): Path {
         return cachePath.resolve(guild.id).resolve("commands_metadata.json")
     }
 
-    companion object {
-        fun Collection<CommandData>.toJsonBytes(): ByteArray = DataArray.empty().addAll(this).toJson()
+    internal companion object {
+        internal fun Collection<CommandData>.toJsonBytes(): ByteArray = DataArray.fromCollection(this).toJson()
 
         @Suppress("UNCHECKED_CAST")
-        fun isJsonContentSame(context: BContextImpl, oldContentBytes: ByteArray, newContentBytes: ByteArray): Boolean {
+        internal fun isJsonContentSame(context: BContextImpl, oldContentBytes: ByteArray, newContentBytes: ByteArray): Boolean {
             val oldCommands = DefaultObjectMapper.readList(oldContentBytes) as List<Map<String, *>>
             val newCommands = DefaultObjectMapper.readList(newContentBytes) as List<Map<String, *>>
 
             val isSame = DiffLogger.withLogger(context) {
-                NewApplicationCommandDiffEngine.checkCommands(oldCommands, newCommands)
+                context.applicationConfig.diffEngine.instance.checkCommands(oldCommands, newCommands)
             }
 
             return isSame

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsUpdater.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsUpdater.kt
@@ -150,7 +150,7 @@ internal class ApplicationCommandsUpdater private constructor(
         val oldCommands = DefaultObjectMapper.readList(oldBytes) as List<Map<String, *>>
         val newCommands = DefaultObjectMapper.readList(newBytes) as List<Map<String, *>>
 
-        val isSame = DiffLogger.withLogger(context) {
+        val isSame = DiffLogger.withLogger(context, guild.asScopeString()) {
             context.applicationConfig.diffEngine.instance.checkCommands(oldCommands, newCommands)
         }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/diff/ApplicationCommandDiffEngine.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/diff/ApplicationCommandDiffEngine.kt
@@ -1,0 +1,8 @@
+package io.github.freya022.botcommands.internal.commands.application.diff
+
+import io.github.freya022.botcommands.internal.application.diff.DiffLogger
+
+internal interface ApplicationCommandDiffEngine {
+    context(DiffLogger)
+    fun checkCommands(oldCommands: List<Map<String, *>>, newCommands: List<Map<String, *>>): Boolean
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/diff/NewApplicationCommandDiffEngine.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/diff/NewApplicationCommandDiffEngine.kt
@@ -1,0 +1,197 @@
+package io.github.freya022.botcommands.internal.commands.application.diff
+
+import io.github.freya022.botcommands.internal.application.diff.DiffLogger
+import net.dv8tion.jda.api.interactions.commands.OptionType
+
+private typealias Command = Map<String, *>
+private typealias Option = Map<String, *>
+private typealias Choice = Map<String, *>
+private typealias Object = Map<String, *>
+private typealias ObjectName = String
+
+internal object NewApplicationCommandDiffEngine : ApplicationCommandDiffEngine {
+    context(DiffLogger)
+    override fun checkCommands(oldCommands: List<Command>, newCommands: List<Command>): Boolean {
+        val addedCommands = newCommands.toNames() - oldCommands.toNames()
+        if (addedCommands.isNotEmpty()) log { "Added top-level commands: ${addedCommands.joinToString()}" }
+
+        val removedCommands = oldCommands.toNames() - newCommands.toNames()
+        if (removedCommands.isNotEmpty()) log { "Removed top-level commands: ${removedCommands.joinToString()}" }
+
+        val isSame = forEachByName(oldCommands, newCommands) { commandName, oldCommand, newCommand ->
+            checkProperties(oldCommand, newCommand, "Top-level command '$commandName'") &&
+                    checkOptions(commandName, oldCommand, newCommand) &&
+                    checkSubcommands(commandName, oldCommand, newCommand) &&
+                    checkSubcommandGroups(commandName, oldCommand, newCommand)
+        }
+
+        return addedCommands.isEmpty() && removedCommands.isEmpty() && isSame
+    }
+
+    context(DiffLogger)
+    private fun checkSubcommandGroups(
+        topLevelName: ObjectName,
+        oldCommand: Command,
+        newCommand: Command,
+    ): Boolean {
+        val oldSubcommandGroups = oldCommand.subcommandGroups
+        val newSubcommandGroups = newCommand.subcommandGroups
+
+        val addedSubcommandGroups = newSubcommandGroups.toNames() - oldSubcommandGroups.toNames()
+        if (addedSubcommandGroups.isNotEmpty()) log { "Added subcommand groups to '$topLevelName': ${addedSubcommandGroups.joinToString()}" }
+
+        val removedSubcommandGroups = oldSubcommandGroups.toNames() - newSubcommandGroups.toNames()
+        if (removedSubcommandGroups.isNotEmpty()) log { "Removed subcommand groups from '$topLevelName': ${removedSubcommandGroups.joinToString()}" }
+
+        val isSame = forEachByName(oldSubcommandGroups, newSubcommandGroups) { subcommandGroupName, oldSubcommandGroup, newSubcommandGroup ->
+            checkProperties(oldSubcommandGroup, newSubcommandGroup, "Subcommand group '$topLevelName $subcommandGroupName'") &&
+                    checkSubcommands("$topLevelName $subcommandGroupName", oldSubcommandGroup, newSubcommandGroup)
+        }
+
+        return addedSubcommandGroups.isEmpty() && removedSubcommandGroups.isEmpty() && isSame
+    }
+
+    context(DiffLogger)
+    private fun checkSubcommands(
+        parentName: ObjectName,
+        oldCommand: Command,
+        newCommand: Command,
+    ): Boolean {
+        val oldSubcommands = oldCommand.subcommands
+        val newSubcommands = newCommand.subcommands
+
+        val addedSubcommands = newSubcommands.toNames() - oldSubcommands.toNames()
+        if (addedSubcommands.isNotEmpty()) log { "Added subcommands to '$parentName': ${addedSubcommands.joinToString()}" }
+
+        val removedSubcommands = oldSubcommands.toNames() - newSubcommands.toNames()
+        if (removedSubcommands.isNotEmpty()) log { "Removed subcommands from '$parentName': ${removedSubcommands.joinToString()}" }
+
+        val isSame = forEachByName(oldSubcommands, newSubcommands) { subcommandName, oldSubcommand, newSubcommand ->
+            checkProperties(oldSubcommand, newSubcommand, "Subcommand '$parentName $subcommandName'")
+        }
+
+        return addedSubcommands.isEmpty() && removedSubcommands.isEmpty() && isSame
+    }
+
+    context(DiffLogger)
+    private fun checkOptions(cmdName: ObjectName, oldCommand: Command, newCommand: Command): Boolean {
+        val oldOptions = oldCommand.options
+        val newOptions = newCommand.options
+
+        val addedOptions = newOptions.toNames() - oldOptions.toNames()
+        if (addedOptions.isNotEmpty()) log { "Added options to '$cmdName': ${addedOptions.joinToString()}" }
+
+        val removedOptions = oldOptions.toNames() - newOptions.toNames()
+        if (removedOptions.isNotEmpty()) log { "Removed options from '$cmdName': ${removedOptions.joinToString()}" }
+
+        val isSame = forEachOption(oldOptions, newOptions) { optionName, oldOptionIndex, oldOption, newOptionIndex, newOption ->
+            var isSame = true
+            if (oldOptionIndex != newOptionIndex) {
+                log { "Option '$optionName' from '$cmdName' moved from #$oldOptionIndex to #$newOptionIndex" }
+                isSame = false
+            }
+
+            isSame &&
+                    checkProperties(oldOption, newOption, "Option '$optionName' in '$cmdName'") &&
+                    checkChoices(cmdName, optionName, oldOption, newOption)
+        }
+
+        return addedOptions.isEmpty() && removedOptions.isEmpty() && isSame
+    }
+
+    context(DiffLogger)
+    private fun checkChoices(cmdName: ObjectName, optionName: ObjectName, oldOption: Option, newOption: Option): Boolean {
+        val oldChoices = oldOption.choices
+        val newChoices = newOption.choices
+
+        val addedChoices = newChoices.toNames() - oldChoices.toNames()
+        if (addedChoices.isNotEmpty()) log { "Added choices to option '$optionName' of '$cmdName': ${addedChoices.joinToString()}" }
+
+        val removedChoices = oldChoices.toNames() - newChoices.toNames()
+        if (removedChoices.isNotEmpty()) log { "Removed choices from option '$optionName' of '$cmdName': ${removedChoices.joinToString()}" }
+
+        val isUnmodified = forEachByName(oldChoices, newChoices) { choiceName, oldChoice, newChoice ->
+            checkProperties(oldChoice, newChoice, "Choice '$choiceName' in option '$optionName' of '$cmdName'")
+        }
+
+        return addedChoices.isEmpty() && removedChoices.isEmpty() && isUnmodified
+    }
+
+    context(DiffLogger)
+    private fun checkProperties(oldCommand: Command, newCommand: Command, cmdName: ObjectName): Boolean {
+        val oldPropertyNames = oldCommand.keys
+        val newPropertyNames = newCommand.keys
+
+        val addedPropertyNames = newPropertyNames - oldPropertyNames
+        if (addedPropertyNames.isNotEmpty()) log { "Added properties to $cmdName: ${addedPropertyNames.joinToString()}" }
+
+        val removedPropertyNames = oldPropertyNames - newPropertyNames
+        if (removedPropertyNames.isNotEmpty()) log { "Removed properties from $cmdName: ${removedPropertyNames.joinToString()}" }
+
+        var hasModifications = false
+        // Don't check order-sensitive properties, they're done manually
+        val allProperties = (oldPropertyNames + newPropertyNames) - "options" - "choices"
+        allProperties.forEach { propertyName ->
+            val oldProperty = oldCommand[propertyName]
+            val newProperty = newCommand[propertyName]
+            if (oldProperty?.javaClass != newProperty?.javaClass || oldProperty != newProperty) {
+                fun Any?.q() = if (this == null) "null" else "'$this'"
+                log { "Property '$propertyName' from $cmdName changed from ${oldProperty.q()} -> ${newProperty.q()}" }
+                hasModifications = true
+            }
+        }
+        return !hasModifications
+    }
+
+    private fun List<Object>.toNames(): Set<ObjectName> = mapTo(hashSetOf()) { it["name"] as ObjectName }
+
+    private fun <T : Object> forEachByName(old: List<T>, new: List<T>, block: (name: ObjectName, old: T, new: T) -> Boolean): Boolean {
+        var isSame = true
+        old.toNames().intersect(new.toNames()).forEach { objectName ->
+            val oldObject = old.first { it["name"] == objectName }
+            val newObject = new.first { it["name"] == objectName }
+            isSame = isSame && block(objectName, oldObject, newObject)
+        }
+        return isSame
+    }
+
+    private fun forEachOption(old: List<Option>, new: List<Option>, block: (name: String, oldIndex: Int, old: Option, newIndex: Int, new: Option) -> Boolean): Boolean {
+        var isSame = true
+        new.toNames().intersect(old.toNames()).forEach { optionName ->
+            val oldOptionIndex = old.indexOfFirst { it["name"] == optionName }
+            val newOptionIndex = new.indexOfFirst { it["name"] == optionName }
+            val oldOption = old[oldOptionIndex]
+            val newOption = new[newOptionIndex]
+            isSame = isSame && block(optionName, oldOptionIndex, oldOption, newOptionIndex, newOption)
+        }
+        return isSame
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private val Command.subcommands: List<Command>
+        get() {
+            val options = this["options"] as List<Command>?
+            return options?.filter { it["type"] == OptionType.SUB_COMMAND.key }
+                ?: emptyList()
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    private val Command.subcommandGroups: List<Command>
+        get() {
+            val options = this["options"] as List<Command>?
+            return options?.filter { it["type"] == OptionType.SUB_COMMAND_GROUP.key }
+                ?: emptyList()
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    private val Command.options: List<Option>
+        get() {
+            val options = this["options"] as List<Option>?
+            return options?.filter { it["type"] !in arrayOf(OptionType.SUB_COMMAND_GROUP.key, OptionType.SUB_COMMAND.key) }
+                ?: emptyList()
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    private val Option.choices: List<Choice>
+        get() = this["choices"] as List<Choice>? ?: emptyList()
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/diff/OldApplicationCommandDiffEngine.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/diff/OldApplicationCommandDiffEngine.kt
@@ -1,0 +1,97 @@
+package io.github.freya022.botcommands.internal.commands.application.diff
+
+import io.github.freya022.botcommands.internal.application.diff.DiffLogger
+import io.github.freya022.botcommands.internal.application.diff.logDifferent
+import io.github.freya022.botcommands.internal.application.diff.logSame
+
+internal object OldApplicationCommandDiffEngine : ApplicationCommandDiffEngine {
+    context(DiffLogger)
+    override fun checkCommands(oldCommands: List<Map<String, *>>, newCommands: List<Map<String, *>>): Boolean {
+        return checkDiff(oldCommands, newCommands, indent = 0)
+    }
+
+    context(DiffLogger)
+    private fun checkDiff(oldObj: Any?, newObj: Any?, indent: Int): Boolean {
+        if (oldObj == null && newObj == null) {
+            return true
+        }
+
+        if (oldObj == null) {
+            return logDifferent(indent) { "oldObj is null" }
+        } else if (newObj == null) {
+            return logDifferent(indent) { "newObj is null" }
+        }
+
+        if (oldObj.javaClass != newObj.javaClass) {
+            return logDifferent(indent) { "Class type not equal: ${oldObj.javaClass.simpleName} to ${newObj.javaClass.simpleName}" }
+        }
+
+        return if (oldObj is Map<*, *> && newObj is Map<*, *>) {
+            checkMap(oldObj, newObj, indent)
+        } else if (oldObj is List<*> && newObj is List<*>) {
+            checkList(oldObj, newObj, indent)
+        } else {
+            (oldObj == newObj).also { equals ->
+                if (!equals) logDifferent(indent) { "Not same object: $oldObj to $newObj" }
+            }
+        }
+    }
+
+    context(DiffLogger)
+    private fun checkList(oldList: List<*>, newList: List<*>, indent: Int): Boolean {
+        if (oldList.size != newList.size) return false
+
+        for (i in oldList.indices) {
+            var found = false
+            var index = -1
+            for (o in newList) {
+                index++
+                if (checkDiff(oldList[i], o, indent + 1)) {
+                    found = true
+                    break
+                }
+            }
+
+            if (found) {
+                //If command options (parameters, not subcommands, not groups) are moved
+                // then it means the command data changed
+                if (i != index) {
+                    //Check if any final command property is here,
+                    // such as autocomplete, or required
+                    if (oldList[index] is Map<*, *>) {
+                        val map = oldList[index] as Map<*, *>
+                        if (map["autocomplete"] != null) {
+                            //We found a real command option that has **changed index**,
+                            // this is NOT equal under different indexes
+                            return logDifferent(indent) {
+                                "Final command option has changed place from index $i to $index : ${oldList[i]}"
+                            }
+                        }
+                    }
+                }
+
+                logSame(indent) { "Found exact object at index $index (original object at $i) : ${oldList[i]}" }
+                continue
+            }
+
+            if (!checkDiff(oldList[i], newList[i], indent + 1)) {
+                return logDifferent(indent) { "List item not equal: ${oldList[i]} to ${newList[i]}" }
+            }
+        }
+
+        return true
+    }
+
+    context(DiffLogger)
+    private fun checkMap(oldMap: Map<*, *>, newMap: Map<*, *>, indent: Int): Boolean {
+        if (!oldMap.keys.containsAll(newMap.keys)) return false
+
+        for (key in oldMap.keys) {
+            if (!checkDiff(oldMap[key], newMap[key], indent + 1)) {
+                return logDifferent(indent) { "Map value not equal for key 'key': ${oldMap[key]} to ${newMap[key]}" }
+            }
+        }
+
+        return true
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/diff/OldRefactoredApplicationCommandDiffEngine.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/diff/OldRefactoredApplicationCommandDiffEngine.kt
@@ -1,0 +1,94 @@
+package io.github.freya022.botcommands.internal.commands.application.diff
+
+import io.github.freya022.botcommands.internal.application.diff.*
+
+internal object OldRefactoredApplicationCommandDiffEngine : ApplicationCommandDiffEngine {
+    context(DiffLogger)
+    override fun checkCommands(oldCommands: List<Map<String, *>>, newCommands: List<Map<String, *>>): Boolean {
+        return checkDiff(oldCommands, newCommands, indent = 0)
+    }
+
+    context(DiffLogger)
+    private fun checkDiff(oldObj: Any?, newObj: Any?, indent: Int): Boolean {
+        if (oldObj == null && newObj == null) {
+            return logSame(indent) { "Both null" }
+        }
+
+        if (oldObj == null) {
+            return logDifferent(indent) { "oldObj is null" }
+        } else if (newObj == null) {
+            return logDifferent(indent) { "newObj is null" }
+        }
+
+        if (oldObj.javaClass != newObj.javaClass) {
+            return logDifferent(indent) { "Class type not equal: ${oldObj.javaClass.simpleName} to ${newObj.javaClass.simpleName}" }
+        }
+
+        return if (oldObj is Map<*, *> && newObj is Map<*, *>) {
+            checkMap(oldObj, newObj, indent)
+        } else if (oldObj is List<*> && newObj is List<*>) {
+            checkList(oldObj, newObj, indent)
+        } else {
+            return when (oldObj == newObj) {
+                true -> logSame(indent) { "Same object: $oldObj" }
+                false -> logDifferent(indent) { "Not same object: $oldObj to $newObj" }
+            }
+        }
+    }
+
+    context(DiffLogger)
+    private fun checkList(oldList: List<*>, newList: List<*>, indent: Int): Boolean {
+        if (oldList.size != newList.size)
+            return logDifferent(indent) { "List is not of the same size" }
+
+        oldList.indices.forEach { i ->
+            withKey(i.toString()) {
+                // Try to find an object with the same content but at a different index
+                // Whether it is effectively different depends on the type of the object
+                val index = newList.indexOfFirst { ignoreLogs { checkDiff(oldList[i], it, indent + 1) } }
+                if (index == -1)
+                    return logDifferent(indent) { "List item not found: ${oldList[i]} to ${newList[i]}" }
+
+                if (index != i) {
+                    // Found the obj somewhere else, let's see if the object is an option
+                    val oldObj = oldList[index]
+                    if (oldObj is Map<*, *> && "autocomplete" in oldObj) {
+                        // Is an option
+                        return logDifferent(indent) { "Final command option has changed place from index $i to $index : ${oldList[i]}" }
+                    } else {
+                        // Is not an option
+                        logSame(indent) { "Found exact object at index $index (original object at $i) : ${oldList[i]}" }
+                        return@forEach // Look at other options
+                    }
+                } else {
+                    // Same index
+                    logSame(indent) { "Found exact object at same index $i : ${oldList[i]}" }
+                    return@forEach // Look at other options
+                }
+            }
+        }
+
+        return true
+    }
+
+    context(DiffLogger)
+    private fun checkMap(oldMap: Map<*, *>, newMap: Map<*, *>, indent: Int): Boolean {
+        val missingKeys = oldMap.keys - newMap.keys
+        if (missingKeys.isNotEmpty())
+            return logDifferent(indent) { "Missing keys: $missingKeys" }
+
+        val addedKeys = newMap.keys - oldMap.keys
+        if (addedKeys.isNotEmpty())
+            return logDifferent(indent) { "Added keys: $addedKeys" }
+
+        for (key in oldMap.keys) {
+            withKey(key.toString()) {
+                if (!checkDiff(oldMap[key], newMap[key], indent + 1)) {
+                    return logDifferent(indent) { "Map value not equal for key '$key': ${oldMap[key]} to ${newMap[key]}" }
+                }
+            }
+        }
+
+        return true
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
@@ -2,6 +2,7 @@
 
 package io.github.freya022.botcommands.internal.core.config
 
+import io.github.freya022.botcommands.api.commands.application.diff.DiffEngine
 import io.github.freya022.botcommands.api.core.config.*
 import io.github.freya022.botcommands.api.utils.EmojiUtils
 import io.github.freya022.botcommands.internal.utils.throwArgument
@@ -125,6 +126,7 @@ internal class BotCommandsApplicationConfiguration(
     override val testGuildIds: List<Long> = emptyList(),
     override val disableAutocompleteCache: Boolean = false,
     override val onlineAppCommandCheckEnabled: Boolean = false,
+    override val diffEngine: DiffEngine = DiffEngine.NEW,
     override val forceGuildCommands: Boolean = false,
     localizations: Map<String, List<DiscordLocale>> = emptyMap()
 ) : BApplicationConfig {
@@ -138,6 +140,7 @@ internal fun BApplicationConfigBuilder.applyConfig(configuration: BotCommandsApp
     testGuildIds += configuration.testGuildIds
     disableAutocompleteCache = configuration.disableAutocompleteCache
     onlineAppCommandCheckEnabled = configuration.onlineAppCommandCheckEnabled
+    diffEngine = configuration.diffEngine
     forceGuildCommands = configuration.forceGuildCommands
     configuration.baseNameToLocalesMap.forEach(::addLocalizations)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
@@ -52,6 +52,7 @@ internal fun BConfigBuilder.applyConfig(configuration: BotCommandsCoreConfigurat
 
 @ConfigurationProperties(prefix = "botcommands.debug", ignoreUnknownFields = false)
 internal class BotCommandsDebugConfiguration(
+    @Suppress("OVERRIDE_DEPRECATION")
     override val enableApplicationDiffsLogs: Boolean = false,
     override val enabledMissingLocalizationLogs: Boolean = false
 ) : BDebugConfig
@@ -127,6 +128,7 @@ internal class BotCommandsApplicationConfiguration(
     override val disableAutocompleteCache: Boolean = false,
     override val onlineAppCommandCheckEnabled: Boolean = false,
     override val diffEngine: DiffEngine = DiffEngine.NEW,
+    override val logApplicationCommandData: Boolean = false,
     override val forceGuildCommands: Boolean = false,
     localizations: Map<String, List<DiscordLocale>> = emptyMap()
 ) : BApplicationConfig {
@@ -141,6 +143,7 @@ internal fun BApplicationConfigBuilder.applyConfig(configuration: BotCommandsApp
     disableAutocompleteCache = configuration.disableAutocompleteCache
     onlineAppCommandCheckEnabled = configuration.onlineAppCommandCheckEnabled
     diffEngine = configuration.diffEngine
+    logApplicationCommandData = configuration.logApplicationCommandData
     forceGuildCommands = configuration.forceGuildCommands
     configuration.baseNameToLocalesMap.forEach(::addLocalizations)
 }

--- a/src/test/kotlin/io/github/freya022/botcommands/othertests/JsonDiffTest.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/othertests/JsonDiffTest.kt
@@ -47,7 +47,7 @@ object JsonDiffTest {
         val oldMap = readResource("/commands_data/$folderName/old.json").let(DefaultObjectMapper::readList) as List<Map<String, *>>
         val newMap = readResource("/commands_data/$folderName/new.json").let(DefaultObjectMapper::readList) as List<Map<String, *>>
 
-        DiffLoggerImpl().apply {
+        DiffLoggerImpl("tests").apply {
             val isEqual = diffEngine.instance.checkCommands(oldMap, newMap)
             printLogs()
             assertEquals(shouldBeEqual, isEqual)

--- a/src/test/kotlin/io/github/freya022/botcommands/othertests/JsonDiffTest.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/othertests/JsonDiffTest.kt
@@ -7,7 +7,7 @@ import io.github.freya022.botcommands.api.core.utils.DefaultObjectMapper
 import io.github.freya022.botcommands.api.core.utils.readResource
 import io.github.freya022.botcommands.internal.application.diff.DiffLogger
 import io.github.freya022.botcommands.internal.application.diff.DiffLoggerImpl
-import io.github.freya022.botcommands.internal.commands.application.ApplicationCommandsCache
+import io.github.freya022.botcommands.internal.commands.application.diff.NewApplicationCommandDiff
 import io.github.freya022.botcommands.test.config.Environment
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
@@ -38,12 +38,13 @@ object JsonDiffTest {
         runTest(folderName = "diff_command_order", shouldBeEqual = true)
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun runTest(folderName: String, shouldBeEqual: Boolean) {
-        val oldMap = readResource("/commands_data/$folderName/old.json").let(DefaultObjectMapper::readList)
-        val newMap = readResource("/commands_data/$folderName/new.json").let(DefaultObjectMapper::readList)
+        val oldMap = readResource("/commands_data/$folderName/old.json").let(DefaultObjectMapper::readList) as List<Map<String, *>>
+        val newMap = readResource("/commands_data/$folderName/new.json").let(DefaultObjectMapper::readList) as List<Map<String, *>>
 
-        DiffLoggerImpl(arrayListOf()).apply {
-            val isEqual = ApplicationCommandsCache.checkDiff(oldMap, newMap)
+        DiffLoggerImpl().apply {
+            val isEqual = NewApplicationCommandDiff.checkCommands(oldMap, newMap)
             printLogs()
             assertEquals(shouldBeEqual, isEqual)
         }

--- a/src/test/kotlin/io/github/freya022/botcommands/othertests/JsonDiffTest.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/othertests/JsonDiffTest.kt
@@ -1,0 +1,51 @@
+package io.github.freya022.botcommands.othertests
+
+import ch.qos.logback.classic.ClassicConstants
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import io.github.freya022.botcommands.api.core.utils.DefaultObjectMapper
+import io.github.freya022.botcommands.api.core.utils.readResource
+import io.github.freya022.botcommands.internal.application.diff.DiffLogger
+import io.github.freya022.botcommands.internal.application.diff.DiffLoggerImpl
+import io.github.freya022.botcommands.internal.commands.application.ApplicationCommandsCache
+import io.github.freya022.botcommands.test.config.Environment
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import kotlin.io.path.absolutePathString
+
+object JsonDiffTest {
+    @JvmStatic
+    @BeforeAll
+    fun setup() {
+        System.setProperty(ClassicConstants.CONFIG_FILE_PROPERTY, Environment.logbackConfigPath.absolutePathString())
+        (LoggerFactory.getLogger(DiffLogger::class.java) as Logger).level = Level.TRACE
+    }
+
+    @Test
+    fun `Different command description`() {
+        runTest(folderName = "diff_command_description", shouldBeEqual = false)
+    }
+
+    @Test
+    fun `Different option order`() {
+        runTest(folderName = "diff_option_order", shouldBeEqual = false)
+    }
+
+    @Test
+    fun `Different command order`() {
+        runTest(folderName = "diff_command_order", shouldBeEqual = true)
+    }
+
+    private fun runTest(folderName: String, shouldBeEqual: Boolean) {
+        val oldMap = readResource("/commands_data/$folderName/old.json").let(DefaultObjectMapper::readList)
+        val newMap = readResource("/commands_data/$folderName/new.json").let(DefaultObjectMapper::readList)
+
+        DiffLoggerImpl(arrayListOf()).apply {
+            val isEqual = ApplicationCommandsCache.checkDiff(oldMap, newMap)
+            printLogs()
+            assertEquals(shouldBeEqual, isEqual)
+        }
+    }
+}

--- a/src/test/kotlin/io/github/freya022/botcommands/othertests/JsonDiffTest.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/othertests/JsonDiffTest.kt
@@ -3,15 +3,16 @@ package io.github.freya022.botcommands.othertests
 import ch.qos.logback.classic.ClassicConstants
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
+import io.github.freya022.botcommands.api.commands.application.diff.DiffEngine
 import io.github.freya022.botcommands.api.core.utils.DefaultObjectMapper
 import io.github.freya022.botcommands.api.core.utils.readResource
 import io.github.freya022.botcommands.internal.application.diff.DiffLogger
 import io.github.freya022.botcommands.internal.application.diff.DiffLoggerImpl
-import io.github.freya022.botcommands.internal.commands.application.diff.NewApplicationCommandDiff
 import io.github.freya022.botcommands.test.config.Environment
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.slf4j.LoggerFactory
 import kotlin.io.path.absolutePathString
 
@@ -23,28 +24,31 @@ object JsonDiffTest {
         (LoggerFactory.getLogger(DiffLogger::class.java) as Logger).level = Level.TRACE
     }
 
-    @Test
-    fun `Different command description`() {
-        runTest(folderName = "diff_command_description", shouldBeEqual = false)
+    @ParameterizedTest
+    @EnumSource(DiffEngine::class)
+    fun `Different command description`(diffEngine: DiffEngine) {
+        runTest(diffEngine, folderName = "diff_command_description", shouldBeEqual = false)
     }
 
-    @Test
-    fun `Different option order`() {
-        runTest(folderName = "diff_option_order", shouldBeEqual = false)
+    @ParameterizedTest
+    @EnumSource(DiffEngine::class)
+    fun `Different option order`(diffEngine: DiffEngine) {
+        runTest(diffEngine, folderName = "diff_option_order", shouldBeEqual = false)
     }
 
-    @Test
-    fun `Different command order`() {
-        runTest(folderName = "diff_command_order", shouldBeEqual = true)
+    @ParameterizedTest
+    @EnumSource(DiffEngine::class)
+    fun `Different command order`(diffEngine: DiffEngine) {
+        runTest(diffEngine, folderName = "diff_command_order", shouldBeEqual = true)
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun runTest(folderName: String, shouldBeEqual: Boolean) {
+    private fun runTest(diffEngine: DiffEngine, folderName: String, shouldBeEqual: Boolean) {
         val oldMap = readResource("/commands_data/$folderName/old.json").let(DefaultObjectMapper::readList) as List<Map<String, *>>
         val newMap = readResource("/commands_data/$folderName/new.json").let(DefaultObjectMapper::readList) as List<Map<String, *>>
 
         DiffLoggerImpl().apply {
-            val isEqual = NewApplicationCommandDiff.checkCommands(oldMap, newMap)
+            val isEqual = diffEngine.instance.checkCommands(oldMap, newMap)
             printLogs()
             assertEquals(shouldBeEqual, isEqual)
         }

--- a/src/test/resources/commands_data/diff_command_description/new.json
+++ b/src/test/resources/commands_data/diff_command_description/new.json
@@ -1,0 +1,151 @@
+[
+  {
+    "dm_permission": true,
+    "name_localizations": {},
+    "nsfw": false,
+    "name": "tags",
+    "options": [
+      {
+        "name_localizations": {},
+        "name": "transfer",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": true,
+            "name": "name",
+            "description": "Name of the tag",
+            "description_localizations": {},
+            "type": 3,
+            "required": true
+          },
+          {
+            "name_localizations": {},
+            "autocomplete": false,
+            "name": "new_owner",
+            "description": "Member to transfer the tag to",
+            "description_localizations": {},
+            "type": 6,
+            "required": true
+          }
+        ],
+        "description": "Transfers a tag ownership to someone else in this guild",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "edit",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": true,
+            "name": "name",
+            "description": "Name of the tag",
+            "description_localizations": {},
+            "type": 3,
+            "required": true
+          }
+        ],
+        "description": "Edits a tag in this guild",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "create",
+        "options": [],
+        "description": "Creates a tag in this guild",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "raw",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": true,
+            "name": "name",
+            "description": "Name of the tag",
+            "description_localizations": {},
+            "type": 3,
+            "required": true
+          }
+        ],
+        "description": "Sends a predefined tag with all the markdown escaped",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "list",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": false,
+            "name": "sorting",
+            "description": "Type of tag sorting",
+            "description_localizations": {},
+            "type": 3,
+            "choices": [
+              {
+                "name_localizations": {},
+                "name": "Name",
+                "value": "NAME"
+              },
+              {
+                "name_localizations": {},
+                "name": "Uses",
+                "value": "USES"
+              }
+            ],
+            "required": false
+          }
+        ],
+        "description": "Creates a tag in this guild",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "delete",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": true,
+            "name": "name",
+            "description": "Name of the tag",
+            "description_localizations": {},
+            "type": 3,
+            "required": true
+          }
+        ],
+        "description": "Deletes a tag you own in this guild",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "info",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": true,
+            "name": "tag_name",
+            "description": "Name of the tag",
+            "description_localizations": {},
+            "type": 3,
+            "required": true
+          }
+        ],
+        "description": "Gives information about a tag in this guild",
+        "description_localizations": {},
+        "type": 1
+      }
+    ],
+    "description": "Deletes a tag you own in this guild",
+    "description_localizations": {},
+    "default_member_permissions": null,
+    "type": 1
+  }
+]

--- a/src/test/resources/commands_data/diff_command_description/old.json
+++ b/src/test/resources/commands_data/diff_command_description/old.json
@@ -1,0 +1,151 @@
+[
+  {
+    "dm_permission": true,
+    "name_localizations": {},
+    "nsfw": false,
+    "name": "tags",
+    "options": [
+      {
+        "name_localizations": {},
+        "name": "transfer",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": true,
+            "name": "name",
+            "description": "Name of the tag",
+            "description_localizations": {},
+            "type": 3,
+            "required": true
+          },
+          {
+            "name_localizations": {},
+            "autocomplete": false,
+            "name": "new_owner",
+            "description": "Member to transfer the tag to",
+            "description_localizations": {},
+            "type": 6,
+            "required": true
+          }
+        ],
+        "description": "Transfers a tag ownership to someone else in this guild",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "edit",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": true,
+            "name": "name",
+            "description": "Name of the tag",
+            "description_localizations": {},
+            "type": 3,
+            "required": true
+          }
+        ],
+        "description": "Edits a tag in this guild",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "raw",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": true,
+            "name": "name",
+            "description": "Name of the tag",
+            "description_localizations": {},
+            "type": 3,
+            "required": true
+          }
+        ],
+        "description": "Sends a predefined tag with all the markdown escaped",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "create",
+        "options": [],
+        "description": "Creates a tag in this guild",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "list",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": false,
+            "name": "sorting",
+            "description": "Type of tag sorting",
+            "description_localizations": {},
+            "type": 3,
+            "choices": [
+              {
+                "name_localizations": {},
+                "name": "Name",
+                "value": "NAME"
+              },
+              {
+                "name_localizations": {},
+                "name": "Uses",
+                "value": "USES"
+              }
+            ],
+            "required": false
+          }
+        ],
+        "description": "Creates a tag in this guild",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "delete",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": true,
+            "name": "name",
+            "description": "Name of the tag",
+            "description_localizations": {},
+            "type": 3,
+            "required": true
+          }
+        ],
+        "description": "Deletes a tag you own in this guild",
+        "description_localizations": {},
+        "type": 1
+      },
+      {
+        "name_localizations": {},
+        "name": "info",
+        "options": [
+          {
+            "name_localizations": {},
+            "autocomplete": true,
+            "name": "tag_name",
+            "description": "Name of the tag",
+            "description_localizations": {},
+            "type": 3,
+            "required": true
+          }
+        ],
+        "description": "Gives information about a tag in this guild",
+        "description_localizations": {},
+        "type": 1
+      }
+    ],
+    "description": "Transfers a tag ownership to someone else in this guild",
+    "description_localizations": {},
+    "default_member_permissions": null,
+    "type": 1
+  }
+]

--- a/src/test/resources/commands_data/diff_command_order/new.json
+++ b/src/test/resources/commands_data/diff_command_order/new.json
@@ -1,0 +1,22 @@
+[
+  {
+    "dm_permission": true,
+    "name_localizations": {},
+    "nsfw": false,
+    "name": "tags",
+    "description": "",
+    "description_localizations": {},
+    "default_member_permissions": null,
+    "type": 1
+  },
+  {
+    "dm_permission": true,
+    "name_localizations": {},
+    "nsfw": false,
+    "name": "tag",
+    "description": "",
+    "description_localizations": {},
+    "default_member_permissions": null,
+    "type": 1
+  }
+]

--- a/src/test/resources/commands_data/diff_command_order/old.json
+++ b/src/test/resources/commands_data/diff_command_order/old.json
@@ -1,0 +1,22 @@
+[
+  {
+    "dm_permission": true,
+    "name_localizations": {},
+    "nsfw": false,
+    "name": "tag",
+    "description": "",
+    "description_localizations": {},
+    "default_member_permissions": null,
+    "type": 1
+  },
+  {
+    "dm_permission": true,
+    "name_localizations": {},
+    "nsfw": false,
+    "name": "tags",
+    "description": "",
+    "description_localizations": {},
+    "default_member_permissions": null,
+    "type": 1
+  }
+]

--- a/src/test/resources/commands_data/diff_option_order/new.json
+++ b/src/test/resources/commands_data/diff_option_order/new.json
@@ -1,0 +1,41 @@
+[
+  {
+    "dm_permission": true,
+    "name_localizations": {},
+    "nsfw": false,
+    "name": "tag",
+    "options": [
+      {
+        "name_localizations": {},
+        "autocomplete": true,
+        "name": "name",
+        "description": "",
+        "description_localizations": {},
+        "type": 3,
+        "required": true
+      },
+      {
+        "name_localizations": {},
+        "autocomplete": false,
+        "name": "title",
+        "description": "",
+        "description_localizations": {},
+        "type": 6,
+        "required": true
+      },
+      {
+        "name_localizations": {},
+        "autocomplete": false,
+        "name": "new_owner",
+        "description": "",
+        "description_localizations": {},
+        "type": 6,
+        "required": true
+      }
+    ],
+    "description": "",
+    "description_localizations": {},
+    "default_member_permissions": null,
+    "type": 1
+  }
+]

--- a/src/test/resources/commands_data/diff_option_order/old.json
+++ b/src/test/resources/commands_data/diff_option_order/old.json
@@ -1,0 +1,41 @@
+[
+  {
+    "dm_permission": true,
+    "name_localizations": {},
+    "nsfw": false,
+    "name": "tag",
+    "options": [
+      {
+        "name_localizations": {},
+        "autocomplete": true,
+        "name": "name",
+        "description": "",
+        "description_localizations": {},
+        "type": 3,
+        "required": true
+      },
+      {
+        "name_localizations": {},
+        "autocomplete": false,
+        "name": "new_owner",
+        "description": "",
+        "description_localizations": {},
+        "type": 6,
+        "required": true
+      },
+      {
+        "name_localizations": {},
+        "autocomplete": false,
+        "name": "title",
+        "description": "",
+        "description_localizations": {},
+        "type": 6,
+        "required": true
+      }
+    ],
+    "description": "",
+    "description_localizations": {},
+    "default_member_permissions": null,
+    "type": 1
+  }
+]


### PR DESCRIPTION
### Deprecations
- `BDebugConfig#enableApplicationDiffsLogs`
  - Only used for the old diff engine

### Changes
- New application command diff engine by default
  - Only logs what changed, with more accuracy, logs on `TRACE`

### Additions
- `BApplicationConfig#diffEngine`
  - Lets you switch back in case there's a bug
- `BApplicationConfig#logApplicationCommandData`
  - Logs the raw JSON when commands needs to be updated