### PR TITLE
Rate limit command updates

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BConfig.kt
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.autocomplet
 import io.github.freya022.botcommands.api.commands.text.annotations.Hidden
 import io.github.freya022.botcommands.api.core.BotOwners
 import io.github.freya022.botcommands.api.core.annotations.BEventListener
+import io.github.freya022.botcommands.api.core.requests.PriorityGlobalRestRateLimiter
 import io.github.freya022.botcommands.api.core.service.ClassGraphProcessor
 import io.github.freya022.botcommands.api.core.service.annotations.InjectedService
 import io.github.freya022.botcommands.api.core.utils.enumSetOf
@@ -18,6 +19,7 @@ import io.github.freya022.botcommands.internal.core.config.DeprecatedValue
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.events.Event
 import net.dv8tion.jda.api.requests.GatewayIntent
+import net.dv8tion.jda.api.requests.RestRateLimiter
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 
 @InjectedService
@@ -109,6 +111,18 @@ interface BConfig {
     @ConfigurationValue(path = "botcommands.core.ignoredEventIntents", type = "java.util.Set<java.lang.Class<net.dv8tion.jda.api.events.Event>>")
     val ignoredEventIntents: Set<Class<out Event>>
 
+    /**
+     * Suppresses warnings about the default [RestRateLimiter] being used for large bots.
+     *
+     * Default: `false`
+     *
+     * Spring property: `botcommands.core.ignoreRestRateLimiter`
+     *
+     * @see PriorityGlobalRestRateLimiter
+     */
+    @ConfigurationValue("botcommands.core.ignoreRestRateLimiter")
+    val ignoreRestRateLimiter: Boolean
+
     val classGraphProcessors: List<ClassGraphProcessor>
 
     @Suppress("DEPRECATION")
@@ -160,6 +174,8 @@ class BConfigBuilder internal constructor() : BConfig {
     override val ignoredIntents: MutableSet<GatewayIntent> = enumSetOf()
 
     override val ignoredEventIntents: MutableSet<Class<out Event>> = hashSetOf()
+
+    override var ignoreRestRateLimiter: Boolean = false
 
     override val classGraphProcessors: MutableList<ClassGraphProcessor> = arrayListOf()
 
@@ -335,6 +351,7 @@ class BConfigBuilder internal constructor() : BConfig {
             override val disableExceptionsInDMs = this@BConfigBuilder.disableExceptionsInDMs
             override val ignoredIntents = this@BConfigBuilder.ignoredIntents.toImmutableSet()
             override val ignoredEventIntents = this@BConfigBuilder.ignoredEventIntents.toImmutableSet()
+            override val ignoreRestRateLimiter = this@BConfigBuilder.ignoreRestRateLimiter
             override val classGraphProcessors = this@BConfigBuilder.classGraphProcessors.toImmutableList()
             override val debugConfig = this@BConfigBuilder.debugConfig.build()
             override val serviceConfig = this@BConfigBuilder.serviceConfig.build()

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/requests/PriorityGlobalRestRateLimiter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/requests/PriorityGlobalRestRateLimiter.kt
@@ -1,0 +1,121 @@
+package io.github.freya022.botcommands.api.core.requests
+
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import io.github.freya022.botcommands.api.core.errorNull
+import io.github.oshai.kotlinlogging.KotlinLogging
+import net.dv8tion.jda.api.requests.RestRateLimiter
+import net.dv8tion.jda.api.requests.Route
+import net.dv8tion.jda.api.sharding.DefaultShardManagerBuilder
+import java.util.PriorityQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.thread
+import kotlin.concurrent.withLock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+private val logger = KotlinLogging.logger { }
+
+/**
+ * An implementation of [RestRateLimiter] which handles the global rate limit (50/s),
+ * and in which low-priority requests are queued last to the [delegate] (such as application command updates).
+ *
+ * While JDA already reads the global rate limit headers, it does not prevent doing 50+ requests on different buckets.
+ * For example, when updating commands on 50+ guilds, JDA would launch all requests in parallel,
+ * as each guild has its own bucket, resulting in a hefty rate limit.
+ *
+ * When using this, guild commands will be updated as fast as possible, otherwise, it will be slowed down.
+ *
+ * **It is highly recommended using this (or your own implementation) with large bots.**
+ *
+ * ### Usage
+ *
+ * You will need to configure the RestConfig on your [DefaultShardManagerBuilder][DefaultShardManagerBuilder.setRestConfig].
+ *
+ * **Example:**
+ * ```kt
+ * val restConfig = RestConfig()
+ *     .setRateLimiterFactory { rlConfig: RateLimitConfig ->
+ *         PriorityGlobalRestRateLimiter(SequentialRestRateLimiter(rlConfig))
+ *     }
+ * setRestConfig(restConfig)
+ * ```
+ */
+class PriorityGlobalRestRateLimiter(private val delegate: RestRateLimiter) : RestRateLimiter {
+    private class PriorityWork(val task: RestRateLimiter.Work) : Comparable<PriorityWork> {
+        override fun compareTo(other: PriorityWork): Int {
+            return task.priority.compareTo(other.task.priority)
+        }
+
+        // Natural order
+        // * Note: this can technically go in an IdentityHashMap as the routes are constants
+        private val RestRateLimiter.Work.priority: Int get() = when (this.route.baseRoute) {
+            // Do command updates last
+            Route.Interactions.UPDATE_COMMANDS -> 1
+            Route.Interactions.UPDATE_GUILD_COMMANDS -> 2
+            else -> 0
+        }
+    }
+
+    // 50/s
+    private val bucket = Bucket.builder()
+        .addLimit(
+            Bandwidth.builder()
+                .capacity(50)
+                .refillIntervally(50, 1.seconds.toJavaDuration())
+                .build()
+        )
+        .build()
+        .asScheduler()
+    private val rateLimitScheduler = Executors.newSingleThreadScheduledExecutor {
+        thread(name = "Global RateLimiter", start = false) {}
+    }
+
+    private val lock = ReentrantLock()
+    private val queue = PriorityQueue<PriorityWork>()
+
+    // Queue the task in a PriorityQueue, so we can give the most important tasks first to the delegate
+    override fun enqueue(task: RestRateLimiter.Work): Unit = lock.withLock {
+        if (isStopped) return
+
+        queue.offer(PriorityWork(task))
+        bucket.consume(1, rateLimitScheduler).thenApply {
+            val priorityTask = pollWorkQueue(submittedTask = task) ?: return@thenApply
+            delegate.enqueue(priorityTask)
+        }
+    }
+
+    private fun pollWorkQueue(submittedTask: RestRateLimiter.Work): RestRateLimiter.Work? {
+        return queue.poll()?.task ?: return logger.errorNull {
+            """
+                Queue is empty! Task that may or may not have been processed earlier:
+                Route: ${submittedTask.route}
+                Is done: ${submittedTask.isDone}
+                Is skipped: ${submittedTask.isSkipped}
+                Is cancelled: ${submittedTask.isCancelled}
+            """
+        }
+    }
+
+    override fun stop(shutdown: Boolean, callback: Runnable) = lock.withLock {
+        if (shutdown) {
+            rateLimitScheduler.shutdownNow()
+        } else {
+            rateLimitScheduler.shutdown()
+        }
+        delegate.stop(shutdown, callback)
+    }
+
+    override fun isStopped(): Boolean {
+        return rateLimitScheduler.isShutdown
+    }
+
+    override fun cancelRequests(): Int = lock.withLock {
+        val toBeCancelled = queue.filter { !it.task.isPriority && !it.task.isCancelled }
+        queue.removeAll(toBeCancelled)
+        toBeCancelled.forEach { it.task.cancel() }
+
+        return delegate.cancelRequests()
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsBuilder.kt
@@ -73,7 +73,7 @@ internal class ApplicationCommandsBuilder(
     // Added to set when the first push succeeded
     internal fun hasPushedGuildOnceSuccessfully(guild: Guild): Boolean = guild.idLong !in firstGuildUpdates
 
-    @BEventListener
+    @BEventListener(async = true)
     internal suspend fun onInjectedJDA(event: InjectedJDAEvent) {
         try {
             updateCatching(null) { updateGlobalCommands() }
@@ -82,7 +82,7 @@ internal class ApplicationCommandsBuilder(
         }
     }
 
-    @BEventListener
+    @BEventListener(async = true)
     internal suspend fun onGuildReady(event: GuildReadyEvent) {
         val guild = event.guild
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsBuilder.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.sync.withLock
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.events.guild.GuildReadyEvent
 import java.util.concurrent.Executors
+import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -49,7 +50,9 @@ internal class ApplicationCommandsBuilder(
     private val guildUpdateMutexMap: MutableMap<Long, Mutex> = hashMapOf()
 
     // Whatever, there will be no code running on it at all, apart from resuming the coroutine
-    private val updateRateLimitScheduler = Executors.newSingleThreadScheduledExecutor()
+    private val updateRateLimitScheduler = Executors.newSingleThreadScheduledExecutor {
+        thread(name = "Command update RateLimiter", start = false, isDaemon = true) {}
+    }
     // 10/s
     private val updateBucket = Bucket.builder()
         .addLimit(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsBuilder.kt
@@ -148,6 +148,12 @@ internal class ApplicationCommandsBuilder(
         guildUpdateGlobalMutex.withLock {
             guildUpdateMutexMap.computeIfAbsent(guild.idLong) { Mutex() }
         }.withLock {
+            // In case the bot left the guild before a lock was acquired
+            if (guild.jda.getGuildById(guild.idLong) == null) {
+                logger.trace { "Skipping application commands update in ${guild.name} (${guild.id}) as the bot no longer is in it" }
+                return CommandUpdateResult(guild, false, listOf())
+            }
+
             val failedDeclarations: MutableList<CommandUpdateException> = arrayListOf()
 
             val manager = GuildApplicationCommandManager(context, guild)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsUpdateRateLimiter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsUpdateRateLimiter.kt
@@ -1,0 +1,61 @@
+package io.github.freya022.botcommands.internal.commands.application
+
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.core.service.annotations.Lazy
+import kotlinx.coroutines.future.await
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.requests.SequentialRestRateLimiter
+import net.dv8tion.jda.internal.JDAImpl
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.Executors
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+internal interface ApplicationCommandsUpdateRateLimiter {
+    suspend fun awaitToken()
+}
+
+private object NullApplicationCommandsUpdateRateLimiter : ApplicationCommandsUpdateRateLimiter {
+    override suspend fun awaitToken() {}
+}
+
+private class DefaultApplicationCommandsUpdateRateLimiter : ApplicationCommandsUpdateRateLimiter {
+    // Whatever, there will be no code running on it at all, apart from resuming the coroutine
+    private val updateRateLimitScheduler = Executors.newSingleThreadScheduledExecutor {
+        thread(name = "Command update RateLimiter", start = false, isDaemon = true) {}
+    }
+    // 20/s
+    private val updateBucket = Bucket.builder()
+        .addLimit(
+            Bandwidth.builder()
+                .capacity(20)
+                .refillIntervally(20, 1.seconds.toJavaDuration())
+                .build()
+        )
+        .build()
+        .asScheduler()
+
+    override suspend fun awaitToken() {
+        updateBucket.consume(1, updateRateLimitScheduler).await()
+    }
+}
+
+@BService
+@Configuration
+internal open class ApplicationCommandsUpdateRateLimiterProvider {
+    @Lazy
+    @Bean
+    @BService
+    open fun applicationCommandsUpdateRateLimiter(jda: JDA): ApplicationCommandsUpdateRateLimiter {
+        if (jda !is JDAImpl) return NullApplicationCommandsUpdateRateLimiter
+
+        return when (jda.requester.rateLimiter) {
+            is SequentialRestRateLimiter -> DefaultApplicationCommandsUpdateRateLimiter()
+            else -> NullApplicationCommandsUpdateRateLimiter
+        }
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsUpdateRateLimiter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsUpdateRateLimiter.kt
@@ -19,6 +19,11 @@ internal interface ApplicationCommandsUpdateRateLimiter {
     suspend fun awaitToken()
 }
 
+internal suspend inline fun <R> ApplicationCommandsUpdateRateLimiter.withToken(block: () -> R): R {
+    awaitToken()
+    return block()
+}
+
 private object NullApplicationCommandsUpdateRateLimiter : ApplicationCommandsUpdateRateLimiter {
     override suspend fun awaitToken() {}
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationUpdaterListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationUpdaterListener.kt
@@ -16,13 +16,13 @@ internal class ApplicationUpdaterListener(private val applicationCommandsBuilder
 
     private val failedGuilds: MutableSet<Long> = Collections.synchronizedSet(hashSetOf())
 
-    @BEventListener
+    @BEventListener(async = true)
     suspend fun onGuildAvailable(event: GuildAvailableEvent) {
         logger.trace { "Trying to force update commands due to an unavailable guild becoming available" }
         tryUpdate(event.guild, force = true)
     }
 
-    @BEventListener
+    @BEventListener(async = true)
     suspend fun onGuildJoin(event: GuildJoinEvent) {
         logger.trace { "Trying to force update commands due to a joined guild" }
         tryUpdate(event.guild, force = true)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/JDARestLimiterChecker.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/JDARestLimiterChecker.kt
@@ -1,0 +1,34 @@
+package io.github.freya022.botcommands.internal.core
+
+import io.github.freya022.botcommands.api.core.annotations.BEventListener
+import io.github.freya022.botcommands.api.core.config.BConfig
+import io.github.freya022.botcommands.api.core.config.BConfigBuilder
+import io.github.freya022.botcommands.api.core.events.InjectedJDAEvent
+import io.github.freya022.botcommands.api.core.requests.PriorityGlobalRestRateLimiter
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.internal.utils.classRef
+import io.github.freya022.botcommands.internal.utils.reference
+import io.github.oshai.kotlinlogging.KotlinLogging
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.requests.SequentialRestRateLimiter
+import net.dv8tion.jda.internal.JDAImpl
+
+private val logger = KotlinLogging.logger { }
+
+@BService
+internal class JDARestLimiterChecker(private val config: BConfig) {
+
+    @BEventListener
+    fun onJDA(event: InjectedJDAEvent) {
+        if (config.ignoreRestRateLimiter) return
+        if (User.UserFlag.VERIFIED_BOT !in event.jda.selfUser.flags) return
+
+        val jda = event.jda as? JDAImpl ?: return
+        if (jda.requester.rateLimiter is SequentialRestRateLimiter) {
+            logger.warn {
+                "The default REST rate limiter is not recommended for verified bots, I recommend using ${classRef<PriorityGlobalRestRateLimiter>()} or your own implementation. " +
+                        "You can also disable this message using ${BConfigBuilder::ignoreRestRateLimiter.reference}"
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
@@ -27,6 +27,7 @@ internal class BotCommandsCoreConfiguration(
     internal val _disableAutocompleteCache: Boolean? = null,
     override val ignoredIntents: Set<GatewayIntent> = emptySet(),
     override val ignoredEventIntents: Set<Class<out Event>> = emptySet(),
+    override val ignoreRestRateLimiter: Boolean = false,
 ) : BConfig {
     override val classGraphProcessors: Nothing get() = unusable()
     override val debugConfig: Nothing get() = unusable()
@@ -50,6 +51,7 @@ internal fun BConfigBuilder.applyConfig(configuration: BotCommandsCoreConfigurat
     configuration._disableAutocompleteCache?.let { disableAutocompleteCache = it }
     ignoredIntents += configuration.ignoredIntents
     ignoredEventIntents += configuration.ignoredEventIntents
+    ignoreRestRateLimiter = configuration.ignoreRestRateLimiter
 }
 
 @ConfigurationProperties(prefix = "botcommands.database", ignoreUnknownFields = false)

--- a/src/test/kotlin/io/github/freya022/botcommands/test/services/Bot.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/services/Bot.kt
@@ -2,12 +2,16 @@ package io.github.freya022.botcommands.test.services
 
 import io.github.freya022.botcommands.api.core.JDAService
 import io.github.freya022.botcommands.api.core.events.BReadyEvent
+import io.github.freya022.botcommands.api.core.requests.PriorityGlobalRestRateLimiter
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.utils.enumSetOf
 import io.github.freya022.botcommands.test.config.Config
 import net.dv8tion.jda.api.entities.Activity
 import net.dv8tion.jda.api.hooks.IEventManager
 import net.dv8tion.jda.api.requests.GatewayIntent
+import net.dv8tion.jda.api.requests.RestConfig
+import net.dv8tion.jda.api.requests.RestRateLimiter.RateLimitConfig
+import net.dv8tion.jda.api.requests.SequentialRestRateLimiter
 import net.dv8tion.jda.api.sharding.DefaultShardManagerBuilder
 import net.dv8tion.jda.api.utils.MemberCachePolicy
 import net.dv8tion.jda.api.utils.cache.CacheFlag
@@ -40,6 +44,11 @@ class Bot(private val config: Config, environment: ConfigurableEnvironment?) : J
                 setShardsTotal(2)
                 setShards(0, 1)
             }
+            val restConfig = RestConfig()
+                .setRateLimiterFactory { rlConfig: RateLimitConfig ->
+                    PriorityGlobalRestRateLimiter(SequentialRestRateLimiter(rlConfig))
+                }
+            setRestConfig(restConfig)
         }.build()
     }
 }


### PR DESCRIPTION
### Changes
- If the default `RestRateLimiter` is used, application commands are pushed at a rate of 20 requests/s

### Additions
- Added `PriorityGlobalRestRateLimiter`
  - Enforces 50 requests/s
  - There may be a lot of command updates, so their requests have lower priority
  - Prevents CF bans on large bots as all requests are fired at once due to each request being on its own bucket
  - Use it on your `DefaultShardManagerBuilder`:
  ```kt
  val restConfig = RestConfig()
      .setRateLimiterFactory { rlConfig: RateLimitConfig ->
          PriorityGlobalRestRateLimiter(SequentialRestRateLimiter(rlConfig))
      }
  setRestConfig(restConfig)
  ```