### PR TITLE
Improve instance suppliers

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
@@ -3,10 +3,7 @@ package io.github.freya022.botcommands.api.core.config
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.core.annotations.Handler
 import io.github.freya022.botcommands.api.core.service.InstanceSupplier
-import io.github.freya022.botcommands.api.core.service.annotations.BService
-import io.github.freya022.botcommands.api.core.service.annotations.InjectedService
-import io.github.freya022.botcommands.api.core.service.annotations.Resolver
-import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
+import io.github.freya022.botcommands.api.core.service.annotations.*
 import io.github.freya022.botcommands.api.core.utils.toImmutableMap
 import io.github.freya022.botcommands.api.core.utils.toImmutableSet
 import io.github.freya022.botcommands.api.core.utils.unmodifiableView
@@ -41,8 +38,14 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
      * Registers a supplier lazily returning an instance of the specified class,
      * the instance is then made available via dependency injection.
      *
+     * The class it is **registered as** ([T]) is searched for the usual annotations
+     * such as [@Primary][Primary], [@InterfacedService][InterfacedService] and [@Lazy][Lazy].
+     *
      * **Note:** The class still needs to be in the search path,
      * either using [BConfigBuilder.addSearchPath] or [BConfigBuilder.addClass].
+     *
+     * @param clazz            The primary type as which the service is registered as, other types may be registered with the usual annotations
+     * @param instanceSupplier Supplier for the service instance, ran at startup, unless [clazz] is annotated with [@Lazy][Lazy]
      */
     fun <T : Any> registerInstanceSupplier(clazz: Class<T>, instanceSupplier: InstanceSupplier<T>) {
         _instanceSupplierMap[clazz.kotlin] = instanceSupplier
@@ -61,8 +64,14 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
  * Registers a supplier lazily returning an instance of the specified class,
  * the instance is then made available via dependency injection.
  *
+ * The class it is **registered as** ([T]) is searched for the usual annotations
+ * such as [@Primary][Primary], [@InterfacedService][InterfacedService] and [@Lazy][Lazy].
+ *
  * **Note:** The class still needs to be in the search path,
  * either using [BConfigBuilder.addSearchPath] or [BConfigBuilder.addClass].
+ *
+ * @param T                The primary type as which the service is registered as, other types may be registered with the usual annotations
+ * @param instanceSupplier Supplier for the service instance, ran at startup, unless [T] is annotated with [@Lazy][Lazy]
  */
 inline fun <reified T : Any> BServiceConfigBuilder.registerInstanceSupplier(instanceSupplier: InstanceSupplier<T>) {
     return registerInstanceSupplier(T::class.java, instanceSupplier)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
@@ -56,3 +56,14 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
         override val instanceSupplierMap = this@BServiceConfigBuilder.instanceSupplierMap.toImmutableMap()
     }
 }
