### PR TITLE
Fix assignation of command metadata for commands with the same name but different type

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/TopLevelApplicationCommandMetadata.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/TopLevelApplicationCommandMetadata.kt
@@ -1,12 +1,18 @@
 package io.github.freya022.botcommands.api.commands.application
 
 import io.github.freya022.botcommands.api.commands.application.slash.TopLevelSlashCommandInfo
+import net.dv8tion.jda.api.interactions.commands.Command
 import java.time.OffsetDateTime
 
 /**
  * Discord's metadata about an application command.
  */
 interface TopLevelApplicationCommandMetadata {
+    /**
+     * The type of this application command.
+     */
+    val type: Command.Type
+
     /**
      * The version of this application command,
      * this is a snowflake that contains the time at which the command was created/updated.

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsBuilder.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsBuilder.kt
@@ -159,7 +159,7 @@ internal class ApplicationCommandsBuilder(
 
     private fun setMetadata(updater: ApplicationCommandsUpdater) {
         updater.metadata.forEach { metadata ->
-            val command = updater.applicationCommands.find { it.name == metadata.name }
+            val command = updater.applicationCommands.find { it.type == metadata.type && it.name == metadata.name }
                 ?: throwInternal("Could not match JDA command '${metadata.name}'")
 
             val accessor = command as? TopLevelApplicationCommandInfoMixin

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsUpdater.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandsUpdater.kt
@@ -132,6 +132,7 @@ internal class ApplicationCommandsUpdater private constructor(
         block()
         false
     } catch (e: ParsingException) {
+        logger.debug(e) { "Considering commands to be outdated because of an error during deserialization" }
         true
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/TopLevelApplicationCommandMetadataImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/TopLevelApplicationCommandMetadataImpl.kt
@@ -1,13 +1,16 @@
 package io.github.freya022.botcommands.internal.commands.application
 
 import io.github.freya022.botcommands.api.commands.application.TopLevelApplicationCommandMetadata
+import io.github.freya022.botcommands.internal.core.exceptions.internalErrorMessage
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.exceptions.ParsingException
 import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.utils.TimeUtil
 import net.dv8tion.jda.api.utils.data.DataObject
 import java.time.OffsetDateTime
 
 internal class TopLevelApplicationCommandMetadataImpl private constructor(
+    override val type: Command.Type,
     internal val name: String, // For matching purposes
     override val version: Long,
     override val id: Long,
@@ -16,6 +19,7 @@ internal class TopLevelApplicationCommandMetadataImpl private constructor(
     override val timeModified: OffsetDateTime get() = TimeUtil.getTimeCreated(version)
 
     internal fun toData(): DataObject = DataObject.empty()
+        .put("type", type.name)
         .put("name", name)
         .put("version", version)
         .put("id", id)
@@ -23,15 +27,19 @@ internal class TopLevelApplicationCommandMetadataImpl private constructor(
 
     internal companion object {
         internal fun fromCommand(guild: Guild?, command: Command) =
-            TopLevelApplicationCommandMetadataImpl(command.name, command.version, command.idLong, guild?.idLong)
+            TopLevelApplicationCommandMetadataImpl(command.type, command.name, command.version, command.idLong, guild?.idLong)
 
         internal fun fromData(obj: DataObject): TopLevelApplicationCommandMetadataImpl {
+            val type = obj.getString("type").let(Command.Type::valueOf)
+            if (type == Command.Type.UNKNOWN)
+                throw ParsingException(internalErrorMessage("Serialized interaction metadata should not include unknown command types, as they should have been filtered by the updater"))
+
             val name = obj.getString("name")
             val version = obj.getLong("version")
             val id = obj.getLong("id")
             val guildId = if (obj.isNull("guild_id")) null else obj.getLong("guild_id")
 
-            return TopLevelApplicationCommandMetadataImpl(name, version, id, guildId)
+            return TopLevelApplicationCommandMetadataImpl(type, name, version, id, guildId)
         }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfoImpl.kt
@@ -21,6 +21,7 @@ import io.github.freya022.botcommands.internal.options.transform
 import io.github.freya022.botcommands.internal.parameters.CustomMethodOption
 import io.github.freya022.botcommands.internal.parameters.ServiceMethodOption
 import io.github.freya022.botcommands.internal.utils.*
+import net.dv8tion.jda.api.interactions.commands.Command
 import kotlin.reflect.full.callSuspendBy
 
 internal class MessageCommandInfoImpl internal constructor(
@@ -36,6 +37,7 @@ internal class MessageCommandInfoImpl internal constructor(
     override val parentInstance get() = null
 
     override val scope: CommandScope = builder.scope
+    override val type: Command.Type get() = Command.Type.MESSAGE
     override val isDefaultLocked: Boolean = builder.isDefaultLocked
     override val isGuildOnly: Boolean = scope.isGuildOnly
     override val nsfw: Boolean = builder.nsfw

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfoImpl.kt
@@ -21,6 +21,7 @@ import io.github.freya022.botcommands.internal.options.transform
 import io.github.freya022.botcommands.internal.parameters.CustomMethodOption
 import io.github.freya022.botcommands.internal.parameters.ServiceMethodOption
 import io.github.freya022.botcommands.internal.utils.*
+import net.dv8tion.jda.api.interactions.commands.Command
 import kotlin.reflect.full.callSuspendBy
 
 internal class UserCommandInfoImpl internal constructor(
@@ -36,6 +37,7 @@ internal class UserCommandInfoImpl internal constructor(
     override val parentInstance get() = null
 
     override val scope: CommandScope = builder.scope
+    override val type: Command.Type get() = Command.Type.USER
     override val isDefaultLocked: Boolean = builder.isDefaultLocked
     override val isGuildOnly: Boolean = scope.isGuildOnly
     override val nsfw: Boolean = builder.nsfw

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/TopLevelSlashCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/TopLevelSlashCommandInfoImpl.kt
@@ -7,6 +7,7 @@ import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.utils.unmodifiableView
 import io.github.freya022.botcommands.internal.commands.application.mixins.TopLevelApplicationCommandInfoMixin
 import io.github.freya022.botcommands.internal.commands.application.slash.builder.TopLevelSlashCommandBuilderImpl
+import net.dv8tion.jda.api.interactions.commands.Command
 
 internal class TopLevelSlashCommandInfoImpl internal constructor(
     context: BContext,
@@ -21,6 +22,7 @@ internal class TopLevelSlashCommandInfoImpl internal constructor(
     override lateinit var metadata: TopLevelApplicationCommandMetadata
 
     override val scope: CommandScope = builder.scope
+    override val type: Command.Type get() = Command.Type.SLASH
     override val isDefaultLocked: Boolean = builder.isDefaultLocked
     override val isGuildOnly: Boolean = scope.isGuildOnly
     override val nsfw: Boolean = builder.nsfw


### PR DESCRIPTION
Could occur if an user interaction command and a message interaction command shared the same name