### PR TITLE
Refactor logging of missing command localization keys

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
@@ -108,6 +108,20 @@ interface BApplicationConfig {
      */
     @ConfigurationValue(path = "botcommands.application.localizations")
     val baseNameToLocalesMap: Map<String, List<DiscordLocale>>
+
+    /**
+     * Whether to log a `WARN` if a localization key isn't found when registering the commands.
+     *
+     * They will occur when a bundle from [baseNameToLocalesMap] doesn't contain
+     * a value for a key requested by [LocalizationFunction],
+     * such as command name/description, option name/description, choice name...
+     *
+     * Default: `false`
+     *
+     * Spring property: `botcommands.application.logMissingLocalizationKeys`
+     */
+    @ConfigurationValue(path = "botcommands.application.logMissingLocalizationKeys", defaultValue = "false")
+    val logMissingLocalizationKeys: Boolean
 }
 
 @ConfigDSL
@@ -127,6 +141,8 @@ class BApplicationConfigBuilder internal constructor() : BApplicationConfig {
 
     private val _baseNameToLocalesMap: MutableMap<String, MutableList<DiscordLocale>> = hashMapOf()
     override val baseNameToLocalesMap: Map<String, List<DiscordLocale>> = _baseNameToLocalesMap.unmodifiableView()
+
+    override var logMissingLocalizationKeys: Boolean = false
 
     /**
      * Adds the specified bundle names with its locales;
@@ -195,5 +211,6 @@ class BApplicationConfigBuilder internal constructor() : BApplicationConfig {
         override val baseNameToLocalesMap =
             this@BApplicationConfigBuilder.baseNameToLocalesMap.mapValues { (_, v) -> v.toImmutableList() }
                 .unmodifiableView()
+        override val logMissingLocalizationKeys = this@BApplicationConfigBuilder.logMissingLocalizationKeys
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BDebugConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BDebugConfig.kt
@@ -3,6 +3,7 @@ package io.github.freya022.botcommands.api.core.config
 import io.github.freya022.botcommands.api.core.service.annotations.InjectedService
 import io.github.freya022.botcommands.internal.core.config.ConfigDSL
 import io.github.freya022.botcommands.internal.core.config.ConfigurationValue
+import io.github.freya022.botcommands.internal.core.config.DeprecatedValue
 
 @InjectedService
 interface BDebugConfig {
@@ -23,7 +24,9 @@ interface BDebugConfig {
      *
      * Spring property: `botcommands.debug.enabledMissingLocalizationLogs`
      */
+    @Deprecated("Moved to BApplicationConfig#logMissingLocalizationKeys")
     @ConfigurationValue(path = "botcommands.debug.enabledMissingLocalizationLogs", defaultValue = "false")
+    @DeprecatedValue(reason = "Moved to BApplicationConfig#logMissingLocalizationKeys", replacement = "botcommands.application.logMissingLocalizationKeys")
     val enabledMissingLocalizationLogs: Boolean
 }
 