+
+/**
+ * Registers a supplier lazily returning an instance of the specified class,
+ * the instance is then made available via dependency injection.
+ *
+ * **Note:** The class still needs to be in the search path,
+ * either using [BConfigBuilder.addSearchPath] or [BConfigBuilder.addClass].
+ */
+inline fun <reified T : Any> BServiceConfigBuilder.registerInstanceSupplier(instanceSupplier: InstanceSupplier<T>) {
+    return registerInstanceSupplier(T::class.java, instanceSupplier)
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
@@ -38,12 +38,11 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
     override val instanceSupplierMap: Map<KClass<*>, InstanceSupplier<*>> = _instanceSupplierMap.unmodifiableView()
 
     /**
-     * Registers a supplier returning an instance of the specified class.
+     * Registers a supplier lazily returning an instance of the specified class,
+     * the instance is then made available via dependency injection.
      *
-     * The specified class still needs to be annotated with a compatible service annotation.
-     *
-     * The difference is that instead of using the constructor of the class,
-     * the provided instance supplier is used.
+     * **Note:** The class still needs to be in the search path,
+     * either using [BConfigBuilder.addSearchPath] or [BConfigBuilder.addClass].
      */
     fun <T : Any> registerInstanceSupplier(clazz: Class<T>, instanceSupplier: InstanceSupplier<T>) {
         _instanceSupplierMap[clazz.kotlin] = instanceSupplier

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/service/InstanceSupplier.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/service/InstanceSupplier.kt
@@ -10,6 +10,6 @@ import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder
  *
  * @see BServiceConfigBuilder.registerInstanceSupplier
  */
-interface InstanceSupplier<T> {
+fun interface InstanceSupplier<T : Any> {
     fun supply(context: BContext): T
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/DefaultBotCommandsBootstrap.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/DefaultBotCommandsBootstrap.kt
@@ -19,7 +19,7 @@ internal class DefaultBotCommandsBootstrap internal constructor(
 ) : AbstractBotCommandsBootstrap(config) {
     internal val serviceConfig: BServiceConfig get() = config.serviceConfig
 
-    internal val serviceProviders = ServiceProviders()
+    internal val serviceProviders = ServiceProviders(serviceConfig)
     override val serviceContainer = DefaultServiceContainerImpl(this)
     override val classGraphProcessors: Set<ClassGraphProcessor> =
         setOf(ConditionalObjectChecker, serviceProviders)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ClassServiceProvider.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ClassServiceProvider.kt
@@ -1,17 +1,17 @@
 package io.github.freya022.botcommands.internal.core.service.provider
 
-import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.core.service.*
+import io.github.freya022.botcommands.api.core.service.DynamicSupplier
 import io.github.freya022.botcommands.api.core.service.DynamicSupplier.Instantiability.InstantiabilityType
+import io.github.freya022.botcommands.api.core.service.ServiceError
 import io.github.freya022.botcommands.api.core.service.ServiceError.ErrorType
+import io.github.freya022.botcommands.api.core.service.ServiceResult
 import io.github.freya022.botcommands.api.core.service.annotations.Lazy
 import io.github.freya022.botcommands.api.core.service.annotations.Primary
+import io.github.freya022.botcommands.api.core.service.getInterfacedServices
 import io.github.freya022.botcommands.api.core.utils.getAllAnnotations
 import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
-import io.github.freya022.botcommands.internal.core.exceptions.ServiceException
 import io.github.freya022.botcommands.internal.core.service.DefaultServiceContainerImpl
-import io.github.freya022.botcommands.internal.utils.ReflectionUtils.resolveBestReference
 import io.github.freya022.botcommands.internal.utils.isObject
 import io.github.freya022.botcommands.internal.utils.shortSignature
 import io.github.freya022.botcommands.internal.utils.throwInternal
@@ -135,22 +135,6 @@ internal class ClassServiceProvider internal constructor(
 
                 //Found a supplier, return instance
                 InstantiabilityType.INSTANTIABLE -> return measureTimedInstantiation { dynamicSupplier.get(clazz, name) }
-            }
-        }
-
-        //The command object has to be created either by the instance supplier
-        // or by the **only** constructor a class has
-        // It must resolve all parameter types with the registered parameter suppliers
-        val instanceSupplier = serviceContainer.serviceConfig.instanceSupplierMap[clazz]
-        if (instanceSupplier != null) {
-            return measureTimedInstantiation {
-                instanceSupplier.supply(serviceContainer.getService<BContext>())
-                    ?: throw ServiceException(
-                        ErrorType.PROVIDER_RETURNED_NULL.toError(
-                            errorMessage = "Supplier function in class '${instanceSupplier.javaClass.simpleNestedName}' returned null",
-                            failedFunction = instanceSupplier::supply.resolveBestReference()
-                        )
-                    )
             }
         }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/SuppliedServiceProvider.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/SuppliedServiceProvider.kt
@@ -1,0 +1,56 @@
+package io.github.freya022.botcommands.internal.core.service.provider
+
+import io.github.freya022.botcommands.api.core.service.InstanceSupplier
+import io.github.freya022.botcommands.api.core.service.ServiceError
+import io.github.freya022.botcommands.api.core.service.annotations.Lazy
+import io.github.freya022.botcommands.api.core.service.annotations.Primary
+import io.github.freya022.botcommands.api.core.service.getService
+import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
+import io.github.freya022.botcommands.internal.core.service.DefaultServiceContainerImpl
+import io.github.freya022.botcommands.internal.utils.throwInternal
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.jvm.jvmName
+
+internal class SuppliedServiceProvider internal constructor(
+    private val clazz: KClass<*>,
+    private val supplier: InstanceSupplier<*>
+) : ServiceProvider {
+    override var instance: Any? = null
+
+    override val annotations = clazz.annotations
+    override val name = getServiceName(clazz)
+    override val providerKey = clazz.jvmName
+    override val primaryType get() = clazz
+    override val types = getServiceTypes(primaryType)
+    override val isPrimary = hasAnnotation<Primary>()
+    override val isLazy = hasAnnotation<Lazy>()
+    override val priority = getAnnotatedServicePriority()
+
+    override fun canInstantiate(serviceContainer: DefaultServiceContainerImpl): ServiceError? {
+        return null
+    }
+
+    override fun createInstance(serviceContainer: DefaultServiceContainerImpl): TimedInstantiation<*> {
+        if (instance != null)
+            throwInternal("Tried to create an instance of ${clazz.jvmName} when one already exists, instance should be retrieved manually beforehand")
+
+        val timedInstantiation = createInstanceNonCached(serviceContainer)
+        instance = timedInstantiation.instance
+        return timedInstantiation
+    }
+
+    private fun createInstanceNonCached(serviceContainer: DefaultServiceContainerImpl): TimedInstantiation<*> {
+        return measureTimedInstantiation {
+            supplier.supply(serviceContainer.getService())
+        }
+    }
+
+    override fun getProviderFunction(): KFunction<*>? = null
+
+    override fun getProviderSignature(): String = "<supplied ${clazz.shortQualifiedName}>"
+
+    override fun toString(): String {
+        return "SuppliedServiceProvider(supplier=$supplier, clazz=$clazz, instance=$instance)"
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ReflectionMetadata.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ReflectionMetadata.kt
@@ -260,6 +260,12 @@ internal object ReflectionMetadata {
         }
     }
 
+    internal val Class<*>.hasMetadata: Boolean
+        get() = this in classMetadataMap
+
+    internal val KClass<*>.hasMetadata: Boolean
+        inline get() = java.hasMetadata
+
     internal val Class<*>.sourceFile: String
         get() = (classMetadataMap[this]
             ?: throwArgument("Tried to access a Method which hasn't been scanned: $this, the method must be accessible and in the search path")).sourceFile


### PR DESCRIPTION
### Changes
- Added missing `Any` bound on `T` of `InstanceSupplier`
- Made `InstanceSupplier` a functional interface
- The class being supplied no longer requires being annotated with a service annotation
  - You can still put annotations, they will be taken into account for the resulting service

### Additions
- Added a reified overload of `BServiceConfigBuilder.registerInstanceSupplier`