### PR TITLE
Add parameter resolver factory priority

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/service/annotations/Resolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/service/annotations/Resolver.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.api.core.service.annotations
 
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
+import io.github.freya022.botcommands.api.parameters.ParameterResolverFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.stereotype.Component
 
@@ -21,4 +22,15 @@ import org.springframework.stereotype.Component
 @Retention(AnnotationRetention.RUNTIME)
 @Bean
 @Component
-annotation class Resolver
+annotation class Resolver(
+    /**
+     * The priority of this resolver (then wrapped as a resolver factory).
+     *
+     * When getting a resolver factory, the factory with the highest value that is [resolvable][ParameterResolverFactory.isResolvable] is taken.
+     *
+     * If two factories with the same priority exist and are both resolvable, an exception is thrown.
+     *
+     * @see ParameterResolverFactory.priority
+     */
+    val priority: Int = 0
+)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolverFactory.kt
@@ -49,6 +49,15 @@ abstract class ParameterResolverFactory<T : IParameterResolver<T>>(val resolverT
     abstract val supportedTypesStr: List<String>
 
     /**
+     * The priority of this factory.
+     *
+     * When getting a resolver factory, the factory with the highest value that is [resolvable][isResolvable] is taken.
+     *
+     * If two factories with the same priority exist and are both resolvable, an exception is thrown.
+     */
+    open val priority: Int get() = 0
+
+    /**
      * Determines if a given parameter is supported, only one factory must return `true`.
      *
      * This only gets called if the requested resolver is compatible with [resolverType].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolverFactory.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.api.parameters
 
 import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService
+import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
 import io.github.freya022.botcommands.api.parameters.resolvers.IParameterResolver
@@ -54,6 +55,8 @@ abstract class ParameterResolverFactory<T : IParameterResolver<T>>(val resolverT
      * When getting a resolver factory, the factory with the highest value that is [resolvable][isResolvable] is taken.
      *
      * If two factories with the same priority exist and are both resolvable, an exception is thrown.
+     *
+     * @see Resolver.priority
      */
     open val priority: Int get() = 0
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/Resolvers.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/Resolvers.kt
@@ -328,6 +328,7 @@ fun Enum<*>.toHumanName(locale: Locale = Locale.ROOT): String = toHumanName(this
  * }
  * ```
  *
+ * @param priority Priority of this resolver factory, see [ParameterResolverFactory.priority]
  * @param producer Function providing a [resolver][ParameterResolver] for the provided function parameter
  * @param T Type of the produced parameter resolver
  * @param R Type of the object returned by the resolver
@@ -335,8 +336,10 @@ fun Enum<*>.toHumanName(locale: Locale = Locale.ROOT): String = toHumanName(this
  * @see ParameterResolverFactory
  * @see ParameterResolver
  */
-inline fun <reified T : ParameterResolver<T, R>, reified R : Any> resolverFactory(crossinline producer: (request: ResolverRequest) -> T): ParameterResolverFactory<T> {
+inline fun <reified T : ParameterResolver<T, R>, reified R : Any> resolverFactory(priority: Int = 0, crossinline producer: (request: ResolverRequest) -> T): ParameterResolverFactory<T> {
     return object : TypedParameterResolverFactory<T>(T::class, R::class) {
+        override val priority: Int get() = priority
+
         override fun get(request: ResolverRequest): T = producer(request)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ParameterResolverAdapters.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ParameterResolverAdapters.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters
 
+import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.ParameterResolverFactory
@@ -7,7 +8,8 @@ import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.TypedParameterResolver
 
 private class ClassParameterResolverFactoryAdapter<T : ClassParameterResolver<out T, *>>(
-    private val resolver: T
+    private val resolver: T,
+    override val priority: Int,
 ): ParameterResolverFactory<T>(resolver::class) {
     override val supportedTypesStr: List<String> = listOf(resolver.jvmErasure.simpleNestedName)
 
@@ -16,12 +18,13 @@ private class ClassParameterResolverFactoryAdapter<T : ClassParameterResolver<ou
     override fun toString(): String = "ClassParameterResolverFactoryAdapter(resolver=$resolver)"
 }
 
-internal fun <T : ClassParameterResolver<out T, *>> T.toResolverFactory(): ParameterResolverFactory<T> {
-    return ClassParameterResolverFactoryAdapter(this)
+internal fun <T : ClassParameterResolver<out T, *>> T.toResolverFactory(annotation: Resolver): ParameterResolverFactory<T> {
+    return ClassParameterResolverFactoryAdapter(this, annotation.priority)
 }
 
 private class TypedParameterResolverFactoryAdapter<T : TypedParameterResolver<out T, *>>(
-    private val resolver: T
+    private val resolver: T,
+    override val priority: Int,
 ): ParameterResolverFactory<T>(resolver::class) {
     override val supportedTypesStr: List<String> = listOf(resolver.type.simpleNestedName)
 
@@ -30,6 +33,6 @@ private class TypedParameterResolverFactoryAdapter<T : TypedParameterResolver<ou
     override fun toString(): String = "TypedParameterResolverFactoryAdapter(resolver=$resolver)"
 }
 
-internal fun <T : TypedParameterResolver<out T, *>> T.toResolverFactory(): ParameterResolverFactory<T> {
-    return TypedParameterResolverFactoryAdapter(this)
+internal fun <T : TypedParameterResolver<out T, *>> T.toResolverFactory(annotation: Resolver): ParameterResolverFactory<T> {
+    return TypedParameterResolverFactoryAdapter(this, annotation.priority)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ResolverContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ResolverContainer.kt
@@ -7,10 +7,7 @@ import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.core.service.findAnnotationOnService
 import io.github.freya022.botcommands.api.core.service.getServiceNamesForAnnotation
-import io.github.freya022.botcommands.api.core.utils.arrayOfSize
-import io.github.freya022.botcommands.api.core.utils.isSubclassOf
-import io.github.freya022.botcommands.api.core.utils.joinAsList
-import io.github.freya022.botcommands.api.core.utils.simpleNestedName
+import io.github.freya022.botcommands.api.core.utils.*
 import io.github.freya022.botcommands.api.parameters.*
 import io.github.freya022.botcommands.api.parameters.resolvers.*
 import io.github.freya022.botcommands.internal.utils.annotationRef
@@ -104,8 +101,8 @@ internal class ResolverContainer internal constructor(
                 resolvableFactories.filter { it.priority == maxPriority }
             }
         require(resolvableFactories.size <= 1) {
-            val factoryNameList = resolvableFactories.joinAsList { it.resolverType.simpleNestedName }
-            "Found multiple compatible resolvers, with the same priority, for the provided request\n$factoryNameList"
+            val factoryNameList = resolvableFactories.joinAsList { it.resolverType.shortQualifiedName }
+            "Found multiple compatible resolvers, with the same priority\n$factoryNameList\nIncrease the priority of a resolver to override others"
         }
 
         val factory = resolvableFactories.firstOrNull()

--- a/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/UserResolver.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/UserResolver.kt
@@ -1,0 +1,17 @@
+package io.github.freya022.botcommands.test.resolvers
+
+import io.github.freya022.botcommands.api.core.service.annotations.Resolver
+import io.github.freya022.botcommands.api.core.service.annotations.ServiceName
+import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import org.springframework.stereotype.Component
+
+// Stub resolver overridden by the built-in resolver
+@Resolver(priority = -1)
+@Component("overriddenUserResolver")
+@ServiceName("overriddenUserResolver")
+class UserResolver : ClassParameterResolver<UserResolver, User>(User::class), SlashParameterResolver<UserResolver, User> {
+    override val optionType: OptionType = OptionType.USER
+}


### PR DESCRIPTION
This enables overriding existing parameters resolvers.

To override a built-in resolver with your own, set your factory's (or the `@Resolver` annotation) priority to higher than 0

### Additions
- Added `ParameterResolverFactory#priority`
- Added a `priority` property for `@Resolver`

### Changes
- Resolvers are now choosed based off their compatibility *and* priority
  - Errors if both have same priority