@@ -31,12 +34,14 @@ interface BDebugConfig {
 class BDebugConfigBuilder internal constructor() : BDebugConfig {
     @set:JvmName("enableApplicationDiffsLogs")
     override var enableApplicationDiffsLogs: Boolean = false
+    @Deprecated("Moved to BApplicationConfig#logMissingLocalizationKeys")
     @set:JvmName("enabledMissingLocalizationLogs")
     override var enabledMissingLocalizationLogs: Boolean = false
 
     @JvmSynthetic
     internal fun build() = object : BDebugConfig {
         override val enableApplicationDiffsLogs = this@BDebugConfigBuilder.enableApplicationDiffsLogs
+        @Suppress("OVERRIDE_DEPRECATION")
         override val enabledMissingLocalizationLogs = this@BDebugConfigBuilder.enabledMissingLocalizationLogs
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/localization/BCLocalizationFunction.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/localization/BCLocalizationFunction.kt
@@ -1,50 +1,32 @@
 package io.github.freya022.botcommands.internal.commands.application.localization
 
 import io.github.freya022.botcommands.api.core.service.getService
+import io.github.freya022.botcommands.api.core.utils.enumMapOf
+import io.github.freya022.botcommands.api.localization.Localization
 import io.github.freya022.botcommands.api.localization.LocalizationService
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.SingleLogger
-import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.interactions.DiscordLocale
 import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFunction
 import java.util.*
 
-private val logger = KotlinLogging.logger { }
+private val singleLogger = SingleLogger.of<BCLocalizationFunction>()
 
-internal class BCLocalizationFunction(private val context: BContextImpl) : LocalizationFunction {
+internal class BCLocalizationFunction(context: BContextImpl) : LocalizationFunction {
+    private val logMissingLocalizationKeys = context.applicationConfig.logMissingLocalizationKeys
     private val localizationService: LocalizationService = context.getService<LocalizationService>()
     private val baseNameToLocalesMap: Map<String, List<DiscordLocale>> = context.applicationConfig.baseNameToLocalesMap
 
     override fun apply(localizationKey: String): Map<DiscordLocale, String> {
-        val map: MutableMap<DiscordLocale, String> = EnumMap(DiscordLocale::class.java)
+        val map: MutableMap<DiscordLocale, String> = enumMapOf()
 
-        baseNameToLocalesMap.forEach { (baseName, discordLocales) ->
-            for (discordLocale in discordLocales) {
-                val javaLocale = discordLocale.toLocale()
-                val instance = localizationService.getInstance(baseName, javaLocale)
-                if (instance != null) {
-                    if (instance.effectiveLocale !== javaLocale) {
-                        SingleLogger.current().tryLog(baseName, discordLocale, instance.effectiveLocale.toLanguageTag()) {
-                            logger.warn {
-                                "Localization bundle '${baseName}' with Discord locale '${discordLocale}' was specified to be valid but was not found, falling back to '${instance.effectiveLocale}'"
-                            }
-                        }
-                    }
-
-                    val template = instance[localizationKey]
-                    if (template != null) {
-                        map[discordLocale] = template.localize()
-                    } else if (context.debugConfig.enabledMissingLocalizationLogs) {
-                        SingleLogger.current().tryLog(baseName, discordLocale, localizationKey) {
-                            logger.warn {
-                                "Localization template '${localizationKey}' could not be found in bundle '${baseName}' with locale '${discordLocale}' or below"
-                            }
-                        }
-                    }
-                } else {
-                    SingleLogger.current().tryLog(baseName, discordLocale) {
-                        logger.warn { "Localization bundle '${baseName}' with locale '${discordLocale}' was specified to be valid but was not found." }
-                    }
+        forEachBundle { baseName, javaLocale, discordLocale, localization ->
+            val template = localization[localizationKey]
+            if (template != null) {
+                map[discordLocale] = template.localize()
+            } else if (logMissingLocalizationKeys) {
+                singleLogger.warn(baseName, discordLocale, localizationKey) {
+                    "Localization template '${localizationKey}' could not be found in bundle '${baseName}' with Java locale '${javaLocale}' (from Discord's $discordLocale) or below"
                 }
             }
         }
@@ -52,5 +34,23 @@ internal class BCLocalizationFunction(private val context: BContextImpl) : Local
         return map
     }
 
-    private fun Locale.toDiscordLocale() = DiscordLocale.from(this)
+    private fun forEachBundle(block: (baseName: String, javaLocale: Locale, discordLocale: DiscordLocale, localization: Localization) -> Unit) {
+        baseNameToLocalesMap.forEach { (baseName, discordLocales) ->
+            discordLocales.forEach localeLoop@{ discordLocale ->
+                val javaLocale = discordLocale.toLocale()
+                val instance = localizationService.getInstance(baseName, javaLocale)
+                    ?: return@localeLoop singleLogger.warn(baseName, discordLocale) {
+                        "Localization bundle '${baseName}' with Java locale '${javaLocale}' (from Discord's $discordLocale) was specified to be valid but was not found at all."
+                    }
+
+                if (instance.effectiveLocale !== javaLocale) {
+                    singleLogger.warn(baseName, discordLocale, instance.effectiveLocale.toLanguageTag()) {
+                        "Localization bundle '${baseName}' with Java locale '${javaLocale}' (from Discord's $discordLocale) was specified to be valid but was not found, falling back to '${instance.effectiveLocale}'"
+                    }
+                }
+
+                block(baseName, javaLocale, discordLocale, instance)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
@@ -52,6 +52,7 @@ internal fun BConfigBuilder.applyConfig(configuration: BotCommandsCoreConfigurat
 @ConfigurationProperties(prefix = "botcommands.debug", ignoreUnknownFields = false)
 internal class BotCommandsDebugConfiguration(
     override val enableApplicationDiffsLogs: Boolean = false,
+    @Suppress("OVERRIDE_DEPRECATION")
     override val enabledMissingLocalizationLogs: Boolean = false
 ) : BDebugConfig
 
@@ -126,7 +127,8 @@ internal class BotCommandsApplicationConfiguration(
     override val disableAutocompleteCache: Boolean = false,
     override val onlineAppCommandCheckEnabled: Boolean = false,
     override val forceGuildCommands: Boolean = false,
-    localizations: Map<String, List<DiscordLocale>> = emptyMap()
+    localizations: Map<String, List<DiscordLocale>> = emptyMap(),
+    override val logMissingLocalizationKeys: Boolean = false,
 ) : BApplicationConfig {
     override val baseNameToLocalesMap = localizations
 }
@@ -140,6 +142,7 @@ internal fun BApplicationConfigBuilder.applyConfig(configuration: BotCommandsApp
     onlineAppCommandCheckEnabled = configuration.onlineAppCommandCheckEnabled
     forceGuildCommands = configuration.forceGuildCommands
     configuration.baseNameToLocalesMap.forEach(::addLocalizations)
+    logMissingLocalizationKeys = configuration.logMissingLocalizationKeys
 }
 
 @ConfigurationProperties(prefix = "botcommands.components", ignoreUnknownFields = false)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/localization/LocalizationServiceImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/localization/LocalizationServiceImpl.kt
@@ -11,6 +11,7 @@ import io.github.freya022.botcommands.api.localization.readers.LocalizationMapRe
 import io.github.freya022.botcommands.api.localization.readers.LocalizationMapReaders
 import io.github.freya022.botcommands.internal.commands.application.localization.BCLocalizationFunction
 import io.github.freya022.botcommands.internal.core.SingleLogger
+import io.github.freya022.botcommands.internal.core.SingleLogger.Companion.toSingleLogger
 import io.github.freya022.botcommands.internal.utils.rethrow
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.*
@@ -19,6 +20,7 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 private val logger = KotlinLogging.loggerOf<LocalizationService>()
+private val singleLogger = logger.toSingleLogger()
 
 @BService
 internal class LocalizationServiceImpl internal constructor(
@@ -52,19 +54,19 @@ internal class LocalizationServiceImpl internal constructor(
     private fun retrieveLocalization(baseName: String, targetLocale: Locale): LocalizationImpl? {
         return when (val localizationMap = localizationMapProviders.cycleProvidersWithParents(baseName, targetLocale)) {
             null -> {
-                if (SingleLogger.current().tryLog(baseName))
-                    logger.warn { "Could not find localization resources for '${baseName}'" }
-
+                singleLogger.warn(baseName) { "Could not find localization resources for '${baseName}'" }
                 null
             }
             else -> {
                 if (localizationMap.effectiveLocale != targetLocale) { //Not default
                     if (localizationMap.effectiveLocale.toString().isEmpty()) { //neutral lang
-                        if (SingleLogger.current().tryLog(baseName, targetLocale.toLanguageTag()))
-                            logger.warn { "Unable to find bundle '${baseName}' with locale '${targetLocale}', falling back to neutral lang" }
+                        singleLogger.warn(baseName, targetLocale.toLanguageTag()) {
+                            "Unable to find bundle '${baseName}' with locale '${targetLocale}', falling back to neutral lang"
+                        }
                     } else {
-                        if (SingleLogger.current().tryLog(baseName, targetLocale.toLanguageTag(), localizationMap.effectiveLocale.toLanguageTag()))
-                            logger.warn { "Unable to find bundle '${baseName}' with locale '${targetLocale}', falling back to '${localizationMap.effectiveLocale}'" }
+                        singleLogger.warn(baseName, targetLocale.toLanguageTag(), localizationMap.effectiveLocale.toLanguageTag()) {
+                            "Unable to find bundle '${baseName}' with locale '${targetLocale}', falling back to '${localizationMap.effectiveLocale}'"
+                        }
                     }
                 }
 


### PR DESCRIPTION
### Deprecations
- Deprecated `BDebugConfig#enabledMissingLocalizationLogs`
  - Replaced by `BApplicationConfig#logMissingLocalizationKeys`