### PR TITLE
Add switch to enable more debug logs for built-in DI

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
@@ -15,6 +15,14 @@ import kotlin.reflect.KClass
 
 @InjectedService
 interface BServiceConfig {
+    /**
+     * Enables debugging of service loading.
+     *
+     * This includes the operation type (check/create), the run time, the type of the service and where it comes from.
+     */
+    val debug: Boolean
+
+    //TODO document - this seems to be mostly used to retain classpath elements
     @Deprecated(message = "For removal, didn't do much in the first place")
     val serviceAnnotations: Set<KClass<out Annotation>>
     val instanceSupplierMap: Map<KClass<*>, InstanceSupplier<*>>
@@ -22,6 +30,8 @@ interface BServiceConfig {
 
 @ConfigDSL
 class BServiceConfigBuilder internal constructor() : BServiceConfig {
+    override var debug: Boolean = false
+
     @Deprecated("For removal, didn't do much in the first place")
     override val serviceAnnotations: MutableSet<KClass<out Annotation>> = hashSetOf(BService::class, Command::class, Resolver::class, ResolverFactory::class, Handler::class)
 
@@ -42,6 +52,7 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
 
     @JvmSynthetic
     internal fun build() = object : BServiceConfig {
+        override val debug = this@BServiceConfigBuilder.debug
         @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
         override val serviceAnnotations = this@BServiceConfigBuilder.serviceAnnotations.toImmutableSet()
         override val instanceSupplierMap = this@BServiceConfigBuilder.instanceSupplierMap.toImmutableMap()

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
@@ -22,7 +22,6 @@ interface BServiceConfig {
      */
     val debug: Boolean
 
-    //TODO document - this seems to be mostly used to retain classpath elements
     @Deprecated(message = "For removal, didn't do much in the first place")
     val serviceAnnotations: Set<KClass<out Annotation>>
     val instanceSupplierMap: Map<KClass<*>, InstanceSupplier<*>>

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
@@ -68,14 +68,16 @@ internal fun BDebugConfigBuilder.applyConfig(configuration: BotCommandsDebugConf
 }
 
 @ConfigurationProperties(prefix = "botcommands.service", ignoreUnknownFields = false)
-internal class BotCommandsServiceConfiguration : BServiceConfig {
+internal class BotCommandsServiceConfiguration(
+    override val debug: Boolean = false,
+) : BServiceConfig {
     @Deprecated("For removal, didn't do much in the first place")
     override val serviceAnnotations: Nothing get() = unusable()
     override val instanceSupplierMap: Nothing get() = unusable()
 }
 
 internal fun BServiceConfigBuilder.applyConfig(configuration: BotCommandsServiceConfiguration) = apply {
-
+    debug = configuration.debug
 }
 
 @ConfigurationProperties(prefix = "botcommands.database", ignoreUnknownFields = false)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
@@ -68,16 +68,15 @@ internal fun BDebugConfigBuilder.applyConfig(configuration: BotCommandsDebugConf
 }
 
 @ConfigurationProperties(prefix = "botcommands.service", ignoreUnknownFields = false)
-internal class BotCommandsServiceConfiguration(
-    override val debug: Boolean = false,
-) : BServiceConfig {
+internal class BotCommandsServiceConfiguration : BServiceConfig {
+    override val debug: Nothing get() = unusable()
     @Deprecated("For removal, didn't do much in the first place")
     override val serviceAnnotations: Nothing get() = unusable()
     override val instanceSupplierMap: Nothing get() = unusable()
 }
 
 internal fun BServiceConfigBuilder.applyConfig(configuration: BotCommandsServiceConfiguration) = apply {
-    debug = configuration.debug
+
 }
 
 @ConfigurationProperties(prefix = "botcommands.database", ignoreUnknownFields = false)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/DefaultServiceContainerImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/DefaultServiceContainerImpl.kt
@@ -64,21 +64,9 @@ internal class TracedServiceCreationStack : ServiceCreationStack {
         context(StringBuilder)
         abstract fun print(indent: Int = 0)
 
+        // For circular dependency string
         override fun toString(): String {
             return providerKey
-        }
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
-
-            other as ServiceOperation<*>
-
-            return providerKey == other.providerKey
-        }
-
-        override fun hashCode(): Int {
-            return providerKey.hashCode()
         }
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/DefaultServiceContainerImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/DefaultServiceContainerImpl.kt
@@ -39,7 +39,10 @@ internal class DefaultServiceContainerImpl internal constructor(internal val ser
     internal val serviceConfig: BServiceConfig get() = serviceBootstrap.serviceConfig
     internal val serviceProviders: ServiceProviders get() = serviceBootstrap.serviceProviders
     private val lock = ReentrantLock()
-    private val serviceCreationStack = if (serviceConfig.debug) TracedServiceCreationStack() else DefaultServiceCreationStack()
+    private val serviceCreationStack = when {
+        serviceConfig.debug -> TracedServiceCreationStack()
+        else -> DefaultServiceCreationStack()
+    }
 
     internal fun loadServices() {
         getService<DefaultInstantiableServices>()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ClassServiceProvider.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ClassServiceProvider.kt
@@ -98,7 +98,7 @@ internal class ClassServiceProvider internal constructor(
         return null
     }
 
-    override fun createInstance(serviceContainer: DefaultServiceContainerImpl): TimedInstantiation {
+    override fun createInstance(serviceContainer: DefaultServiceContainerImpl): TimedInstantiation<*> {
         if (instance != null)
             throwInternal("Tried to create an instance of ${clazz.jvmName} when one already exists, instance should be retrieved manually beforehand")
 
@@ -114,11 +114,11 @@ internal class ClassServiceProvider internal constructor(
         }
 
         val timedInstantiation = createInstanceNonCached(serviceContainer)
-        instance = timedInstantiation.result.getOrNull()
+        instance = timedInstantiation.instance
         return timedInstantiation
     }
 
-    private fun createInstanceNonCached(serviceContainer: DefaultServiceContainerImpl): TimedInstantiation {
+    private fun createInstanceNonCached(serviceContainer: DefaultServiceContainerImpl): TimedInstantiation<*> {
         measureNullableTimedInstantiation { clazz.objectInstance }?.let { timedInstantiation ->
             return timedInstantiation
         }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/FunctionServiceProvider.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/FunctionServiceProvider.kt
@@ -76,7 +76,7 @@ internal class FunctionServiceProvider(
         return null
     }
 
-    override fun createInstance(serviceContainer: DefaultServiceContainerImpl): TimedInstantiation {
+    override fun createInstance(serviceContainer: DefaultServiceContainerImpl): TimedInstantiation<*> {
         if (instance != null)
             throwInternal("Tried to create an instance using ${function.shortSignatureNoSrc} when one already exists, instance should be retrieved manually beforehand")
 
@@ -92,10 +92,8 @@ internal class FunctionServiceProvider(
         }
 
         val timedInstantiation = function.callConstructingFunction(serviceContainer)
-        if (timedInstantiation.result.serviceError != null)
-            return timedInstantiation
-
-        return timedInstantiation.also { instance = it.result.getOrThrow() }
+        instance = timedInstantiation.instance
+        return timedInstantiation
     }
 
     override fun getProviderFunction(): KFunction<*> = function

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ProvidedServiceProvider.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ProvidedServiceProvider.kt
@@ -49,7 +49,7 @@ internal class ProvidedServiceProvider internal constructor(
         return null
     }
 
-    override fun createInstance(serviceContainer: DefaultServiceContainerImpl): TimedInstantiation {
+    override fun createInstance(serviceContainer: DefaultServiceContainerImpl): Nothing {
         throwInternal("Tried to create an instance of ${clazz.jvmName} when one already exists, instance should be retrieved manually beforehand")
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/stack/DefaultServiceCreationStack.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/stack/DefaultServiceCreationStack.kt
@@ -1,0 +1,45 @@
+package io.github.freya022.botcommands.internal.core.service.stack
+
+import io.github.freya022.botcommands.api.core.service.ServiceError
+import io.github.freya022.botcommands.api.core.utils.simpleNestedName
+import io.github.freya022.botcommands.internal.core.service.provider.Instance
+import io.github.freya022.botcommands.internal.core.service.provider.ProviderName
+import io.github.freya022.botcommands.internal.core.service.provider.ServiceProvider
+import io.github.freya022.botcommands.internal.core.service.provider.TimedInstantiation
+import io.github.freya022.botcommands.internal.core.service.stack.ServiceCreationStack.Companion.logger
+import kotlin.time.DurationUnit
+
+internal class DefaultServiceCreationStack : ServiceCreationStack {
+    private val localSet: ThreadLocal<MutableSet<ProviderName>> = ThreadLocal.withInitial { linkedSetOf() }
+    private val set get() = localSet.get()
+
+    override fun contains(provider: ServiceProvider) = set.contains(provider.providerKey)
+
+    //If services have circular dependencies during checking, consider it to not be an issue
+    override fun withServiceCheckKey(provider: ServiceProvider, block: () -> ServiceError?): ServiceError? {
+        if (!set.add(provider.providerKey)) return null
+        try {
+            return block()
+        } finally {
+            set.remove(provider.providerKey)
+        }
+    }
+
+    override fun <R : Instance> withServiceCreateKey(provider: ServiceProvider, block: () -> TimedInstantiation<R>): R {
+        check(set.add(provider.providerKey)) {
+            "Circular dependency detected, list of the services being created : [${set.joinToString(" -> ")}] ; attempted to create ${provider.providerKey}"
+        }
+        try {
+            val (instance, duration) = block()
+            logger.trace {
+                val instanceTypeName = instance.javaClass.simpleNestedName
+                val loadedAsTypes = provider.types.joinToString(prefix = "[", postfix = "]") { it.simpleNestedName }
+                val durationStr = duration.toString(DurationUnit.MILLISECONDS, decimals = 3)
+                "Loaded service $instanceTypeName as $loadedAsTypes in $durationStr"
+            }
+            return instance
+        } finally {
+            set.remove(provider.providerKey)
+        }
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/stack/ServiceCreationStack.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/stack/ServiceCreationStack.kt
@@ -1,0 +1,21 @@
+package io.github.freya022.botcommands.internal.core.service.stack
+
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
+import io.github.freya022.botcommands.api.core.service.ServiceError
+import io.github.freya022.botcommands.api.core.utils.loggerOf
+import io.github.freya022.botcommands.internal.core.service.provider.Instance
+import io.github.freya022.botcommands.internal.core.service.provider.ServiceProvider
+import io.github.freya022.botcommands.internal.core.service.provider.TimedInstantiation
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+internal interface ServiceCreationStack {
+    operator fun contains(provider: ServiceProvider): Boolean
+
+    fun withServiceCheckKey(provider: ServiceProvider, block: () -> ServiceError?): ServiceError?
+
+    fun <R : Instance> withServiceCreateKey(provider: ServiceProvider, block: () -> TimedInstantiation<R>): R
+
+    companion object {
+        val logger = KotlinLogging.loggerOf<ServiceContainer>()
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/stack/TracedServiceCreationStack.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/stack/TracedServiceCreationStack.kt
@@ -1,0 +1,140 @@
+package io.github.freya022.botcommands.internal.core.service.stack
+
+import io.github.freya022.botcommands.api.core.service.ServiceError
+import io.github.freya022.botcommands.api.core.utils.simpleNestedName
+import io.github.freya022.botcommands.internal.core.service.provider.Instance
+import io.github.freya022.botcommands.internal.core.service.provider.ServiceProvider
+import io.github.freya022.botcommands.internal.core.service.provider.TimedInstantiation
+import io.github.freya022.botcommands.internal.core.service.stack.ServiceCreationStack.Companion.logger
+import java.util.*
+import kotlin.properties.Delegates
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.TimeSource
+
+internal class TracedServiceCreationStack : ServiceCreationStack {
+    private sealed class ServiceOperation<in V>(protected val provider: ServiceProvider) {
+        private val mark = TimeSource.Monotonic.markNow()
+
+        val providerKey get() = provider.providerKey
+        val children: MutableList<ServiceOperation<*>> = arrayListOf()
+
+        protected var elapsed: Duration by Delegates.notNull()
+            private set
+
+        fun setElapsedNow() {
+            elapsed = mark.elapsedNow()
+        }
+
+        abstract fun onValue(value: V)
+
+        context(StringBuilder)
+        abstract fun print(indent: Int = 0)
+
+        // For circular dependency string
+        override fun toString(): String {
+            return providerKey
+        }
+    }
+
+    private class ServiceCheckOperation(provider: ServiceProvider) : ServiceOperation<ServiceError?>(provider) {
+        private var _error: Any? = NO_VALUE
+        private val error: ServiceError? get() = _error as? ServiceError?
+        private val hasFailed: Boolean get() = _error === NO_VALUE
+
+        override fun onValue(value: ServiceError?) {
+            _error = value
+        }
+
+        context(StringBuilder)
+        override fun print(indent: Int) {
+            append("  ".repeat(indent))
+
+            val opDuration = elapsed.toString(DurationUnit.MILLISECONDS, decimals = 3)
+            val typeName = provider.primaryType.simpleNestedName
+            val failIndicator = if (hasFailed) " failed" else ""
+            val errorMessage = if (error != null) " {${error?.toSimpleString()}}" else ""
+            appendLine("[Check$failIndicator, $opDuration] $typeName$errorMessage ($providerKey)")
+
+            children.forEach { it.print(indent + 1) }
+        }
+
+        companion object {
+            private val NO_VALUE = Any()
+        }
+    }
+
+    private class ServiceCreateOperation(provider: ServiceProvider) : ServiceOperation<TimedInstantiation<*>>(provider) {
+        // Null if the service creation fails
+        private lateinit var instance: Instance
+
+        override fun onValue(value: TimedInstantiation<*>) {
+            instance = value.instance
+        }
+
+        context(StringBuilder)
+        override fun print(indent: Int) {
+            append("  ".repeat(indent))
+
+            val opDuration = elapsed.toString(DurationUnit.MILLISECONDS, decimals = 3)
+            if (::instance.isInitialized) {
+                val typeName = instance::class.simpleNestedName
+                val loadedAsTypes = provider.types.joinToString(prefix = "[", postfix = "]") { it.simpleNestedName }
+                appendLine("[Create, $opDuration] $typeName as $loadedAsTypes ($providerKey)")
+            } else {
+                val typeName = provider.primaryType.simpleNestedName
+                appendLine("[Create failed, $opDuration] $typeName ($providerKey)")
+            }
+
+            children.forEach { it.print(indent + 1) }
+        }
+    }
+
+    private val localSet: ThreadLocal<LinkedList<ServiceOperation<*>>> = ThreadLocal.withInitial { LinkedList() }
+    private val set: LinkedList<ServiceOperation<*>> get() = localSet.get()
+
+    override fun contains(provider: ServiceProvider) = set.any { it.providerKey == provider.providerKey }
+
+    //If services have circular dependencies during checking, consider it to not be an issue
+    override fun withServiceCheckKey(provider: ServiceProvider, block: () -> ServiceError?): ServiceError? {
+        return withServiceKey(provider, ::ServiceCheckOperation, block, onDuplicate = {
+            return null
+        })
+    }
+
+    override fun <R : Instance> withServiceCreateKey(
+        provider: ServiceProvider,
+        block: () -> TimedInstantiation<R>
+    ): R {
+        return withServiceKey(provider, ::ServiceCreateOperation, block, onDuplicate = {
+            throw IllegalStateException("Circular dependency detected, list of the services being created : [${set.joinToString(" -> ")}] ; attempted to create ${provider.providerKey}")
+        }).instance
+    }
+
+    private inline fun <R> withServiceKey(provider: ServiceProvider, operationSupplier: (ServiceProvider) -> ServiceOperation<R>, crossinline block: () -> R, onDuplicate: () -> Nothing): R {
+        if (provider in this)
+            onDuplicate() // Does not return
+
+        val serviceOperation = operationSupplier(provider)
+
+        // Add the new OP to the children of the current OP
+        if (set.isNotEmpty())
+            set.last().children += serviceOperation
+
+        set.addLast(serviceOperation)
+        try {
+            val value = block()
+            serviceOperation.onValue(value)
+            return value
+        } finally {
+            serviceOperation.setElapsedNow()
+            set.removeLast()
+
+            if (set.isEmpty()) {
+                logger.trace {
+                    buildString { serviceOperation.print() }.trim()
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/github/freya022/botcommands/test/Main.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/Main.kt
@@ -63,6 +63,10 @@ object Main {
                     usePingAsPrefix = true
                 }
 
+                services {
+                    debug = true
+                }
+
                 applicationCommands {
                     enable = true
 

--- a/src/test/kotlin/io/github/freya022/botcommands/test/Main.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/Main.kt
@@ -64,7 +64,7 @@ object Main {
                 }
 
                 services {
-                    debug = true
+                    debug = false
                 }
 
                 applicationCommands {


### PR DESCRIPTION
Added `BServiceConfig#debug`, will print all service checks/instantiations, including nested retrievals, their duration and the error message if available.