### PR TITLE
Rework getting custom text command prefixes

### DIFF
--- a/src/main/java/io/github/freya022/botcommands/api/core/SettingsProvider.java
+++ b/src/main/java/io/github/freya022/botcommands/api/core/SettingsProvider.java
@@ -3,6 +3,7 @@ package io.github.freya022.botcommands.api.core;
 import io.github.freya022.botcommands.api.commands.CommandList;
 import io.github.freya022.botcommands.api.commands.application.CommandDeclarationFilter;
 import io.github.freya022.botcommands.api.commands.application.annotations.DeclarationFilter;
+import io.github.freya022.botcommands.api.commands.text.TextPrefixSupplier;
 import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder;
 import io.github.freya022.botcommands.api.core.service.annotations.BService;
 import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService;
@@ -11,6 +12,7 @@ import io.github.freya022.botcommands.api.localization.interaction.GuildLocalePr
 import io.github.freya022.botcommands.api.localization.interaction.UserLocaleProvider;
 import io.github.freya022.botcommands.api.localization.text.TextCommandLocaleProvider;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
 import net.dv8tion.jda.api.interactions.DiscordLocale;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -28,7 +30,10 @@ import java.util.function.Predicate;
  * or {@link BServiceConfigBuilder#getServiceAnnotations() any annotation that enables your class for dependency injection}.
  *
  * @see InterfacedService @InterfacedService
+ *
+ * @deprecated For removal, all functions were deprecated
  */
+@Deprecated(forRemoval = true)
 @InterfacedService(acceptMultiple = false)
 public interface SettingsProvider {
     /**
@@ -36,8 +41,11 @@ public interface SettingsProvider {
      * <b>If the returned list is null or empty, the global prefixes will be used</b>
      *
      * @return The list of prefixes
+     *
+     * @deprecated Replaced by {@link TextPrefixSupplier#getPrefixes(GuildMessageChannel)}
      */
     @Nullable
+    @Deprecated
     default List<String> getPrefixes(@NotNull Guild guild) {
         return null;
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
@@ -40,7 +40,6 @@ interface TextCommandsContext {
     val isPingAsPrefix: Boolean
         get() = textConfig.usePingAsPrefix
 
-    //TODO replace with TextCommandPrefixSupplier
     /**
      * Returns the preferred prefix for triggering this bot,
      * or `null` if [BTextConfig.usePingAsPrefix] is disabled and no prefix was added in [BTextConfig.prefixes].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
@@ -55,6 +55,13 @@ interface TextCommandsContext {
     }
 
     /**
+     * Returns the [configured prefixes][BTextConfig.prefixes] and the [bot mention][BTextConfig.usePingAsPrefix] if enabled.
+     *
+     * Requires [JDA] to be built.
+     */
+    fun getDefaultPrefixes(): List<String>
+
+    /**
      * Returns the prefixes this bot responds to in the specified guild,
      * or an empty list if the bot shouldn't respond to anything.
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
@@ -51,6 +51,14 @@ interface TextCommandsContext {
     fun getEffectivePrefixes(guild: Guild): List<String>
 
     /**
+     * Returns the preferred prefix this bot is able to respond to, in the specified guild,
+     * or `null` if no prefix could be determined, in which case text commands are not usable.
+     *
+     * As a reminder, [TextPrefixSupplier.getPreferredPrefix] takes over the prefixes set in [BTextConfig].
+     */
+    fun getPreferredPrefix(guild: Guild): String?
+
+    /**
      * Returns the [DefaultEmbedSupplier] service.
      *
      * @see DefaultEmbedSupplier

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
@@ -23,12 +23,20 @@ interface TextCommandsContext {
      *
      * @return Full list of prefixes
      */
+    @Deprecated(
+        message = "Read directly on BTextConfig if necessary, this property doesn't mean the bot always responds to these prefixes",
+        replaceWith = ReplaceWith(expression = "textConfig.prefixes")
+    )
     val prefixes: List<String>
         get() = textConfig.prefixes
 
     /**
      * @return `true` if the bot responds to its own mention.
      */
+    @Deprecated(
+        message = "Read directly on BTextConfig if necessary, this property doesn't mean the bot always responds to pings",
+        replaceWith = ReplaceWith(expression = "textConfig.usePingAsPrefix")
+    )
     val isPingAsPrefix: Boolean
         get() = textConfig.usePingAsPrefix
 
@@ -37,6 +45,11 @@ interface TextCommandsContext {
      * Returns the preferred prefix for triggering this bot,
      * or `null` if [BTextConfig.usePingAsPrefix] is disabled and no prefix was added in [BTextConfig.prefixes].
      */
+    @Deprecated(
+        message = "Now requires a GuildMessageChannel",
+        replaceWith = ReplaceWith(expression = "this.getPreferredPrefix(channel)")
+    )
+    @Suppress("DEPRECATION")
     fun getPreferredPrefix(jda: JDA): String? = when {
         isPingAsPrefix -> jda.selfUser.asMention + " "
         else -> prefixes.firstOrNull()

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
@@ -5,7 +5,7 @@ import io.github.freya022.botcommands.api.core.DefaultEmbedSupplier
 import io.github.freya022.botcommands.api.core.config.BTextConfig
 import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService
 import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
 
 /**
  * Helps to get the registered text commands.
@@ -48,7 +48,7 @@ interface TextCommandsContext {
      *
      * As a reminder, [TextPrefixSupplier.getPrefixes] takes over the prefixes set in [BTextConfig].
      */
-    fun getEffectivePrefixes(guild: Guild): List<String>
+    fun getEffectivePrefixes(channel: GuildMessageChannel): List<String>
 
     /**
      * Returns the preferred prefix this bot is able to respond to, in the specified guild,
@@ -56,7 +56,7 @@ interface TextCommandsContext {
      *
      * As a reminder, [TextPrefixSupplier.getPreferredPrefix] takes over the prefixes set in [BTextConfig].
      */
-    fun getPreferredPrefix(guild: Guild): String?
+    fun getPreferredPrefix(channel: GuildMessageChannel): String?
 
     /**
      * Returns the [DefaultEmbedSupplier] service.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandsContext.kt
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.core.DefaultEmbedSupplier
 import io.github.freya022.botcommands.api.core.config.BTextConfig
 import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService
 import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
 
 /**
  * Helps to get the registered text commands.
@@ -40,6 +41,14 @@ interface TextCommandsContext {
         isPingAsPrefix -> jda.selfUser.asMention + " "
         else -> prefixes.firstOrNull()
     }
+
+    /**
+     * Returns the prefixes this bot responds to in the specified guild,
+     * or an empty list if the bot shouldn't respond to anything.
+     *
+     * As a reminder, [TextPrefixSupplier.getPrefixes] takes over the prefixes set in [BTextConfig].
+     */
+    fun getEffectivePrefixes(guild: Guild): List<String>
 
     /**
      * Returns the [DefaultEmbedSupplier] service.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextPrefixSupplier.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextPrefixSupplier.kt
@@ -19,7 +19,8 @@ import net.dv8tion.jda.api.entities.User
 @InterfacedService(acceptMultiple = false)
 interface TextPrefixSupplier {
     /**
-     * Returns the prefixes this bot should respond to, in the provided [guild].
+     * Returns the prefixes this bot responds to in the specified guild,
+     * or an empty list if the bot shouldn't respond to anything.
      *
      * The prefixes returned will be the only ones checked for when receiving a text command,
      * if you want it to reply to [configured prefixes][BTextConfig.prefixes] and/or [ping-as-prefix][BTextConfig.usePingAsPrefix],

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextPrefixSupplier.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextPrefixSupplier.kt
@@ -31,4 +31,17 @@ interface TextPrefixSupplier {
      * @param guild The guild in which the command is executed
      */
     fun getPrefixes(guild: Guild): List<String>
+
+    /**
+     * Returns the preferred prefix this bot is able to respond to, in the provided guild.
+     *
+     * If you have no preferred prefix for this guild,
+     * you can return one of the [prefixes][BTextConfig.prefixes],
+     * or [JDA.getSelfUser().asMention][User.getAsMention]).
+     *
+     * Used by the built-in help command to show command examples.
+     *
+     * @param guild The guild in which the command would be executed
+     */
+    fun getPreferredPrefix(guild: Guild): String
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextPrefixSupplier.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextPrefixSupplier.kt
@@ -1,0 +1,33 @@
+package io.github.freya022.botcommands.api.commands.text
+
+import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder
+import io.github.freya022.botcommands.api.core.config.BTextConfig
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.User
+
+/**
+ * Supplies the prefixes which the bot would respond to in a specific guild.
+ *
+ * **Usage**: Register your instance as a service with [@BService][BService]
+ * or [any annotation that enables your class for dependency injection][BServiceConfigBuilder.serviceAnnotations].
+ *
+ * @see getPrefixes
+ * @see InterfacedService @InterfacedService
+ */
+@InterfacedService(acceptMultiple = false)
+interface TextPrefixSupplier {
+    /**
+     * Returns the prefixes this bot should respond to, in the provided [guild].
+     *
+     * The prefixes returned will be the only ones checked for when receiving a text command,
+     * if you want it to reply to [configured prefixes][BTextConfig.prefixes] and/or [ping-as-prefix][BTextConfig.usePingAsPrefix],
+     * you'll need to pass back those ([BTextConfig.prefixes] + [JDA.getSelfUser().asMention][User.getAsMention]).
+     *
+     * Returning an empty list means the bot will not respond to commands in that guild.
+     *
+     * @param guild The guild in which the command is executed
+     */
+    fun getPrefixes(guild: Guild): List<String>
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextPrefixSupplier.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextPrefixSupplier.kt
@@ -4,8 +4,8 @@ import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder
 import io.github.freya022.botcommands.api.core.config.BTextConfig
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService
-import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
 
 /**
  * Supplies the prefixes which the bot would respond to in a specific guild.
@@ -28,9 +28,9 @@ interface TextPrefixSupplier {
      *
      * Returning an empty list means the bot will not respond to commands in that guild.
      *
-     * @param guild The guild in which the command is executed
+     * @param channel The channel in which the command is executed
      */
-    fun getPrefixes(guild: Guild): List<String>
+    fun getPrefixes(channel: GuildMessageChannel): List<String>
 
     /**
      * Returns the preferred prefix this bot is able to respond to, in the provided guild.
@@ -41,7 +41,7 @@ interface TextPrefixSupplier {
      *
      * Used by the built-in help command to show command examples.
      *
-     * @param guild The guild in which the command would be executed
+     * @param channel The channel in which the command would be executed
      */
-    fun getPreferredPrefix(guild: Guild): String
+    fun getPreferredPrefix(channel: GuildMessageChannel): String
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextPrefixSupplier.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextPrefixSupplier.kt
@@ -10,6 +10,8 @@ import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
 /**
  * Supplies the prefixes which the bot would respond to in a specific guild.
  *
+ * This overrides any other configured prefixes.
+ *
  * **Usage**: Register your instance as a service with [@BService][BService]
  * or [any annotation that enables your class for dependency injection][BServiceConfigBuilder.serviceAnnotations].
  *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/BContext.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/BContext.kt
@@ -137,6 +137,7 @@ interface BContext {
      *
      * @see SettingsProvider
      */
+    @Suppress("removal", "DEPRECATION")
     val settingsProvider: SettingsProvider?
 
     /**

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/BContext.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/BContext.kt
@@ -282,6 +282,7 @@ interface BContext {
      */
     @Deprecated("Moved to TextCommandsContext", ReplaceWith("textCommandsContext.prefixes"))
     val prefixes: List<String>
+        @Suppress("DEPRECATION")
         get() = textCommandsContext.prefixes
 
     /**
@@ -289,6 +290,7 @@ interface BContext {
      */
     @Deprecated("Moved to TextCommandsContext", ReplaceWith("textCommandsContext.isPingAsPrefix"))
     val isPingAsPrefix: Boolean
+        @Suppress("DEPRECATION")
         get() = textCommandsContext.isPingAsPrefix
 
     /**
@@ -299,6 +301,7 @@ interface BContext {
      */
     @Deprecated("Moved to TextCommandsContext", ReplaceWith("textCommandsContext.getPreferredPrefix(jda)"))
     val prefix: String?
+        @Suppress("DEPRECATION")
         get() = textCommandsContext.getPreferredPrefix(jda)
 
     /**

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BTextConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BTextConfig.kt
@@ -1,6 +1,7 @@
 package io.github.freya022.botcommands.api.core.config
 
 import io.github.freya022.botcommands.api.commands.text.IHelpCommand
+import io.github.freya022.botcommands.api.commands.text.TextPrefixSupplier
 import io.github.freya022.botcommands.api.core.service.annotations.InjectedService
 import io.github.freya022.botcommands.api.core.utils.toImmutableList
 import io.github.freya022.botcommands.api.localization.DefaultMessages
@@ -24,6 +25,10 @@ interface BTextConfig {
     /**
      * Whether the bot should look for commands when it is mentioned.
      *
+     * This prefix is not always used for text command detection,
+     * as it can be overridden by [TextPrefixSupplier], but you can read this property and return it
+     * if, for example, the guild channel has no special prefix set.
+     *
      * Default: `false`
      *
      * Spring property: `botcommands.text.usePingAsPrefix`
@@ -33,6 +38,10 @@ interface BTextConfig {
 
     /**
      * Prefixes the bot should listen to.
+     *
+     * These prefixes are not always used for text command detection,
+     * as they can be overridden by [TextPrefixSupplier], but you can read this property and return them
+     * if, for example, the guild channel has no special prefix set.
      *
      * Spring property: `botcommands.text.prefixes`
      */

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/RequiresTextCommandsChecker.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/RequiresTextCommandsChecker.kt
@@ -1,10 +1,13 @@
 package io.github.freya022.botcommands.internal.commands.text
 
+import io.github.freya022.botcommands.api.commands.text.TextPrefixSupplier
 import io.github.freya022.botcommands.api.commands.text.annotations.RequiresTextCommands
 import io.github.freya022.botcommands.api.core.config.BTextConfig
 import io.github.freya022.botcommands.api.core.service.CustomConditionChecker
 import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.service.getService
+import io.github.freya022.botcommands.api.core.service.getServiceOrNull
+import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.internal.commands.text.TextCommandsListener.Status
 import io.github.freya022.botcommands.internal.utils.reference
 
@@ -16,12 +19,16 @@ internal object RequiresTextCommandsChecker : CustomConditionChecker<RequiresTex
         checkedClass: Class<*>,
         annotation: RequiresTextCommands
     ): String? {
-        return when (Status.check(serviceContainer.getService(), serviceContainer.getService())) {
+        fun prefixSupplierName() = serviceContainer.getService<TextPrefixSupplier>().javaClass.simpleNestedName
+        return when (Status.check(serviceContainer.getService(), serviceContainer.getService(), serviceContainer.getServiceOrNull())) {
             Status.DISABLED -> "Text commands needs to be enabled, see ${BTextConfig::enable.reference}"
             Status.ENABLED -> null
+            Status.USES_PREFIX_SUPPLIER -> null
             Status.CAN_READ_PING -> null
+            Status.MISSING_CONTENT_INTENT_WITH_PREFIX_SUPPLIER_WITH_PING -> null
+            Status.MISSING_CONTENT_INTENT_WITH_PREFIX_SUPPLIER_WITHOUT_PING -> "Text prefixes supplied by ${prefixSupplierName()} can't be used without GatewayIntent.MESSAGE_CONTENT, and ${BTextConfig::usePingAsPrefix.reference} is disabled"
             Status.MISSING_CONTENT_INTENT_WITH_PREFIX_WITH_PING -> null
-            Status.MISSING_CONTENT_INTENT_WITH_PREFIX_WITHOUT_PING -> "GatewayIntent.MESSAGE_CONTENT is missing and ${BTextConfig::usePingAsPrefix.reference} is disabled"
+            Status.MISSING_CONTENT_INTENT_WITH_PREFIX_WITHOUT_PING -> "Text prefixes can't be used without GatewayIntent.MESSAGE_CONTENT, and ${BTextConfig::usePingAsPrefix.reference} is disabled"
         }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandStatusLogger.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandStatusLogger.kt
@@ -1,22 +1,32 @@
 package io.github.freya022.botcommands.internal.commands.text
 
+import io.github.freya022.botcommands.api.commands.text.TextPrefixSupplier
 import io.github.freya022.botcommands.api.core.JDAService
 import io.github.freya022.botcommands.api.core.config.BTextConfig
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.utils.loggerOf
+import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.internal.commands.text.TextCommandsListener.Status
 import io.github.freya022.botcommands.internal.utils.reference
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 @BService(priority = Int.MAX_VALUE - 1) // May be important logs
-internal class TextCommandStatusLogger(config: BTextConfig, jdaService: JDAService) {
+internal class TextCommandStatusLogger(config: BTextConfig, jdaService: JDAService, textPrefixSupplier: TextPrefixSupplier?) {
     init {
+        fun prefixSupplierName() = textPrefixSupplier!!.javaClass.simpleNestedName
+
         val logger = KotlinLogging.loggerOf<BTextConfig>()
-        when (Status.check(config, jdaService)) {
+        when (Status.check(config, jdaService, textPrefixSupplier)) {
             Status.DISABLED -> {}
             Status.ENABLED -> {}
+            Status.USES_PREFIX_SUPPLIER ->
+                logger.info { "Listening to text commands, only using prefixes from ${prefixSupplierName()}" }
             Status.CAN_READ_PING ->
-                logger.info { "Listening to text commands, only using ping-as-prefix, as GatewayIntent.MESSAGE_CONTENT is disabled" }
+                logger.info { "Listening to text commands, only using ping-as-prefix" }
+            Status.MISSING_CONTENT_INTENT_WITH_PREFIX_SUPPLIER_WITH_PING ->
+                logger.debug { "Text command prefixes supplied by ${prefixSupplierName()} are set but can't be used without GatewayIntent.MESSAGE_CONTENT, using ping-as-prefix" }
+            Status.MISSING_CONTENT_INTENT_WITH_PREFIX_SUPPLIER_WITHOUT_PING ->
+                logger.info { "Disabling text commands as prefixes supplied by ${prefixSupplierName()} can't be used without GatewayIntent.MESSAGE_CONTENT, and ${BTextConfig::usePingAsPrefix.reference} is disabled" }
             Status.MISSING_CONTENT_INTENT_WITH_PREFIX_WITH_PING ->
                 logger.debug { "Text command prefixes are set but can't be used without GatewayIntent.MESSAGE_CONTENT, using ping-as-prefix" }
             Status.MISSING_CONTENT_INTENT_WITH_PREFIX_WITHOUT_PING ->

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsContextImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsContextImpl.kt
@@ -11,7 +11,7 @@ import io.github.freya022.botcommands.api.core.config.BTextConfig
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.utils.unmodifiableView
 import io.github.freya022.botcommands.internal.utils.putIfAbsentOrThrow
-import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
 
 @BService
 @RequiresTextCommands
@@ -28,31 +28,31 @@ internal class TextCommandsContextImpl internal constructor(
     override val rootCommands: Collection<TopLevelTextCommandInfoImpl>
         get() = textCommandMap.values.unmodifiableView()
 
-    override fun getEffectivePrefixes(guild: Guild): List<String> {
+    override fun getEffectivePrefixes(channel: GuildMessageChannel): List<String> {
         if (textPrefixSupplier != null) {
-            return textPrefixSupplier.getPrefixes(guild)
+            return textPrefixSupplier.getPrefixes(channel)
         }
 
         if (settingsProvider != null) {
-            val prefixes = settingsProvider.getPrefixes(guild)
+            val prefixes = settingsProvider.getPrefixes(channel.guild)
             if (!prefixes.isNullOrEmpty()) return prefixes
         }
 
         val prefixes = textConfig.prefixes
         return when (textConfig.usePingAsPrefix) {
             false -> prefixes
-            true -> prefixes + guild.selfMember.asMention
+            true -> prefixes + channel.jda.selfUser.asMention
         }
     }
 
-    override fun getPreferredPrefix(guild: Guild): String? {
+    override fun getPreferredPrefix(channel: GuildMessageChannel): String? {
         if (textPrefixSupplier != null) {
-            return textPrefixSupplier.getPreferredPrefix(guild)
+            return textPrefixSupplier.getPreferredPrefix(channel)
         }
 
         val prefixes = textConfig.prefixes
         return when (textConfig.usePingAsPrefix) {
-            true -> guild.selfMember.asMention
+            true -> channel.jda.selfUser.asMention
             false -> prefixes.firstOrNull()
         }
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsContextImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsContextImpl.kt
@@ -45,6 +45,18 @@ internal class TextCommandsContextImpl internal constructor(
         }
     }
 
+    override fun getPreferredPrefix(guild: Guild): String? {
+        if (textPrefixSupplier != null) {
+            return textPrefixSupplier.getPreferredPrefix(guild)
+        }
+
+        val prefixes = textConfig.prefixes
+        return when (textConfig.usePingAsPrefix) {
+            true -> guild.selfMember.asMention
+            false -> prefixes.firstOrNull()
+        }
+    }
+
     internal fun addTextCommand(commandInfo: TopLevelTextCommandInfoImpl) {
         (commandInfo.aliases + commandInfo.name).forEach { name ->
             textCommandMap.putIfAbsentOrThrow(name, commandInfo) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsContextImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsContextImpl.kt
@@ -10,14 +10,18 @@ import io.github.freya022.botcommands.api.core.DefaultEmbedFooterIconSupplier
 import io.github.freya022.botcommands.api.core.DefaultEmbedSupplier
 import io.github.freya022.botcommands.api.core.SettingsProvider
 import io.github.freya022.botcommands.api.core.config.BTextConfig
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.unmodifiableView
 import io.github.freya022.botcommands.internal.utils.putIfAbsentOrThrow
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
 
 @BService
 @RequiresTextCommands
 internal class TextCommandsContextImpl internal constructor(
+    private val serviceContainer: ServiceContainer,
     override val textConfig: BTextConfig,
     private val settingsProvider: SettingsProvider?,
     private val textPrefixSupplier: TextPrefixSupplier?,
@@ -29,6 +33,11 @@ internal class TextCommandsContextImpl internal constructor(
 
     override val rootCommands: Collection<TopLevelTextCommandInfoImpl>
         get() = textCommandMap.values.unmodifiableView()
+
+    override fun getDefaultPrefixes(): List<String> = when {
+        textConfig.usePingAsPrefix -> textConfig.prefixes + serviceContainer.getService<JDA>().selfUser.asMention
+        else -> textConfig.prefixes
+    }
 
     override fun getEffectivePrefixes(channel: GuildMessageChannel): List<String> {
         if (textPrefixSupplier != null) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsContextImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsContextImpl.kt
@@ -2,18 +2,23 @@ package io.github.freya022.botcommands.internal.commands.text
 
 import io.github.freya022.botcommands.api.commands.text.HelpBuilderConsumer
 import io.github.freya022.botcommands.api.commands.text.TextCommandsContext
+import io.github.freya022.botcommands.api.commands.text.TextPrefixSupplier
 import io.github.freya022.botcommands.api.commands.text.annotations.RequiresTextCommands
 import io.github.freya022.botcommands.api.core.DefaultEmbedFooterIconSupplier
 import io.github.freya022.botcommands.api.core.DefaultEmbedSupplier
+import io.github.freya022.botcommands.api.core.SettingsProvider
 import io.github.freya022.botcommands.api.core.config.BTextConfig
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.utils.unmodifiableView
 import io.github.freya022.botcommands.internal.utils.putIfAbsentOrThrow
+import net.dv8tion.jda.api.entities.Guild
 
 @BService
 @RequiresTextCommands
 internal class TextCommandsContextImpl internal constructor(
     override val textConfig: BTextConfig,
+    private val settingsProvider: SettingsProvider?,
+    private val textPrefixSupplier: TextPrefixSupplier?,
     override val defaultEmbedSupplier: DefaultEmbedSupplier,
     override val defaultEmbedFooterIconSupplier: DefaultEmbedFooterIconSupplier,
     override val helpBuilderConsumer: HelpBuilderConsumer?
@@ -22,6 +27,23 @@ internal class TextCommandsContextImpl internal constructor(
 
     override val rootCommands: Collection<TopLevelTextCommandInfoImpl>
         get() = textCommandMap.values.unmodifiableView()
+
+    override fun getEffectivePrefixes(guild: Guild): List<String> {
+        if (textPrefixSupplier != null) {
+            return textPrefixSupplier.getPrefixes(guild)
+        }
+
+        if (settingsProvider != null) {
+            val prefixes = settingsProvider.getPrefixes(guild)
+            if (!prefixes.isNullOrEmpty()) return prefixes
+        }
+
+        val prefixes = textConfig.prefixes
+        return when (textConfig.usePingAsPrefix) {
+            false -> prefixes
+            true -> prefixes + guild.selfMember.asMention
+        }
+    }
 
     internal fun addTextCommand(commandInfo: TopLevelTextCommandInfoImpl) {
         (commandInfo.aliases + commandInfo.name).forEach { name ->

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsContextImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsContextImpl.kt
@@ -1,3 +1,5 @@
+@file:Suppress("removal", "DEPRECATION")
+
 package io.github.freya022.botcommands.internal.commands.text
 
 import io.github.freya022.botcommands.api.commands.text.HelpBuilderConsumer

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
@@ -177,7 +177,7 @@ internal class TextCommandsListener internal constructor(
     private fun getMsgNoPrefix(msg: String, guild: Guild): String? {
         return getPrefixes(guild)
             .find { prefix -> msg.startsWith(prefix) }
-            ?.let { prefix -> msg.substring(prefix.length).trim() }
+            ?.let { prefix -> msg.substring(prefix.length).trimStart() }
     }
 
     private fun getPrefixes(guild: Guild): List<String> {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
@@ -26,7 +26,7 @@ import io.github.freya022.botcommands.internal.core.ExceptionHandler
 import io.github.freya022.botcommands.internal.localization.text.LocalizableTextCommandFactory
 import io.github.freya022.botcommands.internal.utils.*
 import io.github.oshai.kotlinlogging.KotlinLogging
-import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException
 import net.dv8tion.jda.api.requests.ErrorResponse
@@ -70,7 +70,7 @@ internal class TextCommandsListener internal constructor(
 
         // Could also check mentions, but this is way easier and faster
         val msg: String = suppressContentWarning { event.message.contentRaw }
-        val content = getMsgNoPrefix(msg, event.guild)
+        val content = getMsgNoPrefix(msg, event.guildChannel)
         if (content.isNullOrBlank()) return
 
         logger.trace { "Received text command: $msg" }
@@ -171,8 +171,8 @@ internal class TextCommandsListener internal constructor(
         }
     }
 
-    private fun getMsgNoPrefix(msg: String, guild: Guild): String? {
-        return textCommandsContext.getEffectivePrefixes(guild)
+    private fun getMsgNoPrefix(msg: String, channel: GuildMessageChannel): String? {
+        return textCommandsContext.getEffectivePrefixes(channel)
             .find { prefix -> msg.startsWith(prefix) }
             ?.let { prefix -> msg.substring(prefix.length).trimStart() }
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
@@ -70,10 +70,7 @@ internal class TextCommandsListener internal constructor(
 
         // Could also check mentions, but this is way easier and faster
         val msg: String = suppressContentWarning { event.message.contentRaw }
-        val content = when {
-            context.textConfig.usePingAsPrefix && msg.startsWith(event.jda.selfUser.asMention) -> msg.substringAfter(' ', missingDelimiterValue = "")
-            else -> getMsgNoPrefix(msg, event.guild)
-        }
+        val content = getMsgNoPrefix(msg, event.guild)
         if (content.isNullOrBlank()) return
 
         logger.trace { "Received text command: $msg" }
@@ -186,7 +183,11 @@ internal class TextCommandsListener internal constructor(
             if (!prefixes.isNullOrEmpty()) return prefixes
         }
 
-        return context.textConfig.prefixes
+        val prefixes = context.textConfig.prefixes
+        return when (context.textConfig.usePingAsPrefix) {
+            false -> prefixes
+            true -> prefixes + guild.selfMember.asMention
+        }
     }
 
     private suspend fun canRun(event: MessageReceivedEvent, commandInfo: TextCommandInfo): Boolean {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
@@ -41,6 +41,7 @@ private val spacePattern = Regex("\\s+")
 @ConditionalService(TextCommandsListener.ActivationCondition::class)
 internal class TextCommandsListener internal constructor(
     private val context: BContext,
+    private val textPrefixSupplier: TextPrefixSupplier?,
     private val defaultMessagesFactory: DefaultMessagesFactory,
     private val textCommandsContext: TextCommandsContextImpl,
     private val localizableTextCommandFactory: LocalizableTextCommandFactory,
@@ -178,6 +179,10 @@ internal class TextCommandsListener internal constructor(
     }
 
     private fun getPrefixes(guild: Guild): List<String> {
+        if (textPrefixSupplier != null) {
+            return textPrefixSupplier.getPrefixes(guild)
+        }
+
         context.settingsProvider?.let { settingsProvider ->
             val prefixes = settingsProvider.getPrefixes(guild)
             if (!prefixes.isNullOrEmpty()) return prefixes

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextUtils.kt
@@ -74,7 +74,7 @@ object TextUtils {
             }
         }
 
-        val prefix = event.context.textCommandsContext.getPreferredPrefix(event.context.jda) ?: throwInternal("Cannot generate help content without a prefix")
+        val prefix = event.context.textCommandsContext.getPreferredPrefix(event.guild) ?: throwInternal("Cannot generate help content without a prefix")
         fun TextCommandVariation.buildUsage(commandOptionsByParameters: Map<TextCommandParameter, List<TextCommandOption>>) = buildString {
             append(prefix)
             append(name)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextUtils.kt
@@ -74,7 +74,7 @@ object TextUtils {
             }
         }
 
-        val prefix = event.context.textCommandsContext.getPreferredPrefix(event.guild) ?: throwInternal("Cannot generate help content without a prefix")
+        val prefix = event.context.textCommandsContext.getPreferredPrefix(event.guildChannel) ?: throwInternal("Cannot generate help content without a prefix")
         fun TextCommandVariation.buildUsage(commandOptionsByParameters: Map<TextCommandParameter, List<TextCommandOption>>) = buildString {
             append(prefix)
             append(name)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/BContextImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/BContextImpl.kt
@@ -32,6 +32,7 @@ internal class BContextImpl internal constructor(
     override var status: Status = Status.PRE_LOAD
         private set
 
+    @Suppress("removal", "DEPRECATION")
     override val settingsProvider: SettingsProvider? by lazy { serviceContainer.getServiceOrNull() }
     override val globalExceptionHandler: GlobalExceptionHandler? by lazy { serviceContainer.getServiceOrNull() }
 

--- a/src/test/kotlin/io/github/freya022/botcommands/test/MyTextPrefixSupplier.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/MyTextPrefixSupplier.kt
@@ -1,0 +1,18 @@
+package io.github.freya022.botcommands.test
+
+import io.github.freya022.botcommands.api.commands.text.TextCommandsContext
+import io.github.freya022.botcommands.api.commands.text.TextPrefixSupplier
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
+
+@BService
+class MyTextPrefixSupplier(private val textCommandsContext: TextCommandsContext) : TextPrefixSupplier {
+    override fun getPrefixes(channel: GuildMessageChannel): List<String> = when {
+        channel.idLong == 1274378050154270720L -> emptyList() // No text commands
+        else -> textCommandsContext.getDefaultPrefixes()
+    }
+
+    override fun getPreferredPrefix(channel: GuildMessageChannel): String {
+        return textCommandsContext.getDefaultPrefixes().first()
+    }
+}


### PR DESCRIPTION
Added a new better way to get custom text command prefixes based on a given `GuildMessageChannel`, methods to get the supported/preferred prefixes now accurately return the prefixes used in other places

### Possible breaking changes
*This only affects you if you had prefixes set with `SettingsProvider`*

Retrieving allowed prefixes of a command in a specific channel has slightly changed:
#### Previous behavior
- If ping-as-prefix is enabled, and the command starts with the bot's mention, then the command is accepted
- Else, the prefixes are gathered, and if it starts with any, the command is accepted:
  - If a `SettingsProvider` is available, from `SettingProvider#getPrefixes(Guild)`
  - Else, from `BTextConfig#prefixes`

#### New behavior
The command is accepted if any prefix given by `TextCommandsContext#getPrefixes(GuildMessageChannel)` matches:
- If a `TextPrefixSupplier` is available, from `TextPrefixSupplier#getPrefixes(GuildMessageChannel)`
- If a `SettingsProvider` is available, from `SettingProvider#getPrefixes(Guild)` **(now deprecated)**
- Else, from `BTextConfig#prefixes` + the bot's mention if `BTextConfig#usePingAsPrefix` is enabled

### Deprecations
- `SettingsProvider`
- `SettingsProvider#getPrefixes(Guild)`
- `TextCommandsContext#prefixes`
- `TextCommandsContext#isPingAsPrefix`
- `TextCommandsContext#getPreferredPrefix(JDA)`

### Changes
- The prefix used in the **content** of the built-in help command is now determined by `TextCommandsContext#getPreferredPrefix(GuildMessageChannel)`

### Additions
- Added `TextPrefixSupplier`
  - Returns the allowed prefixes for a given `GuildMessageChannel`
  - Returns the preferred prefix for a given `GuildMessageChannel`