### PR TITLE
Pull up and add a few members of the command introspection API

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/ICommandParameterContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/ICommandParameterContainer.kt
@@ -1,23 +1,10 @@
 package io.github.freya022.botcommands.api.commands
 
 import io.github.freya022.botcommands.api.core.Executable
-import io.github.freya022.botcommands.api.core.options.Option
-import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 
 /**
  * Holds parameters of commands.
  */
 interface ICommandParameterContainer : Executable {
-    /**
-     * Returns the aggregated parameter with the supplied *declared name* (i.e., name of the method parameter),
-     * or `null` if not found.
-     */
-    fun getParameter(declaredName: String): AggregatedParameter?
 
-    /**
-     * Returns the option with the supplied *declared name* (i.e., name of the method parameter),
-     * or `null` if not found.
-     */
-    fun getOptionByDeclaredName(name: String): Option? =
-        parameters.flatMap { it.allOptions }.find { it.declaredName == name }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandInfo.kt
@@ -25,6 +25,7 @@ interface ApplicationCommandInfo : CommandInfo, Executable,
 
     override val discordOptions: List<ApplicationCommandOption>
 
+    @Deprecated("For removal, confusing on whether it searches nested parameters, prefer using collection operations on 'parameters' instead, make an extension or an utility method")
     override fun getParameter(declaredName: String): ApplicationCommandParameter?
 
     /**

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommandInfo.kt
@@ -1,6 +1,8 @@
 package io.github.freya022.botcommands.api.commands.application
 
 import io.github.freya022.botcommands.api.commands.*
+import io.github.freya022.botcommands.api.commands.application.options.ApplicationCommandOption
+import io.github.freya022.botcommands.api.commands.application.options.ApplicationCommandParameter
 import io.github.freya022.botcommands.api.commands.application.slash.SlashSubcommandGroupInfo
 import io.github.freya022.botcommands.api.commands.application.slash.SlashSubcommandInfo
 import io.github.freya022.botcommands.api.commands.application.slash.TopLevelSlashCommandInfo
@@ -18,6 +20,12 @@ interface ApplicationCommandInfo : CommandInfo, Executable,
      * Retrieves the top-level command owning this application command.
      */
     val topLevelInstance: TopLevelApplicationCommandInfo
+
+    override val parameters: List<ApplicationCommandParameter>
+
+    override val discordOptions: List<ApplicationCommandOption>
+
+    override fun getParameter(declaredName: String): ApplicationCommandParameter?
 
     /**
      * Returns the full command name of this application command, separate with spaces.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/message/MessageCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/message/MessageCommandInfo.kt
@@ -16,6 +16,8 @@ interface MessageCommandInfo : TopLevelApplicationCommandInfo, ApplicationComman
     override val discordOptions: List<MessageContextCommandOption>
         get() = parameters.flatMap { it.allOptions }.filterIsInstance<MessageContextCommandOption>()
 
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("For removal, confusing on whether it searches nested parameters, prefer using collection operations on 'parameters' instead, make an extension or an utility method")
     override fun getParameter(declaredName: String): MessageContextCommandParameter? =
         parameters.find { it.name == declaredName }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/message/options/MessageContextCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/message/options/MessageContextCommandOption.kt
@@ -7,5 +7,8 @@ import io.github.freya022.botcommands.api.commands.application.context.options.C
  * Represents a Discord input option of a message context command.
  */
 interface MessageContextCommandOption : ContextCommandOption {
-    override val command: MessageCommandInfo
+
+    @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
+    override val command get() = executable
+    override val executable: MessageCommandInfo
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/message/options/MessageContextCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/message/options/MessageContextCommandOption.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.commands.application.context.message.options
 
-import io.github.freya022.botcommands.api.commands.application.context.message.MessageCommandInfo
 import io.github.freya022.botcommands.api.commands.application.context.options.ContextCommandOption
 
 /**
@@ -10,5 +9,6 @@ interface MessageContextCommandOption : ContextCommandOption {
 
     @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
     override val command get() = executable
-    override val executable: MessageCommandInfo
+    override val executable get() = parent.executable
+    override val parent: MessageContextCommandParameter
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/message/options/MessageContextCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/message/options/MessageContextCommandParameter.kt
@@ -10,5 +10,7 @@ import io.github.freya022.botcommands.api.commands.application.context.options.C
 interface MessageContextCommandParameter : ContextCommandParameter {
     override val nestedAggregatedParameters: List<MessageContextCommandParameter>
 
-    override val command: MessageCommandInfo
+    @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
+    override val command: MessageCommandInfo get() = executable
+    override val executable: MessageCommandInfo
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/user/UserCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/user/UserCommandInfo.kt
@@ -16,6 +16,8 @@ interface UserCommandInfo : TopLevelApplicationCommandInfo, ApplicationCommandIn
     override val discordOptions: List<UserContextCommandOption>
         get() = parameters.flatMap { it.allOptions }.filterIsInstance<UserContextCommandOption>()
 
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("For removal, confusing on whether it searches nested parameters, prefer using collection operations on 'parameters' instead, make an extension or an utility method")
     override fun getParameter(declaredName: String): UserContextCommandParameter? =
         parameters.find { it.name == declaredName }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/user/options/UserContextCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/user/options/UserContextCommandOption.kt
@@ -1,7 +1,6 @@
 package io.github.freya022.botcommands.api.commands.application.context.user.options
 
 import io.github.freya022.botcommands.api.commands.application.context.options.ContextCommandOption
-import io.github.freya022.botcommands.api.commands.application.context.user.UserCommandInfo
 
 /**
  * Represents a Discord input option of a user context command.
@@ -10,5 +9,6 @@ interface UserContextCommandOption : ContextCommandOption {
 
     @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
     override val command get() = executable
-    override val executable: UserCommandInfo
+    override val executable get() = parent.executable
+    override val parent: UserContextCommandParameter
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/user/options/UserContextCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/user/options/UserContextCommandOption.kt
@@ -7,5 +7,8 @@ import io.github.freya022.botcommands.api.commands.application.context.user.User
  * Represents a Discord input option of a user context command.
  */
 interface UserContextCommandOption : ContextCommandOption {
-    override val command: UserCommandInfo
+
+    @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
+    override val command get() = executable
+    override val executable: UserCommandInfo
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/user/options/UserContextCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/user/options/UserContextCommandParameter.kt
@@ -10,5 +10,7 @@ import io.github.freya022.botcommands.api.commands.application.context.user.User
 interface UserContextCommandParameter : ContextCommandParameter {
     override val nestedAggregatedParameters: List<UserContextCommandParameter>
 
-    override val command: UserCommandInfo
+    @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
+    override val command: UserCommandInfo get() = executable
+    override val executable: UserCommandInfo
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/options/ApplicationCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/options/ApplicationCommandOption.kt
@@ -7,5 +7,8 @@ import io.github.freya022.botcommands.api.commands.options.CommandOption
  * Represents a Discord input option of an application command.
  */
 interface ApplicationCommandOption : CommandOption {
-    override val command: ApplicationCommandInfo
+
+    @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
+    override val command get() = executable
+    override val executable: ApplicationCommandInfo
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/options/ApplicationCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/options/ApplicationCommandOption.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.commands.application.options
 
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommandInfo
 import io.github.freya022.botcommands.api.commands.options.CommandOption
 
 /**
@@ -10,5 +9,6 @@ interface ApplicationCommandOption : CommandOption {
 
     @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
     override val command get() = executable
-    override val executable: ApplicationCommandInfo
+    override val executable get() = parent.executable
+    override val parent: ApplicationCommandParameter
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/options/ApplicationCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/options/ApplicationCommandParameter.kt
@@ -10,5 +10,7 @@ import io.github.freya022.botcommands.api.commands.options.CommandParameter
 interface ApplicationCommandParameter : CommandParameter {
     override val nestedAggregatedParameters: List<ApplicationCommandParameter>
 
-    override val command: ApplicationCommandInfo
+    @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
+    override val command: ApplicationCommandInfo get() = executable
+    override val executable: ApplicationCommandInfo
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/SlashCommandInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/SlashCommandInfo.kt
@@ -29,6 +29,8 @@ interface SlashCommandInfo : ApplicationCommandInfo {
      */
     val asMention: String get() = "</$fullCommandName:${topLevelInstance.id}>"
 
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("For removal, confusing on whether it searches nested parameters, prefer using collection operations on 'parameters' instead, make an extension or an utility method")
     override fun getParameter(declaredName: String): SlashCommandParameter? =
         parameters.find { it.name == declaredName }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/SlashCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/SlashCommandOption.kt
@@ -3,7 +3,6 @@ package io.github.freya022.botcommands.api.commands.application.slash.options
 import io.github.freya022.botcommands.api.commands.application.LengthRange
 import io.github.freya022.botcommands.api.commands.application.ValueRange
 import io.github.freya022.botcommands.api.commands.application.options.ApplicationCommandOption
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.interactions.commands.OptionType
@@ -15,7 +14,8 @@ interface SlashCommandOption : ApplicationCommandOption {
 
     @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
     override val command get() = executable
-    override val executable: SlashCommandInfo
+    override val executable get() = parent.executable
+    override val parent: SlashCommandParameter
 
     /**
      * The name of this option as shown on Discord.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/SlashCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/SlashCommandOption.kt
@@ -12,7 +12,10 @@ import net.dv8tion.jda.api.interactions.commands.OptionType
  * Represents a Discord input option of a slash command.
  */
 interface SlashCommandOption : ApplicationCommandOption {
-    override val command: SlashCommandInfo
+
+    @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
+    override val command get() = executable
+    override val executable: SlashCommandInfo
 
     /**
      * The name of this option as shown on Discord.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/SlashCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/SlashCommandParameter.kt
@@ -10,5 +10,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 interface SlashCommandParameter : ApplicationCommandParameter {
     override val nestedAggregatedParameters: List<SlashCommandParameter>
 
-    override val command: SlashCommandInfo
+    @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
+    override val command: SlashCommandInfo get() = executable
+    override val executable: SlashCommandInfo
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/options/CommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/options/CommandOption.kt
@@ -16,5 +16,7 @@ interface CommandOption : Option {
     /**
      * The executable command this parameter is from.
      */
+    @Deprecated("Renamed to 'executable'", ReplaceWith("executable"))
     val command: Executable
+        get() = executable
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/options/CommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/options/CommandOption.kt
@@ -11,6 +11,6 @@ interface CommandOption : Option {
      * The executable command this parameter is from.
      */
     @Deprecated("Renamed to 'executable'", ReplaceWith("executable"))
-    val command: Executable
-        get() = executable
+    val command: Executable get() = executable
+    override val parent: CommandParameter
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/options/CommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/options/CommandOption.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.commands.options
 
-import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.api.core.options.Option
 
@@ -8,11 +7,6 @@ import io.github.freya022.botcommands.api.core.options.Option
  * Represents a Discord input of a command.
  */
 interface CommandOption : Option {
-    /**
-     * The main context.
-     */
-    val context: BContext
-
     /**
      * The executable command this parameter is from.
      */

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/options/CommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/options/CommandParameter.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.commands.options
 
-import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 
@@ -10,12 +9,9 @@ import io.github.freya022.botcommands.api.parameters.AggregatedParameter
  */
 interface CommandParameter : AggregatedParameter {
     /**
-     * The main context.
-     */
-    val context: BContext
-
-    /**
      * The executable command this parameter is from.
      */
+    @Deprecated("Renamed to 'executable'", ReplaceWith("executable"))
     val command: Executable
+        get() = executable
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandVariation.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandVariation.kt
@@ -6,7 +6,6 @@ import io.github.freya022.botcommands.api.commands.IFilterContainer
 import io.github.freya022.botcommands.api.commands.text.builder.TextCommandBuilder
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandParameter
-import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.api.core.IDeclarationSiteHolder
 
@@ -16,10 +15,6 @@ import io.github.freya022.botcommands.api.core.IDeclarationSiteHolder
 interface TextCommandVariation : Executable, IDeclarationSiteHolder,
                                  ICommandParameterContainer, ICommandOptionContainer,
                                  IFilterContainer {
-    /**
-     * The main context.
-     */
-    val context: BContext
 
     /**
      * The text command this variation is from,

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandVariation.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/TextCommandVariation.kt
@@ -62,6 +62,8 @@ interface TextCommandVariation : Executable, IDeclarationSiteHolder,
      */
     val completePattern: Regex?
 
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("For removal, confusing on whether it searches nested parameters, prefer using collection operations on 'parameters' instead, make an extension or an utility method")
     override fun getParameter(declaredName: String): TextCommandParameter? =
         parameters.find { it.name == declaredName }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/options/TextCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/options/TextCommandOption.kt
@@ -9,7 +9,10 @@ import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterReso
  * Represents a Discord input of a text command.
  */
 interface TextCommandOption : CommandOption {
-    override val command: TextCommandVariation
+
+    @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
+    override val command get() = executable
+    override val executable: TextCommandVariation
 
     /**
      * Name of the text command option,

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/options/TextCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/options/TextCommandOption.kt
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.api.commands.text.options
 
 import io.github.freya022.botcommands.api.commands.options.CommandOption
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver
 
 /**
@@ -12,7 +11,8 @@ interface TextCommandOption : CommandOption {
 
     @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
     override val command get() = executable
-    override val executable: TextCommandVariation
+    override val executable get() = parent.executable
+    override val parent: TextCommandParameter
 
     /**
      * Name of the text command option,

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/options/TextCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/options/TextCommandParameter.kt
@@ -10,5 +10,7 @@ import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 interface TextCommandParameter : CommandParameter {
     override val nestedAggregatedParameters: List<TextCommandParameter>
 
-    override val command: TextCommandVariation
+    @Deprecated("Renamed to 'executable'", replaceWith = ReplaceWith("executable"))
+    override val command: TextCommandVariation get() = executable
+    override val executable: TextCommandVariation
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
@@ -39,12 +39,17 @@ interface Executable {
      * Returns the aggregated parameter with the supplied *declared name* (i.e., name of the method parameter),
      * or `null` if not found.
      */
+    @Deprecated("For removal, confusing on whether it searches nested parameters, " +
+            "prefer using collection operations on 'parameters' instead, make an extension or an utility method")
     fun getParameter(declaredName: String): AggregatedParameter?
 
     /**
      * Returns the option with the supplied *declared name* (i.e., name of the method parameter),
      * or `null` if not found.
      */
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("For removal, there can be one or more options with the provided name, " +
+            "prefer using collection operations on 'allOptions' instead, make an extension or an utility method")
     fun getOptionByDeclaredName(name: String): Option? =
-        parameters.flatMap { it.allOptions }.find { it.declaredName == name }
+        allOptions.find { it.declaredName == name }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
@@ -9,6 +9,11 @@ import kotlin.reflect.KFunction
  */
 interface Executable {
     /**
+     * The main context.
+     */
+    val context: BContext
+
+    /**
      * The target function of this executable.
      *
      * This is strictly for introspection purposes, do not call this function manually.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
@@ -31,9 +31,18 @@ interface Executable {
 
     /**
      * All options from this executable, including from its [aggregates][parameters].
+     *
+     * These options have no specific order of appearance, use [allOptionsOrdered] instead.
      */
     val allOptions: List<Option>
         get() = parameters.flatMap { it.allOptions }
+
+    /**
+     * All options from this executable, including from its [aggregates][parameters],
+     * sorted by order of appearance in this function.
+     */
+    val allOptionsOrdered: List<Option>
+        get() = parameters.flatMap { it.allOptionsOrdered }
 
     /**
      * Returns the aggregated parameter with the supplied *declared name* (i.e., name of the method parameter),

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
@@ -23,6 +23,12 @@ interface Executable {
     val parameters: List<AggregatedParameter>
 
     /**
+     * All options from this executable, including from its [aggregates][parameters].
+     */
+    val allOptions: List<Option>
+        get() = parameters.flatMap { it.allOptions }
+
+    /**
      * Returns the aggregated parameter with the supplied *declared name* (i.e., name of the method parameter),
      * or `null` if not found.
      */

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.api.core
 
+import io.github.freya022.botcommands.api.core.options.Option
 import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import kotlin.reflect.KFunction
 
@@ -20,4 +21,17 @@ interface Executable {
      * @see AggregatedParameter
      */
     val parameters: List<AggregatedParameter>
+
+    /**
+     * Returns the aggregated parameter with the supplied *declared name* (i.e., name of the method parameter),
+     * or `null` if not found.
+     */
+    fun getParameter(declaredName: String): AggregatedParameter?
+
+    /**
+     * Returns the option with the supplied *declared name* (i.e., name of the method parameter),
+     * or `null` if not found.
+     */
+    fun getOptionByDeclaredName(name: String): Option? =
+        parameters.flatMap { it.allOptions }.find { it.declaredName == name }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
@@ -6,6 +6,8 @@ import kotlin.reflect.KFunction
 
 /**
  * Base class for any executable method (commands, components, modals...).
+ *
+ * This never represents an aggregator.
  */
 interface Executable {
     /**

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/options/Option.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/options/Option.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.api.core.options
 
+import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
@@ -8,6 +9,11 @@ import kotlin.reflect.KType
  * One of the actual values in an [aggregated parameter][AggregatedParameter].
  */
 interface Option {
+    /**
+     * The executable this option is from.
+     */
+    val executable: Executable
+
     /**
      * A parameter from either the command function, or from an aggregation function.
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/options/Option.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/options/Option.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.api.core.options
 
+import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import kotlin.reflect.KParameter
@@ -9,6 +10,12 @@ import kotlin.reflect.KType
  * One of the actual values in an [aggregated parameter][AggregatedParameter].
  */
 interface Option {
+    /**
+     * The main context.
+     */
+    val context: BContext
+        get() = executable.context
+
     /**
      * The executable this option is from.
      */

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/options/Option.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/options/Option.kt
@@ -13,13 +13,17 @@ interface Option {
     /**
      * The main context.
      */
-    val context: BContext
-        get() = executable.context
+    val context: BContext get() = parent.context
 
     /**
      * The executable this option is from.
      */
-    val executable: Executable
+    val executable: Executable get() = parent.executable
+
+    /**
+     * The aggregated parameter this option is from.
+     */
+    val parent: AggregatedParameter
 
     /**
      * A parameter from either the command function, or from an aggregation function.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/AggregatedParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/AggregatedParameter.kt
@@ -1,6 +1,7 @@
 package io.github.freya022.botcommands.api.parameters
 
 import io.github.freya022.botcommands.api.core.options.Option
+import io.github.freya022.botcommands.internal.utils.throwInternal
 
 /**
  * Parameter which has its value computed by an aggregation function, from one or more options.
@@ -25,9 +26,34 @@ interface AggregatedParameter : MethodParameter {
 
     /**
      * Options from this parameter and also [nested aggregated parameters][nestedAggregatedParameters].
+     *
+     * These options have no specific order of appearance, use [allOptionsOrdered] instead.
      */
     val allOptions: List<Option>
         get() = options + nestedAggregatedParameters.flatMap { it.allOptions }
+
+    /**
+     * Options from this parameter and also [nested aggregated parameters][nestedAggregatedParameters],
+     * sorted by order of appearance in this function.
+     */
+    val allOptionsOrdered: List<Option>
+        get() = buildList {
+            val sorted = (options + nestedAggregatedParameters).sortedBy {
+                when (it) {
+                    is Option -> it.index
+                    is AggregatedParameter -> it.index
+                    else -> throwInternal("Unhandled type ${it.javaClass.name}")
+                }
+            }
+
+            for (any in sorted) {
+                when (any) {
+                    is Option -> add(any)
+                    is AggregatedParameter -> addAll(any.allOptionsOrdered)
+                    else -> throwInternal("Unhandled type ${any.javaClass.name}")
+                }
+            }
+        }
 
     /**
      * Returns the option with the supplied *declared name* (i.e., name of the method parameter),

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/AggregatedParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/AggregatedParameter.kt
@@ -36,6 +36,8 @@ interface AggregatedParameter : MethodParameter {
      * This does not take into account [nested aggregations][nestedAggregatedParameters],
      * use [getNestedOptionByDeclaredName] instead.
      */
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("For removal, prefer using collection operations on 'options' instead, make an extension or an utility method")
     fun getOptionByDeclaredName(name: String): Option? =
         options.find { it.declaredName == name }
 
@@ -45,6 +47,9 @@ interface AggregatedParameter : MethodParameter {
      *
      * Takes into account [nested aggregations][nestedAggregatedParameters].
      */
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("For removal, there can be one or more options with the provided name, " +
+            "prefer using collection operations on 'allOptions' instead, make an extension or an utility method")
     fun getNestedOptionByDeclaredName(name: String): Option? =
         allOptions.find { it.declaredName == name }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/MethodParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/MethodParameter.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.api.parameters
 
+import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.Executable
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
@@ -10,6 +11,17 @@ import kotlin.reflect.KType
  * @see AggregatedParameter
  */
 interface MethodParameter {
+    /**
+     * The main context.
+     */
+    val context: BContext
+        get() = executable.context
+
+    /**
+     * The executable this parameter is from.
+     */
+    val executable: Executable
+
     /**
      * The parameter of the function.
      */

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandOptionImpl.kt
@@ -1,14 +1,17 @@
 package io.github.freya022.botcommands.internal.commands.application.context.message.options
 
 import io.github.freya022.botcommands.api.commands.application.context.message.options.MessageContextCommandOption
+import io.github.freya022.botcommands.api.commands.application.context.message.options.MessageContextCommandParameter
 import io.github.freya022.botcommands.api.parameters.resolvers.MessageContextParameterResolver
-import io.github.freya022.botcommands.internal.commands.application.context.message.MessageCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.context.message.options.builder.MessageCommandOptionBuilderImpl
 import io.github.freya022.botcommands.internal.commands.application.context.options.ContextCommandOptionImpl
 
 internal class MessageContextCommandOptionImpl internal constructor(
-    override val executable: MessageCommandInfoImpl,
+    override val parent: MessageContextCommandParameter,
     optionBuilder: MessageCommandOptionBuilderImpl,
     val resolver: MessageContextParameterResolver<*, *>
 ) : ContextCommandOptionImpl(optionBuilder),
-    MessageContextCommandOption
+    MessageContextCommandOption {
+
+    override val executable get() = parent.executable
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandOptionImpl.kt
@@ -9,7 +9,7 @@ import io.github.freya022.botcommands.internal.commands.application.context.opti
 
 internal class MessageContextCommandOptionImpl internal constructor(
     override val context: BContext,
-    override val command: MessageCommandInfoImpl,
+    override val executable: MessageCommandInfoImpl,
     optionBuilder: MessageCommandOptionBuilderImpl,
     val resolver: MessageContextParameterResolver<*, *>
 ) : ContextCommandOptionImpl(optionBuilder),

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandOptionImpl.kt
@@ -1,14 +1,12 @@
 package io.github.freya022.botcommands.internal.commands.application.context.message.options
 
 import io.github.freya022.botcommands.api.commands.application.context.message.options.MessageContextCommandOption
-import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.parameters.resolvers.MessageContextParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.context.message.MessageCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.context.message.options.builder.MessageCommandOptionBuilderImpl
 import io.github.freya022.botcommands.internal.commands.application.context.options.ContextCommandOptionImpl
 
 internal class MessageContextCommandOptionImpl internal constructor(
-    override val context: BContext,
     override val executable: MessageCommandInfoImpl,
     optionBuilder: MessageCommandOptionBuilderImpl,
     val resolver: MessageContextParameterResolver<*, *>

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandParameterImpl.kt
@@ -4,11 +4,9 @@ import io.github.freya022.botcommands.api.commands.application.ApplicationComman
 import io.github.freya022.botcommands.api.commands.application.context.message.GlobalMessageEvent
 import io.github.freya022.botcommands.api.commands.application.context.message.options.MessageContextCommandParameter
 import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.parameters.resolvers.MessageContextParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.context.message.MessageCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.context.message.builder.MessageCommandBuilderImpl
 import io.github.freya022.botcommands.internal.commands.application.context.message.options.builder.MessageCommandOptionAggregateBuilderImpl
-import io.github.freya022.botcommands.internal.commands.application.context.message.options.builder.MessageCommandOptionBuilderImpl
 import io.github.freya022.botcommands.internal.commands.application.context.options.ContextCommandParameterImpl
 import io.github.freya022.botcommands.internal.options.CommandOptions
 import io.github.freya022.botcommands.internal.options.transform
@@ -25,11 +23,10 @@ internal class MessageContextCommandParameterImpl internal constructor(
         MessageContextCommandParameterImpl(context, executable, builder, it as MessageCommandOptionAggregateBuilderImpl)
     }
 
-    override val options = CommandOptions.transform<MessageCommandOptionBuilderImpl, MessageContextParameterResolver<*, *>>(
-        context,
-        executable,
+    override val options = CommandOptions.transform(
+        this,
         ApplicationCommandResolverData(builder),
         optionAggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> MessageContextCommandOptionImpl(executable, optionBuilder, resolver) }
+        optionFinalizer = ::MessageContextCommandOptionImpl
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandParameterImpl.kt
@@ -30,6 +30,6 @@ internal class MessageContextCommandParameterImpl internal constructor(
         command,
         ApplicationCommandResolverData(builder),
         optionAggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> MessageContextCommandOptionImpl(context, command, optionBuilder, resolver) }
+        optionFinalizer = { optionBuilder, resolver -> MessageContextCommandOptionImpl(command, optionBuilder, resolver) }
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandParameterImpl.kt
@@ -27,6 +27,7 @@ internal class MessageContextCommandParameterImpl internal constructor(
 
     override val options = CommandOptions.transform<MessageCommandOptionBuilderImpl, MessageContextParameterResolver<*, *>>(
         context,
+        command,
         ApplicationCommandResolverData(builder),
         optionAggregateBuilder,
         optionFinalizer = { optionBuilder, resolver -> MessageContextCommandOptionImpl(context, command, optionBuilder, resolver) }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/options/MessageContextCommandParameterImpl.kt
@@ -14,22 +14,22 @@ import io.github.freya022.botcommands.internal.options.CommandOptions
 import io.github.freya022.botcommands.internal.options.transform
 
 internal class MessageContextCommandParameterImpl internal constructor(
-    override val context: BContext,
-    override val command: MessageCommandInfoImpl,
+    context: BContext,
+    override val executable: MessageCommandInfoImpl,
     builder: MessageCommandBuilderImpl,
     optionAggregateBuilder: MessageCommandOptionAggregateBuilderImpl
 ) : ContextCommandParameterImpl(context, optionAggregateBuilder, GlobalMessageEvent::class),
     MessageContextCommandParameter {
 
     override val nestedAggregatedParameters = optionAggregateBuilder.optionAggregateBuilders.transform {
-        MessageContextCommandParameterImpl(context, command, builder, it as MessageCommandOptionAggregateBuilderImpl)
+        MessageContextCommandParameterImpl(context, executable, builder, it as MessageCommandOptionAggregateBuilderImpl)
     }
 
     override val options = CommandOptions.transform<MessageCommandOptionBuilderImpl, MessageContextParameterResolver<*, *>>(
         context,
-        command,
+        executable,
         ApplicationCommandResolverData(builder),
         optionAggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> MessageContextCommandOptionImpl(command, optionBuilder, resolver) }
+        optionFinalizer = { optionBuilder, resolver -> MessageContextCommandOptionImpl(executable, optionBuilder, resolver) }
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandOptionImpl.kt
@@ -1,14 +1,12 @@
 package io.github.freya022.botcommands.internal.commands.application.context.user.options
 
 import io.github.freya022.botcommands.api.commands.application.context.user.options.UserContextCommandOption
-import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.parameters.resolvers.UserContextParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.context.options.ContextCommandOptionImpl
 import io.github.freya022.botcommands.internal.commands.application.context.user.UserCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.context.user.options.builder.UserCommandOptionBuilderImpl
 
 internal class UserContextCommandOptionImpl internal constructor(
-    override val context: BContext,
     override val executable: UserCommandInfoImpl,
     optionBuilder: UserCommandOptionBuilderImpl,
     val resolver: UserContextParameterResolver<*, *>

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandOptionImpl.kt
@@ -1,13 +1,13 @@
 package io.github.freya022.botcommands.internal.commands.application.context.user.options
 
 import io.github.freya022.botcommands.api.commands.application.context.user.options.UserContextCommandOption
+import io.github.freya022.botcommands.api.commands.application.context.user.options.UserContextCommandParameter
 import io.github.freya022.botcommands.api.parameters.resolvers.UserContextParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.context.options.ContextCommandOptionImpl
-import io.github.freya022.botcommands.internal.commands.application.context.user.UserCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.context.user.options.builder.UserCommandOptionBuilderImpl
 
 internal class UserContextCommandOptionImpl internal constructor(
-    override val executable: UserCommandInfoImpl,
+    override val parent: UserContextCommandParameter,
     optionBuilder: UserCommandOptionBuilderImpl,
     val resolver: UserContextParameterResolver<*, *>
 ) : ContextCommandOptionImpl(optionBuilder),

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandOptionImpl.kt
@@ -9,7 +9,7 @@ import io.github.freya022.botcommands.internal.commands.application.context.user
 
 internal class UserContextCommandOptionImpl internal constructor(
     override val context: BContext,
-    override val command: UserCommandInfoImpl,
+    override val executable: UserCommandInfoImpl,
     optionBuilder: UserCommandOptionBuilderImpl,
     val resolver: UserContextParameterResolver<*, *>
 ) : ContextCommandOptionImpl(optionBuilder),

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandParameterImpl.kt
@@ -27,6 +27,7 @@ internal class UserContextCommandParameterImpl internal constructor(
 
     override val options = CommandOptions.transform<UserCommandOptionBuilderImpl, UserContextParameterResolver<*, *>>(
         context,
+        command,
         ApplicationCommandResolverData(builder),
         optionAggregateBuilder,
         optionFinalizer = { optionBuilder, resolver -> UserContextCommandOptionImpl(context, command, optionBuilder, resolver) }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandParameterImpl.kt
@@ -14,22 +14,22 @@ import io.github.freya022.botcommands.internal.options.CommandOptions
 import io.github.freya022.botcommands.internal.options.transform
 
 internal class UserContextCommandParameterImpl internal constructor(
-    override val context: BContext,
-    override val command: UserCommandInfoImpl,
+    context: BContext,
+    override val executable: UserCommandInfoImpl,
     builder: UserCommandBuilderImpl,
     optionAggregateBuilder: UserCommandOptionAggregateBuilderImpl
 ) : ContextCommandParameterImpl(context, optionAggregateBuilder, GlobalUserEvent::class),
     UserContextCommandParameter {
 
     override val nestedAggregatedParameters = optionAggregateBuilder.optionAggregateBuilders.transform {
-        UserContextCommandParameterImpl(context, command, builder, it as UserCommandOptionAggregateBuilderImpl)
+        UserContextCommandParameterImpl(context, executable, builder, it as UserCommandOptionAggregateBuilderImpl)
     }
 
     override val options = CommandOptions.transform<UserCommandOptionBuilderImpl, UserContextParameterResolver<*, *>>(
         context,
-        command,
+        executable,
         ApplicationCommandResolverData(builder),
         optionAggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> UserContextCommandOptionImpl(command, optionBuilder, resolver) }
+        optionFinalizer = { optionBuilder, resolver -> UserContextCommandOptionImpl(executable, optionBuilder, resolver) }
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandParameterImpl.kt
@@ -4,12 +4,10 @@ import io.github.freya022.botcommands.api.commands.application.ApplicationComman
 import io.github.freya022.botcommands.api.commands.application.context.user.GlobalUserEvent
 import io.github.freya022.botcommands.api.commands.application.context.user.options.UserContextCommandParameter
 import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.parameters.resolvers.UserContextParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.context.options.ContextCommandParameterImpl
 import io.github.freya022.botcommands.internal.commands.application.context.user.UserCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.context.user.builder.UserCommandBuilderImpl
 import io.github.freya022.botcommands.internal.commands.application.context.user.options.builder.UserCommandOptionAggregateBuilderImpl
-import io.github.freya022.botcommands.internal.commands.application.context.user.options.builder.UserCommandOptionBuilderImpl
 import io.github.freya022.botcommands.internal.options.CommandOptions
 import io.github.freya022.botcommands.internal.options.transform
 
@@ -25,11 +23,10 @@ internal class UserContextCommandParameterImpl internal constructor(
         UserContextCommandParameterImpl(context, executable, builder, it as UserCommandOptionAggregateBuilderImpl)
     }
 
-    override val options = CommandOptions.transform<UserCommandOptionBuilderImpl, UserContextParameterResolver<*, *>>(
-        context,
-        executable,
+    override val options = CommandOptions.transform(
+        this,
         ApplicationCommandResolverData(builder),
         optionAggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> UserContextCommandOptionImpl(executable, optionBuilder, resolver) }
+        optionFinalizer = ::UserContextCommandOptionImpl
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/options/UserContextCommandParameterImpl.kt
@@ -30,6 +30,6 @@ internal class UserContextCommandParameterImpl internal constructor(
         command,
         ApplicationCommandResolverData(builder),
         optionAggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> UserContextCommandOptionImpl(context, command, optionBuilder, resolver) }
+        optionFinalizer = { optionBuilder, resolver -> UserContextCommandOptionImpl(command, optionBuilder, resolver) }
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/options/ApplicationGeneratedOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/options/ApplicationGeneratedOption.kt
@@ -1,9 +1,11 @@
 package io.github.freya022.botcommands.internal.commands.application.options
 
+import io.github.freya022.botcommands.internal.commands.application.ApplicationCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.options.builder.ApplicationGeneratedOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.AbstractGeneratedOption
 
 internal class ApplicationGeneratedOption internal constructor(
+    override val executable: ApplicationCommandInfoImpl,
     generatedOptionBuilder: ApplicationGeneratedOptionBuilderImpl
 ) : AbstractGeneratedOption(generatedOptionBuilder.optionParameter) {
     val generatedValueSupplier = generatedOptionBuilder.generatedValueSupplier

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/options/ApplicationGeneratedOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/options/ApplicationGeneratedOption.kt
@@ -1,12 +1,15 @@
 package io.github.freya022.botcommands.internal.commands.application.options
 
-import io.github.freya022.botcommands.internal.commands.application.ApplicationCommandInfoImpl
+import io.github.freya022.botcommands.api.commands.application.options.ApplicationCommandParameter
 import io.github.freya022.botcommands.internal.commands.application.options.builder.ApplicationGeneratedOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.AbstractGeneratedOption
 
 internal class ApplicationGeneratedOption internal constructor(
-    override val executable: ApplicationCommandInfoImpl,
+    override val parent: ApplicationCommandParameter,
     generatedOptionBuilder: ApplicationGeneratedOptionBuilderImpl
 ) : AbstractGeneratedOption(generatedOptionBuilder.optionParameter) {
+
+    override val executable get() = parent.executable
+
     val generatedValueSupplier = generatedOptionBuilder.generatedValueSupplier
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/options/builder/ApplicationGeneratedOptionBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/options/builder/ApplicationGeneratedOptionBuilderImpl.kt
@@ -1,8 +1,8 @@
 package io.github.freya022.botcommands.internal.commands.application.options.builder
 
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier
-import io.github.freya022.botcommands.api.core.Executable
-import io.github.freya022.botcommands.internal.commands.application.ApplicationCommandInfoImpl
+import io.github.freya022.botcommands.api.commands.application.options.ApplicationCommandParameter
+import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import io.github.freya022.botcommands.internal.commands.application.options.ApplicationGeneratedOption
 import io.github.freya022.botcommands.internal.core.options.builder.AbstractGeneratedOptionBuilderImpl
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
@@ -11,6 +11,6 @@ internal class ApplicationGeneratedOptionBuilderImpl internal constructor(
     optionParameter: OptionParameter,
     internal val generatedValueSupplier: ApplicationGeneratedValueSupplier
 ) : AbstractGeneratedOptionBuilderImpl(optionParameter) {
-    override fun toGeneratedOption(executable: Executable) =
-        ApplicationGeneratedOption(executable as ApplicationCommandInfoImpl, this)
+    override fun toGeneratedOption(parent: AggregatedParameter) =
+        ApplicationGeneratedOption(parent as ApplicationCommandParameter, this)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/options/builder/ApplicationGeneratedOptionBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/options/builder/ApplicationGeneratedOptionBuilderImpl.kt
@@ -1,6 +1,8 @@
 package io.github.freya022.botcommands.internal.commands.application.options.builder
 
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier
+import io.github.freya022.botcommands.api.core.Executable
+import io.github.freya022.botcommands.internal.commands.application.ApplicationCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.options.ApplicationGeneratedOption
 import io.github.freya022.botcommands.internal.core.options.builder.AbstractGeneratedOptionBuilderImpl
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
@@ -9,5 +11,6 @@ internal class ApplicationGeneratedOptionBuilderImpl internal constructor(
     optionParameter: OptionParameter,
     internal val generatedValueSupplier: ApplicationGeneratedValueSupplier
 ) : AbstractGeneratedOptionBuilderImpl(optionParameter) {
-    override fun toGeneratedOption() = ApplicationGeneratedOption(this)
+    override fun toGeneratedOption(executable: Executable) =
+        ApplicationGeneratedOption(executable as ApplicationCommandInfoImpl, this)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/AutocompleteHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/AutocompleteHandler.kt
@@ -90,6 +90,8 @@ internal class AutocompleteHandler(
         }
     }
 
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("For removal, confusing on whether it searches nested parameters, prefer using collection operations on 'parameters' instead, make an extension or an utility method")
     override fun getParameter(declaredName: String): AggregatedParameter? =
         parameters.find { it.name == declaredName }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/AutocompleteHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/AutocompleteHandler.kt
@@ -9,6 +9,7 @@ import io.github.freya022.botcommands.api.core.service.getInterfacedServices
 import io.github.freya022.botcommands.api.core.utils.arrayOfSize
 import io.github.freya022.botcommands.api.core.utils.getSignature
 import io.github.freya022.botcommands.api.core.utils.isSubclassOf
+import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import io.github.freya022.botcommands.internal.ExecutableMixin
 import io.github.freya022.botcommands.internal.commands.application.slash.SlashCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.slash.autocomplete.options.AutocompleteCommandParameterImpl
@@ -83,6 +84,9 @@ internal class AutocompleteHandler(
             }
         }
     }
+
+    override fun getParameter(declaredName: String): AggregatedParameter? =
+        parameters.find { it.name == declaredName }
 
     internal fun invalidate() {
         autocompleteInfo.invalidate()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/AutocompleteHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/AutocompleteHandler.kt
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.autocomplet
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.annotations.AutocompleteHandler
 import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption
 import io.github.freya022.botcommands.api.commands.application.slash.options.builder.SlashCommandOptionAggregateBuilder
+import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.service.getInterfacedServices
 import io.github.freya022.botcommands.api.core.utils.arrayOfSize
 import io.github.freya022.botcommands.api.core.utils.getSignature
@@ -45,6 +46,10 @@ internal class AutocompleteHandler(
     private val autocompleteInfo: AutocompleteInfoImpl,
     builder: SlashCommandBuilderImpl
 ) : ExecutableMixin {
+
+    override val context: BContext
+        get() = slashCommandInfo.context
+
     override val eventFunction = autocompleteInfo.eventFunction
     override val parameters: List<AutocompleteCommandParameterImpl>
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/AutocompleteHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/AutocompleteHandler.kt
@@ -59,7 +59,7 @@ internal class AutocompleteHandler(
 
     init {
         this.parameters = slashCmdOptionAggregateBuilders.filterKeys { function.findParameterByName(it) != null }.transform {
-            AutocompleteCommandParameterImpl(slashCommandInfo.context, slashCommandInfo, builder, slashCmdOptionAggregateBuilders, it as SlashCommandOptionAggregateBuilderImpl, function)
+            AutocompleteCommandParameterImpl(context, slashCommandInfo, builder, slashCmdOptionAggregateBuilders, it as SlashCommandOptionAggregateBuilderImpl, function)
         }
 
         val unmappedParameters = function.nonEventParameters.map { it.findDeclarationName() } - parameters.mapTo(hashSetOf()) { it.name }
@@ -80,7 +80,7 @@ internal class AutocompleteHandler(
                 generateSupplierFromStrings(autocompleteInfo.mode)
             collectionElementType.isSubclassOf<Command.Choice>() -> ChoiceSupplierChoices(maxChoices)
             else -> {
-                val transformer = slashCommandInfo.context.serviceContainer
+                val transformer = context.serviceContainer
                     .getInterfacedServices<AutocompleteTransformer<Any>>()
                     .firstOrNull { it.elementType == collectionElementType.java }
                     ?: throwUser("No autocomplete transformer has been register for objects of type '${collectionElementType.simpleName}', " +

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/options/AutocompleteCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/options/AutocompleteCommandOptionImpl.kt
@@ -2,8 +2,8 @@ package io.github.freya022.botcommands.internal.commands.application.slash.autoc
 
 import io.github.freya022.botcommands.api.core.utils.enumSetOf
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
-import io.github.freya022.botcommands.internal.commands.application.slash.SlashCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.slash.options.AbstractSlashCommandOption
+import io.github.freya022.botcommands.internal.commands.application.slash.options.AbstractSlashCommandParameter
 import io.github.freya022.botcommands.internal.commands.application.slash.options.builder.SlashCommandOptionBuilderImpl
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.function
 import io.github.freya022.botcommands.internal.utils.requireAt
@@ -18,10 +18,13 @@ private val unsupportedTypes = enumSetOf(
 )
 
 internal class AutocompleteCommandOptionImpl(
-    override val executable: SlashCommandInfoImpl,
+    override val parent: AbstractSlashCommandParameter,
     optionBuilder: SlashCommandOptionBuilderImpl,
     resolver: SlashParameterResolver<*, *>
 ) : AbstractSlashCommandOption(optionBuilder, resolver) {
+
+    override val executable get() = parent.executable
+
     init {
         requireAt(resolver.optionType !in unsupportedTypes, optionBuilder.parameter.function) {
             "Autocomplete parameters does not support option type ${resolver.optionType} as Discord does not send them"

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/options/AutocompleteCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/options/AutocompleteCommandOptionImpl.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.internal.commands.application.slash.autocomplete.options
 
-import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.utils.enumSetOf
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.slash.SlashCommandInfoImpl
@@ -19,7 +18,6 @@ private val unsupportedTypes = enumSetOf(
 )
 
 internal class AutocompleteCommandOptionImpl(
-    override val context: BContext,
     override val executable: SlashCommandInfoImpl,
     optionBuilder: SlashCommandOptionBuilderImpl,
     resolver: SlashParameterResolver<*, *>

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/options/AutocompleteCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/options/AutocompleteCommandOptionImpl.kt
@@ -20,7 +20,7 @@ private val unsupportedTypes = enumSetOf(
 
 internal class AutocompleteCommandOptionImpl(
     override val context: BContext,
-    override val command: SlashCommandInfoImpl,
+    override val executable: SlashCommandInfoImpl,
     optionBuilder: SlashCommandOptionBuilderImpl,
     resolver: SlashParameterResolver<*, *>
 ) : AbstractSlashCommandOption(optionBuilder, resolver) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/options/AutocompleteCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/options/AutocompleteCommandParameterImpl.kt
@@ -2,12 +2,10 @@ package io.github.freya022.botcommands.internal.commands.application.slash.autoc
 
 import io.github.freya022.botcommands.api.commands.application.slash.options.builder.SlashCommandOptionAggregateBuilder
 import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.slash.SlashCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.slash.builder.SlashCommandBuilderImpl
 import io.github.freya022.botcommands.internal.commands.application.slash.options.AbstractSlashCommandParameter
 import io.github.freya022.botcommands.internal.commands.application.slash.options.builder.SlashCommandOptionAggregateBuilderImpl
-import io.github.freya022.botcommands.internal.commands.application.slash.options.builder.SlashCommandOptionBuilderImpl
 import io.github.freya022.botcommands.internal.options.transform
 import io.github.freya022.botcommands.internal.utils.ReflectionMetadata.isNullable
 import io.github.freya022.botcommands.internal.utils.requireAt
@@ -22,7 +20,7 @@ internal class AutocompleteCommandParameterImpl internal constructor(
     slashCmdOptionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,
     optionAggregateBuilder: SlashCommandOptionAggregateBuilderImpl,
     autocompleteFunction: KFunction<*>
-) : AbstractSlashCommandParameter(context, command, builder, slashCmdOptionAggregateBuilders, optionAggregateBuilder) {
+) : AbstractSlashCommandParameter(context, command, optionAggregateBuilder) {
 
     override val executableParameter =
         autocompleteFunction.findParameterByName(name)
@@ -48,11 +46,5 @@ internal class AutocompleteCommandParameterImpl internal constructor(
         )
     }
 
-    override fun constructOption(
-        command: SlashCommandInfoImpl,
-        builder: SlashCommandBuilderImpl,
-        optionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,
-        optionBuilder: SlashCommandOptionBuilderImpl,
-        resolver: SlashParameterResolver<*, *>
-    ) = AutocompleteCommandOptionImpl(command, optionBuilder, resolver)
+    override val options = transformOptions(this, builder, optionAggregateBuilder, ::AutocompleteCommandOptionImpl)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/options/AutocompleteCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/autocomplete/options/AutocompleteCommandParameterImpl.kt
@@ -49,11 +49,10 @@ internal class AutocompleteCommandParameterImpl internal constructor(
     }
 
     override fun constructOption(
-        context: BContext,
         command: SlashCommandInfoImpl,
         builder: SlashCommandBuilderImpl,
         optionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,
         optionBuilder: SlashCommandOptionBuilderImpl,
         resolver: SlashParameterResolver<*, *>
-    ) = AutocompleteCommandOptionImpl(context, command, optionBuilder, resolver)
+    ) = AutocompleteCommandOptionImpl(command, optionBuilder, resolver)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandOption.kt
@@ -9,6 +9,7 @@ internal abstract class AbstractSlashCommandOption internal constructor(
     optionBuilder: SlashCommandOptionBuilderImpl,
     internal val resolver: SlashParameterResolver<*, *>
 ) : ApplicationCommandOptionImpl(optionBuilder) {
+
     abstract override val executable: SlashCommandInfo
 
     val discordName = optionBuilder.optionName

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandOption.kt
@@ -9,7 +9,7 @@ internal abstract class AbstractSlashCommandOption internal constructor(
     optionBuilder: SlashCommandOptionBuilderImpl,
     internal val resolver: SlashParameterResolver<*, *>
 ) : ApplicationCommandOptionImpl(optionBuilder) {
-    abstract override val command: SlashCommandInfo
+    abstract override val executable: SlashCommandInfo
 
     val discordName = optionBuilder.optionName
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandParameter.kt
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.commands.application.slash.optio
 
 import io.github.freya022.botcommands.api.commands.application.ApplicationCommandResolverData
 import io.github.freya022.botcommands.api.commands.application.slash.GlobalSlashEvent
-import io.github.freya022.botcommands.api.commands.application.slash.options.builder.SlashCommandOptionAggregateBuilder
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.options.ApplicationCommandParameterImpl
@@ -10,30 +9,25 @@ import io.github.freya022.botcommands.internal.commands.application.slash.SlashC
 import io.github.freya022.botcommands.internal.commands.application.slash.builder.SlashCommandBuilderImpl
 import io.github.freya022.botcommands.internal.commands.application.slash.options.builder.SlashCommandOptionAggregateBuilderImpl
 import io.github.freya022.botcommands.internal.commands.application.slash.options.builder.SlashCommandOptionBuilderImpl
+import io.github.freya022.botcommands.internal.core.options.OptionImpl
 import io.github.freya022.botcommands.internal.options.CommandOptions
 
 internal abstract class AbstractSlashCommandParameter internal constructor(
     context: BContext,
     final override val executable: SlashCommandInfoImpl,
-    builder: SlashCommandBuilderImpl,
-    slashCmdOptionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,
     optionAggregateBuilder: SlashCommandOptionAggregateBuilderImpl
 ) : ApplicationCommandParameterImpl(context, optionAggregateBuilder, GlobalSlashEvent::class) {
-    final override val options = CommandOptions.transform<SlashCommandOptionBuilderImpl, SlashParameterResolver<*, *>>(
-        context,
-        executable,
-        ApplicationCommandResolverData(builder),
-        optionAggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver ->
-            constructOption(executable, builder, slashCmdOptionAggregateBuilders, optionBuilder, resolver)
-        }
-    )
-
-    internal abstract fun constructOption(
-        command: SlashCommandInfoImpl,
+    protected fun <P : AbstractSlashCommandParameter> transformOptions(
+        parent: P,
         builder: SlashCommandBuilderImpl,
-        optionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,
-        optionBuilder: SlashCommandOptionBuilderImpl,
-        resolver: SlashParameterResolver<*, *>
-    ): AbstractSlashCommandOption
+        optionAggregateBuilder: SlashCommandOptionAggregateBuilderImpl,
+        block: (parent: P, optionBuilder: SlashCommandOptionBuilderImpl, resolver: SlashParameterResolver<*, *>) -> AbstractSlashCommandOption
+    ): List<OptionImpl> {
+        return CommandOptions.transform<SlashCommandOptionBuilderImpl, SlashParameterResolver<*, *>, P>(
+            parent,
+            ApplicationCommandResolverData(builder),
+            optionAggregateBuilder,
+            optionFinalizer = block
+        )
+    }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandParameter.kt
@@ -25,12 +25,11 @@ internal abstract class AbstractSlashCommandParameter internal constructor(
         ApplicationCommandResolverData(builder),
         optionAggregateBuilder,
         optionFinalizer = { optionBuilder, resolver ->
-            constructOption(context, command, builder, slashCmdOptionAggregateBuilders, optionBuilder, resolver)
+            constructOption(command, builder, slashCmdOptionAggregateBuilders, optionBuilder, resolver)
         }
     )
 
     internal abstract fun constructOption(
-        context: BContext,
         command: SlashCommandInfoImpl,
         builder: SlashCommandBuilderImpl,
         optionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandParameter.kt
@@ -13,19 +13,19 @@ import io.github.freya022.botcommands.internal.commands.application.slash.option
 import io.github.freya022.botcommands.internal.options.CommandOptions
 
 internal abstract class AbstractSlashCommandParameter internal constructor(
-    final override val context: BContext,
-    final override val command: SlashCommandInfoImpl,
+    context: BContext,
+    final override val executable: SlashCommandInfoImpl,
     builder: SlashCommandBuilderImpl,
     slashCmdOptionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,
     optionAggregateBuilder: SlashCommandOptionAggregateBuilderImpl
 ) : ApplicationCommandParameterImpl(context, optionAggregateBuilder, GlobalSlashEvent::class) {
     final override val options = CommandOptions.transform<SlashCommandOptionBuilderImpl, SlashParameterResolver<*, *>>(
         context,
-        command,
+        executable,
         ApplicationCommandResolverData(builder),
         optionAggregateBuilder,
         optionFinalizer = { optionBuilder, resolver ->
-            constructOption(command, builder, slashCmdOptionAggregateBuilders, optionBuilder, resolver)
+            constructOption(executable, builder, slashCmdOptionAggregateBuilders, optionBuilder, resolver)
         }
     )
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/AbstractSlashCommandParameter.kt
@@ -21,6 +21,7 @@ internal abstract class AbstractSlashCommandParameter internal constructor(
 ) : ApplicationCommandParameterImpl(context, optionAggregateBuilder, GlobalSlashEvent::class) {
     final override val options = CommandOptions.transform<SlashCommandOptionBuilderImpl, SlashParameterResolver<*, *>>(
         context,
+        command,
         ApplicationCommandResolverData(builder),
         optionAggregateBuilder,
         optionFinalizer = { optionBuilder, resolver ->

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandOptionImpl.kt
@@ -18,7 +18,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType
 
 internal class SlashCommandOptionImpl internal constructor(
     override val context: BContext,
-    override val command: SlashCommandInfoImpl,
+    override val executable: SlashCommandInfoImpl,
     builder: SlashCommandBuilderImpl,
     optionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,
     optionBuilder: SlashCommandOptionBuilderImpl,
@@ -31,7 +31,7 @@ internal class SlashCommandOptionImpl internal constructor(
     internal val autocompleteHandler by lazy {
         when (val autocompleteInfo = optionBuilder.autocompleteInfo) {
             null -> null
-            else -> AutocompleteHandler(command, optionAggregateBuilders, autocompleteInfo, builder)
+            else -> AutocompleteHandler(executable, optionAggregateBuilders, autocompleteInfo, builder)
         }
     }
 
@@ -47,7 +47,7 @@ internal class SlashCommandOptionImpl internal constructor(
             }
         }
 
-        description = LocalizationUtils.getOptionDescription(command.context, optionBuilder)
+        description = LocalizationUtils.getOptionDescription(executable.context, optionBuilder)
 
         if (range != null) {
             check(resolver.optionType == OptionType.NUMBER || resolver.optionType == OptionType.INTEGER) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandOptionImpl.kt
@@ -6,7 +6,6 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.application.slash.options.builder.SlashCommandOptionAggregateBuilder
 import io.github.freya022.botcommands.api.core.config.BApplicationConfigBuilder
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
-import io.github.freya022.botcommands.internal.commands.application.slash.SlashCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.slash.autocomplete.AutocompleteHandler
 import io.github.freya022.botcommands.internal.commands.application.slash.builder.SlashCommandBuilderImpl
 import io.github.freya022.botcommands.internal.commands.application.slash.options.builder.SlashCommandOptionBuilderImpl
@@ -16,7 +15,7 @@ import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.interactions.commands.OptionType
 
 internal class SlashCommandOptionImpl internal constructor(
-    override val executable: SlashCommandInfoImpl,
+    override val parent: SlashCommandParameterImpl,
     builder: SlashCommandBuilderImpl,
     optionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,
     optionBuilder: SlashCommandOptionBuilderImpl,
@@ -24,12 +23,14 @@ internal class SlashCommandOptionImpl internal constructor(
 ) : AbstractSlashCommandOption(optionBuilder, resolver),
     SlashCommandOption {
 
+    override val executable get() = parent.executable
+
     override val description: String
 
     internal val autocompleteHandler by lazy {
         when (val autocompleteInfo = optionBuilder.autocompleteInfo) {
             null -> null
-            else -> AutocompleteHandler(executable, optionAggregateBuilders, autocompleteInfo, builder)
+            else -> AutocompleteHandler(parent.executable, optionAggregateBuilders, autocompleteInfo, builder)
         }
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandOptionImpl.kt
@@ -4,7 +4,6 @@ import io.github.freya022.botcommands.api.commands.application.LengthRange
 import io.github.freya022.botcommands.api.commands.application.ValueRange
 import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption
 import io.github.freya022.botcommands.api.commands.application.slash.options.builder.SlashCommandOptionAggregateBuilder
-import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.config.BApplicationConfigBuilder
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.slash.SlashCommandInfoImpl
@@ -17,7 +16,6 @@ import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.interactions.commands.OptionType
 
 internal class SlashCommandOptionImpl internal constructor(
-    override val context: BContext,
     override val executable: SlashCommandInfoImpl,
     builder: SlashCommandBuilderImpl,
     optionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandParameterImpl.kt
@@ -24,11 +24,10 @@ internal class SlashCommandParameterImpl internal constructor(
     }
 
     override fun constructOption(
-        context: BContext,
         command: SlashCommandInfoImpl,
         builder: SlashCommandBuilderImpl,
         optionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,
         optionBuilder: SlashCommandOptionBuilderImpl,
         resolver: SlashParameterResolver<*, *>
-    ) = SlashCommandOptionImpl(context, command, builder, optionAggregateBuilders, optionBuilder, resolver)
+    ) = SlashCommandOptionImpl(command, builder, optionAggregateBuilders, optionBuilder, resolver)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandParameterImpl.kt
@@ -3,11 +3,9 @@ package io.github.freya022.botcommands.internal.commands.application.slash.optio
 import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandParameter
 import io.github.freya022.botcommands.api.commands.application.slash.options.builder.SlashCommandOptionAggregateBuilder
 import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.internal.commands.application.slash.SlashCommandInfoImpl
 import io.github.freya022.botcommands.internal.commands.application.slash.builder.SlashCommandBuilderImpl
 import io.github.freya022.botcommands.internal.commands.application.slash.options.builder.SlashCommandOptionAggregateBuilderImpl
-import io.github.freya022.botcommands.internal.commands.application.slash.options.builder.SlashCommandOptionBuilderImpl
 import io.github.freya022.botcommands.internal.options.transform
 
 internal class SlashCommandParameterImpl internal constructor(
@@ -16,18 +14,14 @@ internal class SlashCommandParameterImpl internal constructor(
     builder: SlashCommandBuilderImpl,
     slashCmdOptionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,
     optionAggregateBuilder: SlashCommandOptionAggregateBuilderImpl
-) : AbstractSlashCommandParameter(context, command, builder, slashCmdOptionAggregateBuilders, optionAggregateBuilder),
+) : AbstractSlashCommandParameter(context, command, optionAggregateBuilder),
     SlashCommandParameter {
 
     override val nestedAggregatedParameters = optionAggregateBuilder.optionAggregateBuilders.transform {
         SlashCommandParameterImpl(context, command, builder, slashCmdOptionAggregateBuilders, it as SlashCommandOptionAggregateBuilderImpl)
     }
 
-    override fun constructOption(
-        command: SlashCommandInfoImpl,
-        builder: SlashCommandBuilderImpl,
-        optionAggregateBuilders: Map<String, SlashCommandOptionAggregateBuilder>,
-        optionBuilder: SlashCommandOptionBuilderImpl,
-        resolver: SlashParameterResolver<*, *>
-    ) = SlashCommandOptionImpl(command, builder, optionAggregateBuilders, optionBuilder, resolver)
+    override val options = transformOptions(this, builder, optionAggregateBuilder) { parent, optionBuilder, resolver ->
+        SlashCommandOptionImpl(parent, builder, slashCmdOptionAggregateBuilders, optionBuilder, resolver)
+    }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandOptionImpl.kt
@@ -1,19 +1,21 @@
 package io.github.freya022.botcommands.internal.commands.text.options
 
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
+import io.github.freya022.botcommands.api.commands.text.options.TextCommandParameter
 import io.github.freya022.botcommands.api.parameters.resolvers.QuotableTextParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver
 import io.github.freya022.botcommands.internal.commands.options.CommandOptionImpl
 import io.github.freya022.botcommands.internal.commands.text.options.builder.TextCommandOptionBuilderImpl
 
 internal class TextCommandOptionImpl internal constructor(
-    override val executable: TextCommandVariation,
+    override val parent: TextCommandParameter,
     optionBuilder: TextCommandOptionBuilderImpl,
     internal val resolver: TextParameterResolver<*, *>
 ) : CommandOptionImpl(optionBuilder),
     TextCommandOption {
+
+    override val executable get() = parent.executable
 
     override val helpName: String = optionBuilder.optionName
     override val helpExample: String? = optionBuilder.helpExample

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandOptionImpl.kt
@@ -3,14 +3,12 @@ package io.github.freya022.botcommands.internal.commands.text.options
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
-import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.parameters.resolvers.QuotableTextParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver
 import io.github.freya022.botcommands.internal.commands.options.CommandOptionImpl
 import io.github.freya022.botcommands.internal.commands.text.options.builder.TextCommandOptionBuilderImpl
 
 internal class TextCommandOptionImpl internal constructor(
-    override val context: BContext,
     override val executable: TextCommandVariation,
     optionBuilder: TextCommandOptionBuilderImpl,
     internal val resolver: TextParameterResolver<*, *>

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandOptionImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandOptionImpl.kt
@@ -11,7 +11,7 @@ import io.github.freya022.botcommands.internal.commands.text.options.builder.Tex
 
 internal class TextCommandOptionImpl internal constructor(
     override val context: BContext,
-    override val command: TextCommandVariation,
+    override val executable: TextCommandVariation,
     optionBuilder: TextCommandOptionBuilderImpl,
     internal val resolver: TextParameterResolver<*, *>
 ) : CommandOptionImpl(optionBuilder),

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandParameterImpl.kt
@@ -12,21 +12,21 @@ import io.github.freya022.botcommands.internal.options.CommandOptions
 import io.github.freya022.botcommands.internal.options.transform
 
 internal class TextCommandParameterImpl internal constructor(
-    override val context: BContext,
-    override val command: TextCommandVariation,
+    context: BContext,
+    override val executable: TextCommandVariation,
     optionAggregateBuilder: TextCommandOptionAggregateBuilderImpl
 ) : CommandParameterImpl(context, optionAggregateBuilder, BaseCommandEvent::class),
     TextCommandParameter {
 
     override val nestedAggregatedParameters = optionAggregateBuilder.optionAggregateBuilders.transform {
-        TextCommandParameterImpl(context, command, it as TextCommandOptionAggregateBuilderImpl)
+        TextCommandParameterImpl(context, executable, it as TextCommandOptionAggregateBuilderImpl)
     }
 
     override val options = CommandOptions.transform<TextCommandOptionBuilderImpl, TextParameterResolver<*, *>>(
         context,
-        command,
+        executable,
         null,
         optionAggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> TextCommandOptionImpl(command, optionBuilder, resolver) }
+        optionFinalizer = { optionBuilder, resolver -> TextCommandOptionImpl(executable, optionBuilder, resolver) }
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandParameterImpl.kt
@@ -24,6 +24,7 @@ internal class TextCommandParameterImpl internal constructor(
 
     override val options = CommandOptions.transform<TextCommandOptionBuilderImpl, TextParameterResolver<*, *>>(
         context,
+        command,
         null,
         optionAggregateBuilder,
         optionFinalizer = { optionBuilder, resolver -> TextCommandOptionImpl(context, command, optionBuilder, resolver) }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandParameterImpl.kt
@@ -4,10 +4,8 @@ import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandParameter
 import io.github.freya022.botcommands.api.core.BContext
-import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver
 import io.github.freya022.botcommands.internal.commands.options.CommandParameterImpl
 import io.github.freya022.botcommands.internal.commands.text.options.builder.TextCommandOptionAggregateBuilderImpl
-import io.github.freya022.botcommands.internal.commands.text.options.builder.TextCommandOptionBuilderImpl
 import io.github.freya022.botcommands.internal.options.CommandOptions
 import io.github.freya022.botcommands.internal.options.transform
 
@@ -22,11 +20,10 @@ internal class TextCommandParameterImpl internal constructor(
         TextCommandParameterImpl(context, executable, it as TextCommandOptionAggregateBuilderImpl)
     }
 
-    override val options = CommandOptions.transform<TextCommandOptionBuilderImpl, TextParameterResolver<*, *>>(
-        context,
-        executable,
+    override val options = CommandOptions.transform(
+        this,
         null,
         optionAggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> TextCommandOptionImpl(executable, optionBuilder, resolver) }
+        optionFinalizer = ::TextCommandOptionImpl
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextCommandParameterImpl.kt
@@ -27,6 +27,6 @@ internal class TextCommandParameterImpl internal constructor(
         command,
         null,
         optionAggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> TextCommandOptionImpl(context, command, optionBuilder, resolver) }
+        optionFinalizer = { optionBuilder, resolver -> TextCommandOptionImpl(command, optionBuilder, resolver) }
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextGeneratedOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextGeneratedOption.kt
@@ -1,12 +1,15 @@
 package io.github.freya022.botcommands.internal.commands.text.options
 
-import io.github.freya022.botcommands.internal.commands.text.TextCommandVariationImpl
+import io.github.freya022.botcommands.api.commands.text.options.TextCommandParameter
 import io.github.freya022.botcommands.internal.commands.text.options.builder.TextGeneratedOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.AbstractGeneratedOption
 
 internal class TextGeneratedOption internal constructor(
-    override val executable: TextCommandVariationImpl,
+    override val parent: TextCommandParameter,
     generatedOptionBuilder: TextGeneratedOptionBuilderImpl
 ) : AbstractGeneratedOption(generatedOptionBuilder.optionParameter) {
+
+    override val executable get() = parent.executable
+
     val generatedValueSupplier = generatedOptionBuilder.generatedValueSupplier
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextGeneratedOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/TextGeneratedOption.kt
@@ -1,9 +1,11 @@
 package io.github.freya022.botcommands.internal.commands.text.options
 
+import io.github.freya022.botcommands.internal.commands.text.TextCommandVariationImpl
 import io.github.freya022.botcommands.internal.commands.text.options.builder.TextGeneratedOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.AbstractGeneratedOption
 
 internal class TextGeneratedOption internal constructor(
+    override val executable: TextCommandVariationImpl,
     generatedOptionBuilder: TextGeneratedOptionBuilderImpl
 ) : AbstractGeneratedOption(generatedOptionBuilder.optionParameter) {
     val generatedValueSupplier = generatedOptionBuilder.generatedValueSupplier

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/builder/TextGeneratedOptionBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/builder/TextGeneratedOptionBuilderImpl.kt
@@ -1,6 +1,8 @@
 package io.github.freya022.botcommands.internal.commands.text.options.builder
 
 import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSupplier
+import io.github.freya022.botcommands.api.core.Executable
+import io.github.freya022.botcommands.internal.commands.text.TextCommandVariationImpl
 import io.github.freya022.botcommands.internal.commands.text.options.TextGeneratedOption
 import io.github.freya022.botcommands.internal.core.options.builder.AbstractGeneratedOptionBuilderImpl
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
@@ -9,5 +11,6 @@ internal class TextGeneratedOptionBuilderImpl internal constructor(
     optionParameter: OptionParameter,
     val generatedValueSupplier: TextGeneratedValueSupplier
 ) : AbstractGeneratedOptionBuilderImpl(optionParameter) {
-    override fun toGeneratedOption() = TextGeneratedOption(this)
+    override fun toGeneratedOption(executable: Executable) =
+        TextGeneratedOption(executable as TextCommandVariationImpl, this)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/builder/TextGeneratedOptionBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/builder/TextGeneratedOptionBuilderImpl.kt
@@ -1,8 +1,8 @@
 package io.github.freya022.botcommands.internal.commands.text.options.builder
 
 import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSupplier
-import io.github.freya022.botcommands.api.core.Executable
-import io.github.freya022.botcommands.internal.commands.text.TextCommandVariationImpl
+import io.github.freya022.botcommands.api.commands.text.options.TextCommandParameter
+import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import io.github.freya022.botcommands.internal.commands.text.options.TextGeneratedOption
 import io.github.freya022.botcommands.internal.core.options.builder.AbstractGeneratedOptionBuilderImpl
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
@@ -11,6 +11,6 @@ internal class TextGeneratedOptionBuilderImpl internal constructor(
     optionParameter: OptionParameter,
     val generatedValueSupplier: TextGeneratedValueSupplier
 ) : AbstractGeneratedOptionBuilderImpl(optionParameter) {
-    override fun toGeneratedOption(executable: Executable) =
-        TextGeneratedOption(executable as TextCommandVariationImpl, this)
+    override fun toGeneratedOption(parent: AggregatedParameter) =
+        TextGeneratedOption(parent as TextCommandParameter, this)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
@@ -55,7 +55,7 @@ internal class ComponentDescriptor internal constructor(
                     optionParameter.toFallbackOptionBuilder(context.serviceContainer, resolverContainer)
                 }
             },
-            aggregateBlock = { ComponentHandlerParameterImpl(context, it, eventType) }
+            aggregateBlock = { ComponentHandlerParameterImpl(context, this, it, eventType) }
         )
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.core.Logging.toUnwrappedLogger
 import io.github.freya022.botcommands.api.core.reflect.wrap
 import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.hasAnnotationRecursive
+import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
 import io.github.freya022.botcommands.internal.ExecutableMixin
 import io.github.freya022.botcommands.internal.components.handler.options.ComponentHandlerParameterImpl
@@ -59,4 +60,7 @@ internal class ComponentDescriptor internal constructor(
     }
 
     internal val optionSize = parameters.sumOf { p -> p.allOptions.count { o -> o.optionType == OptionType.OPTION } }
+
+    override fun getParameter(declaredName: String): AggregatedParameter? =
+        parameters.find { it.name == declaredName }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
@@ -61,6 +61,8 @@ internal class ComponentDescriptor internal constructor(
 
     internal val optionSize = parameters.sumOf { p -> p.allOptions.count { o -> o.optionType == OptionType.OPTION } }
 
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("For removal, confusing on whether it searches nested parameters, prefer using collection operations on 'parameters' instead, make an extension or an utility method")
     override fun getParameter(declaredName: String): AggregatedParameter? =
         parameters.find { it.name == declaredName }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
@@ -55,7 +55,7 @@ internal class ComponentDescriptor internal constructor(
                     optionParameter.toFallbackOptionBuilder(context.serviceContainer, resolverContainer)
                 }
             },
-            aggregateBlock = { ComponentHandlerParameterImpl(context, this, it, eventType) }
+            aggregateBlock = { ComponentHandlerParameterImpl(this, it, eventType) }
         )
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentDescriptor.kt
@@ -27,7 +27,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 
 internal class ComponentDescriptor internal constructor(
-    context: BContextImpl,
+    override val context: BContextImpl,
     handler: KFunction<*>,
     eventType: KClass<out GenericComponentInteractionCreateEvent>
 ) : ExecutableMixin {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerOption.kt
@@ -1,13 +1,15 @@
 package io.github.freya022.botcommands.internal.components.handler.options
 
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
-import io.github.freya022.botcommands.internal.components.handler.ComponentDescriptor
 import io.github.freya022.botcommands.internal.components.handler.options.builder.ComponentHandlerOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 
 internal class ComponentHandlerOption internal constructor(
-    override val executable: ComponentDescriptor,
+    override val parent: ComponentHandlerParameterImpl,
     optionBuilder: ComponentHandlerOptionBuilderImpl,
     internal val resolver: ComponentParameterResolver<*, *>
-) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION)
+) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION) {
+
+    override val executable get() = parent.executable
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerOption.kt
@@ -1,11 +1,13 @@
 package io.github.freya022.botcommands.internal.components.handler.options
 
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
+import io.github.freya022.botcommands.internal.components.handler.ComponentDescriptor
 import io.github.freya022.botcommands.internal.components.handler.options.builder.ComponentHandlerOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 
 internal class ComponentHandlerOption internal constructor(
+    override val executable: ComponentDescriptor,
     optionBuilder: ComponentHandlerOptionBuilderImpl,
     internal val resolver: ComponentParameterResolver<*, *>
 ) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerParameterImpl.kt
@@ -1,8 +1,6 @@
 package io.github.freya022.botcommands.internal.components.handler.options
 
-import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 import io.github.freya022.botcommands.internal.components.handler.ComponentDescriptor
-import io.github.freya022.botcommands.internal.components.handler.options.builder.ComponentHandlerOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.builder.OptionAggregateBuilderImpl
 import io.github.freya022.botcommands.internal.core.reflection.toAggregatorFunction
 import io.github.freya022.botcommands.internal.options.CommandOptions
@@ -25,11 +23,10 @@ internal class ComponentHandlerParameterImpl internal constructor(
         ComponentHandlerParameterImpl(executable, it as OptionAggregateBuilderImpl<*>, eventType)
     }
 
-    override val options = CommandOptions.transform<ComponentHandlerOptionBuilderImpl, ComponentParameterResolver<*, *>>(
-        context,
-        executable,
+    override val options = CommandOptions.transform(
+        this,
         null,
         aggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> ComponentHandlerOption(executable, optionBuilder, resolver) }
+        optionFinalizer = ::ComponentHandlerOption
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerParameterImpl.kt
@@ -1,5 +1,8 @@
 package io.github.freya022.botcommands.internal.components.handler.options
 
+import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
+import io.github.freya022.botcommands.internal.components.handler.ComponentDescriptor
+import io.github.freya022.botcommands.internal.components.handler.options.builder.ComponentHandlerOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.builder.OptionAggregateBuilderImpl
 import io.github.freya022.botcommands.internal.core.reflection.toAggregatorFunction
@@ -12,6 +15,7 @@ import kotlin.reflect.KClass
 
 internal class ComponentHandlerParameterImpl internal constructor(
     context: BContextImpl,
+    executable: ComponentDescriptor,
     aggregateBuilder: OptionAggregateBuilderImpl<*>,
     eventType: KClass<out GenericComponentInteractionCreateEvent>
 ) : AbstractMethodParameter(aggregateBuilder.parameter),
@@ -20,13 +24,14 @@ internal class ComponentHandlerParameterImpl internal constructor(
     override val aggregator = aggregateBuilder.aggregator.toAggregatorFunction(context, eventType)
 
     override val nestedAggregatedParameters = aggregateBuilder.optionAggregateBuilders.transform {
-        ComponentHandlerParameterImpl(context, it as OptionAggregateBuilderImpl<*>, eventType)
+        ComponentHandlerParameterImpl(context, executable, it as OptionAggregateBuilderImpl<*>, eventType)
     }
 
-    override val options = CommandOptions.transform(
+    override val options = CommandOptions.transform<ComponentHandlerOptionBuilderImpl, ComponentParameterResolver<*, *>>(
         context,
+        executable,
         null,
         aggregateBuilder,
-        optionFinalizer = ::ComponentHandlerOption
+        optionFinalizer = { optionBuilder, resolver -> ComponentHandlerOption(executable, optionBuilder, resolver) }
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerParameterImpl.kt
@@ -3,7 +3,6 @@ package io.github.freya022.botcommands.internal.components.handler.options
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 import io.github.freya022.botcommands.internal.components.handler.ComponentDescriptor
 import io.github.freya022.botcommands.internal.components.handler.options.builder.ComponentHandlerOptionBuilderImpl
-import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.builder.OptionAggregateBuilderImpl
 import io.github.freya022.botcommands.internal.core.reflection.toAggregatorFunction
 import io.github.freya022.botcommands.internal.options.CommandOptions
@@ -14,8 +13,7 @@ import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteract
 import kotlin.reflect.KClass
 
 internal class ComponentHandlerParameterImpl internal constructor(
-    context: BContextImpl,
-    executable: ComponentDescriptor,
+    override val executable: ComponentDescriptor,
     aggregateBuilder: OptionAggregateBuilderImpl<*>,
     eventType: KClass<out GenericComponentInteractionCreateEvent>
 ) : AbstractMethodParameter(aggregateBuilder.parameter),
@@ -24,7 +22,7 @@ internal class ComponentHandlerParameterImpl internal constructor(
     override val aggregator = aggregateBuilder.aggregator.toAggregatorFunction(context, eventType)
 
     override val nestedAggregatedParameters = aggregateBuilder.optionAggregateBuilders.transform {
-        ComponentHandlerParameterImpl(context, executable, it as OptionAggregateBuilderImpl<*>, eventType)
+        ComponentHandlerParameterImpl(executable, it as OptionAggregateBuilderImpl<*>, eventType)
     }
 
     override val options = CommandOptions.transform<ComponentHandlerOptionBuilderImpl, ComponentParameterResolver<*, *>>(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
@@ -3,6 +3,7 @@ package io.github.freya022.botcommands.internal.components.timeout
 import io.github.freya022.botcommands.api.components.annotations.TimeoutData
 import io.github.freya022.botcommands.api.core.Logging.toUnwrappedLogger
 import io.github.freya022.botcommands.api.core.utils.hasAnnotationRecursive
+import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import io.github.freya022.botcommands.internal.ExecutableMixin
 import io.github.freya022.botcommands.internal.components.timeout.options.TimeoutHandlerParameter
 import io.github.freya022.botcommands.internal.components.timeout.options.builder.TimeoutHandlerOptionBuilderImpl
@@ -51,4 +52,7 @@ internal class TimeoutDescriptor<T : Any> internal constructor(
     }
 
     internal val optionSize = parameters.sumOf { p -> p.allOptions.count { o -> o.optionType == OptionType.OPTION } }
+
+    override fun getParameter(declaredName: String): AggregatedParameter? =
+        parameters.find { it.name == declaredName }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
@@ -53,6 +53,8 @@ internal class TimeoutDescriptor<T : Any> internal constructor(
 
     internal val optionSize = parameters.sumOf { p -> p.allOptions.count { o -> o.optionType == OptionType.OPTION } }
 
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("For removal, confusing on whether it searches nested parameters, prefer using collection operations on 'parameters' instead, make an extension or an utility method")
     override fun getParameter(declaredName: String): AggregatedParameter? =
         parameters.find { it.name == declaredName }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
@@ -20,7 +20,7 @@ import io.github.freya022.botcommands.internal.utils.shortSignature
 import kotlin.reflect.KClass
 
 internal class TimeoutDescriptor<T : Any> internal constructor(
-    context: BContextImpl,
+    override val context: BContextImpl,
     override val eventFunction: MemberParamFunction<T, *>,
     aggregatorFirstParamType: KClass<T>
 ) : ExecutableMixin {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
@@ -47,7 +47,7 @@ internal class TimeoutDescriptor<T : Any> internal constructor(
                     ServiceOptionBuilderImpl(optionParameter)
                 }
             },
-            aggregateBlock = { TimeoutHandlerParameter(context, this, it, aggregatorFirstParamType) }
+            aggregateBlock = { TimeoutHandlerParameter(this, it, aggregatorFirstParamType) }
         )
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/TimeoutDescriptor.kt
@@ -47,7 +47,7 @@ internal class TimeoutDescriptor<T : Any> internal constructor(
                     ServiceOptionBuilderImpl(optionParameter)
                 }
             },
-            aggregateBlock = { TimeoutHandlerParameter(context, it, aggregatorFirstParamType) }
+            aggregateBlock = { TimeoutHandlerParameter(context, this, it, aggregatorFirstParamType) }
         )
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerOption.kt
@@ -1,13 +1,15 @@
 package io.github.freya022.botcommands.internal.components.timeout.options
 
 import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
-import io.github.freya022.botcommands.internal.components.timeout.TimeoutDescriptor
 import io.github.freya022.botcommands.internal.components.timeout.options.builder.TimeoutHandlerOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 
 internal class TimeoutHandlerOption internal constructor(
-    override val executable: TimeoutDescriptor<*>,
+    override val parent: TimeoutHandlerParameter,
     optionBuilder: TimeoutHandlerOptionBuilderImpl,
     val resolver: TimeoutParameterResolver<*, *>
-) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION)
+) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION) {
+
+    override val executable get() = parent.executable
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerOption.kt
@@ -1,11 +1,13 @@
 package io.github.freya022.botcommands.internal.components.timeout.options
 
 import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
+import io.github.freya022.botcommands.internal.components.timeout.TimeoutDescriptor
 import io.github.freya022.botcommands.internal.components.timeout.options.builder.TimeoutHandlerOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 
 internal class TimeoutHandlerOption internal constructor(
+    override val executable: TimeoutDescriptor<*>,
     optionBuilder: TimeoutHandlerOptionBuilderImpl,
     val resolver: TimeoutParameterResolver<*, *>
 ) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerParameter.kt
@@ -1,8 +1,6 @@
 package io.github.freya022.botcommands.internal.components.timeout.options
 
-import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
 import io.github.freya022.botcommands.internal.components.timeout.TimeoutDescriptor
-import io.github.freya022.botcommands.internal.components.timeout.options.builder.TimeoutHandlerOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.builder.OptionAggregateBuilderImpl
 import io.github.freya022.botcommands.internal.core.reflection.toAggregatorFunction
 import io.github.freya022.botcommands.internal.options.CommandOptions
@@ -24,11 +22,10 @@ internal class TimeoutHandlerParameter internal constructor(
         TimeoutHandlerParameter(executable, it as OptionAggregateBuilderImpl<*>, aggregatorFirstParamType)
     }
 
-    override val options = CommandOptions.transform<TimeoutHandlerOptionBuilderImpl, TimeoutParameterResolver<*, *>>(
-        context,
-        executable,
+    override val options = CommandOptions.transform(
+        this,
         null,
         aggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> TimeoutHandlerOption(executable, optionBuilder, resolver) }
+        optionFinalizer = ::TimeoutHandlerOption
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerParameter.kt
@@ -1,5 +1,8 @@
 package io.github.freya022.botcommands.internal.components.timeout.options
 
+import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
+import io.github.freya022.botcommands.internal.components.timeout.TimeoutDescriptor
+import io.github.freya022.botcommands.internal.components.timeout.options.builder.TimeoutHandlerOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.builder.OptionAggregateBuilderImpl
 import io.github.freya022.botcommands.internal.core.reflection.toAggregatorFunction
@@ -11,6 +14,7 @@ import kotlin.reflect.KClass
 
 internal class TimeoutHandlerParameter internal constructor(
     context: BContextImpl,
+    executable: TimeoutDescriptor<*>,
     aggregateBuilder: OptionAggregateBuilderImpl<*>,
     aggregatorFirstParamType: KClass<*>
 ) : AbstractMethodParameter(aggregateBuilder.parameter),
@@ -19,13 +23,14 @@ internal class TimeoutHandlerParameter internal constructor(
     override val aggregator = aggregateBuilder.aggregator.toAggregatorFunction(context, aggregatorFirstParamType)
 
     override val nestedAggregatedParameters = aggregateBuilder.optionAggregateBuilders.transform {
-        TimeoutHandlerParameter(context, it as OptionAggregateBuilderImpl<*>, aggregatorFirstParamType)
+        TimeoutHandlerParameter(context, executable, it as OptionAggregateBuilderImpl<*>, aggregatorFirstParamType)
     }
 
-    override val options = CommandOptions.transform(
+    override val options = CommandOptions.transform<TimeoutHandlerOptionBuilderImpl, TimeoutParameterResolver<*, *>>(
         context,
+        executable,
         null,
         aggregateBuilder,
-        optionFinalizer = ::TimeoutHandlerOption
+        optionFinalizer = { optionBuilder, resolver -> TimeoutHandlerOption(executable, optionBuilder, resolver) }
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerParameter.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerParameter.kt
@@ -3,7 +3,6 @@ package io.github.freya022.botcommands.internal.components.timeout.options
 import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
 import io.github.freya022.botcommands.internal.components.timeout.TimeoutDescriptor
 import io.github.freya022.botcommands.internal.components.timeout.options.builder.TimeoutHandlerOptionBuilderImpl
-import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.builder.OptionAggregateBuilderImpl
 import io.github.freya022.botcommands.internal.core.reflection.toAggregatorFunction
 import io.github.freya022.botcommands.internal.options.CommandOptions
@@ -13,8 +12,7 @@ import io.github.freya022.botcommands.internal.parameters.AggregatedParameterMix
 import kotlin.reflect.KClass
 
 internal class TimeoutHandlerParameter internal constructor(
-    context: BContextImpl,
-    executable: TimeoutDescriptor<*>,
+    override val executable: TimeoutDescriptor<*>,
     aggregateBuilder: OptionAggregateBuilderImpl<*>,
     aggregatorFirstParamType: KClass<*>
 ) : AbstractMethodParameter(aggregateBuilder.parameter),
@@ -23,7 +21,7 @@ internal class TimeoutHandlerParameter internal constructor(
     override val aggregator = aggregateBuilder.aggregator.toAggregatorFunction(context, aggregatorFirstParamType)
 
     override val nestedAggregatedParameters = aggregateBuilder.optionAggregateBuilders.transform {
-        TimeoutHandlerParameter(context, executable, it as OptionAggregateBuilderImpl<*>, aggregatorFirstParamType)
+        TimeoutHandlerParameter(executable, it as OptionAggregateBuilderImpl<*>, aggregatorFirstParamType)
     }
 
     override val options = CommandOptions.transform<TimeoutHandlerOptionBuilderImpl, TimeoutParameterResolver<*, *>>(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/options/builder/AbstractGeneratedOptionBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/options/builder/AbstractGeneratedOptionBuilderImpl.kt
@@ -1,10 +1,11 @@
 package io.github.freya022.botcommands.internal.core.options.builder
 
+import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.internal.core.options.AbstractGeneratedOption
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
 
 internal abstract class AbstractGeneratedOptionBuilderImpl(
     optionParameter: OptionParameter
 ) : OptionBuilderImpl(optionParameter) {
-    internal abstract fun toGeneratedOption(): AbstractGeneratedOption
+    internal abstract fun toGeneratedOption(executable: Executable): AbstractGeneratedOption
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/options/builder/AbstractGeneratedOptionBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/options/builder/AbstractGeneratedOptionBuilderImpl.kt
@@ -1,11 +1,11 @@
 package io.github.freya022.botcommands.internal.core.options.builder
 
-import io.github.freya022.botcommands.api.core.Executable
+import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import io.github.freya022.botcommands.internal.core.options.AbstractGeneratedOption
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
 
 internal abstract class AbstractGeneratedOptionBuilderImpl(
     optionParameter: OptionParameter
 ) : OptionBuilderImpl(optionParameter) {
-    internal abstract fun toGeneratedOption(executable: Executable): AbstractGeneratedOption
+    internal abstract fun toGeneratedOption(parent: AggregatedParameter): AbstractGeneratedOption
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
@@ -56,7 +56,7 @@ internal class ModalHandlerInfo internal constructor(
                     optionParameter.toFallbackOptionBuilder(context.serviceContainer, resolverContainer)
                 }
             },
-            aggregateBlock = { ModalHandlerParameterImpl(context, this, it) }
+            aggregateBlock = { ModalHandlerParameterImpl(this, it) }
         )
 
         val options = parameters.flatMap { it.allOptions }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
@@ -9,6 +9,7 @@ import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.modals.ModalEvent
 import io.github.freya022.botcommands.api.modals.annotations.ModalHandler
 import io.github.freya022.botcommands.api.modals.annotations.ModalInput
+import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import io.github.freya022.botcommands.internal.ExecutableMixin
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
@@ -62,6 +63,9 @@ internal class ModalHandlerInfo internal constructor(
         expectedModalDatas = options.filterIsInstance<ModalHandlerDataOption>().count()
         expectedModalInputs = options.filterIsInstance<ModalHandlerInputOption>().count()
     }
+
+    override fun getParameter(declaredName: String): AggregatedParameter? =
+        parameters.find { it.name == declaredName }
 
     internal suspend fun execute(modalData: ModalData, event: ModalEvent) {
         val handlerData = modalData.handlerData as? PersistentModalHandlerData ?: throwInternal("This method should have not been ran as there is no handler data")

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
@@ -64,6 +64,8 @@ internal class ModalHandlerInfo internal constructor(
         expectedModalInputs = options.filterIsInstance<ModalHandlerInputOption>().count()
     }
 
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("For removal, confusing on whether it searches nested parameters, prefer using collection operations on 'parameters' instead, make an extension or an utility method")
     override fun getParameter(declaredName: String): AggregatedParameter? =
         parameters.find { it.name == declaredName }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.jvm.jvmErasure
 import io.github.freya022.botcommands.api.modals.annotations.ModalData as ModalDataAnnotation
 
 internal class ModalHandlerInfo internal constructor(
-    context: BContextImpl,
+    override val context: BContextImpl,
     override val eventFunction: MemberParamFunction<ModalEvent, *>
 ) : ExecutableMixin {
     override val parameters: List<ModalHandlerParameterImpl>

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
@@ -56,7 +56,7 @@ internal class ModalHandlerInfo internal constructor(
                     optionParameter.toFallbackOptionBuilder(context.serviceContainer, resolverContainer)
                 }
             },
-            aggregateBlock = { ModalHandlerParameterImpl(context, it) }
+            aggregateBlock = { ModalHandlerParameterImpl(context, this, it) }
         )
 
         val options = parameters.flatMap { it.allOptions }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerDataOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerDataOption.kt
@@ -1,10 +1,12 @@
 package io.github.freya022.botcommands.internal.modals.options
 
 import io.github.freya022.botcommands.internal.core.options.AbstractGeneratedOption
-import io.github.freya022.botcommands.internal.modals.ModalHandlerInfo
 import io.github.freya022.botcommands.internal.modals.options.builder.ModalHandlerDataOptionBuilderImpl
 
 internal class ModalHandlerDataOption internal constructor(
-    override val executable: ModalHandlerInfo,
+    override val parent: ModalHandlerParameterImpl,
     optionBuilder: ModalHandlerDataOptionBuilderImpl
-) : AbstractGeneratedOption(optionBuilder.optionParameter)
+) : AbstractGeneratedOption(optionBuilder.optionParameter) {
+
+    override val executable get() = parent.executable
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerDataOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerDataOption.kt
@@ -1,8 +1,10 @@
 package io.github.freya022.botcommands.internal.modals.options
 
 import io.github.freya022.botcommands.internal.core.options.AbstractGeneratedOption
+import io.github.freya022.botcommands.internal.modals.ModalHandlerInfo
 import io.github.freya022.botcommands.internal.modals.options.builder.ModalHandlerDataOptionBuilderImpl
 
 internal class ModalHandlerDataOption internal constructor(
+    override val executable: ModalHandlerInfo,
     optionBuilder: ModalHandlerDataOptionBuilderImpl
 ) : AbstractGeneratedOption(optionBuilder.optionParameter)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerInputOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerInputOption.kt
@@ -3,13 +3,15 @@ package io.github.freya022.botcommands.internal.modals.options
 import io.github.freya022.botcommands.api.core.utils.findAnnotationRecursive
 import io.github.freya022.botcommands.api.modals.annotations.ModalInput
 import io.github.freya022.botcommands.api.parameters.resolvers.ModalParameterResolver
-import io.github.freya022.botcommands.internal.modals.ModalHandlerInfo
 import io.github.freya022.botcommands.internal.modals.options.builder.ModalHandlerInputOptionBuilderImpl
 
 internal class ModalHandlerInputOption(
-    override val executable: ModalHandlerInfo,
+    override val parent: ModalHandlerParameterImpl,
     optionBuilder: ModalHandlerInputOptionBuilderImpl,
     val resolver: ModalParameterResolver<*, *>
 ) : ModalHandlerOption(optionBuilder) {
+
+    override val executable get() = parent.executable
+
     val inputName: String = kParameter.findAnnotationRecursive<ModalInput>()!!.name
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerInputOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerInputOption.kt
@@ -3,9 +3,11 @@ package io.github.freya022.botcommands.internal.modals.options
 import io.github.freya022.botcommands.api.core.utils.findAnnotationRecursive
 import io.github.freya022.botcommands.api.modals.annotations.ModalInput
 import io.github.freya022.botcommands.api.parameters.resolvers.ModalParameterResolver
+import io.github.freya022.botcommands.internal.modals.ModalHandlerInfo
 import io.github.freya022.botcommands.internal.modals.options.builder.ModalHandlerInputOptionBuilderImpl
 
 internal class ModalHandlerInputOption(
+    override val executable: ModalHandlerInfo,
     optionBuilder: ModalHandlerInputOptionBuilderImpl,
     val resolver: ModalParameterResolver<*, *>
 ) : ModalHandlerOption(optionBuilder) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerParameterImpl.kt
@@ -1,11 +1,9 @@
 package io.github.freya022.botcommands.internal.modals.options
 
 import io.github.freya022.botcommands.api.modals.ModalEvent
-import io.github.freya022.botcommands.api.parameters.resolvers.ModalParameterResolver
 import io.github.freya022.botcommands.internal.core.options.builder.OptionAggregateBuilderImpl
 import io.github.freya022.botcommands.internal.core.reflection.toAggregatorFunction
 import io.github.freya022.botcommands.internal.modals.ModalHandlerInfo
-import io.github.freya022.botcommands.internal.modals.options.builder.ModalHandlerInputOptionBuilderImpl
 import io.github.freya022.botcommands.internal.options.CommandOptions
 import io.github.freya022.botcommands.internal.options.transform
 import io.github.freya022.botcommands.internal.parameters.AbstractMethodParameter
@@ -23,11 +21,10 @@ internal class ModalHandlerParameterImpl internal constructor(
         ModalHandlerParameterImpl(executable, it as OptionAggregateBuilderImpl<*>)
     }
 
-    override val options = CommandOptions.transform<ModalHandlerInputOptionBuilderImpl, ModalParameterResolver<*, *>>(
-        context,
-        executable,
+    override val options = CommandOptions.transform(
+        this,
         null,
         aggregateBuilder,
-        optionFinalizer = { optionBuilder, resolver -> ModalHandlerInputOption(executable, optionBuilder, resolver) }
+        optionFinalizer = ::ModalHandlerInputOption
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerParameterImpl.kt
@@ -1,9 +1,12 @@
 package io.github.freya022.botcommands.internal.modals.options
 
 import io.github.freya022.botcommands.api.modals.ModalEvent
+import io.github.freya022.botcommands.api.parameters.resolvers.ModalParameterResolver
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.builder.OptionAggregateBuilderImpl
 import io.github.freya022.botcommands.internal.core.reflection.toAggregatorFunction
+import io.github.freya022.botcommands.internal.modals.ModalHandlerInfo
+import io.github.freya022.botcommands.internal.modals.options.builder.ModalHandlerInputOptionBuilderImpl
 import io.github.freya022.botcommands.internal.options.CommandOptions
 import io.github.freya022.botcommands.internal.options.transform
 import io.github.freya022.botcommands.internal.parameters.AbstractMethodParameter
@@ -11,6 +14,7 @@ import io.github.freya022.botcommands.internal.parameters.AggregatedParameterMix
 
 internal class ModalHandlerParameterImpl internal constructor(
     context: BContextImpl,
+    executable: ModalHandlerInfo,
     aggregateBuilder: OptionAggregateBuilderImpl<*>
 ) : AbstractMethodParameter(aggregateBuilder.parameter),
     AggregatedParameterMixin {
@@ -18,13 +22,14 @@ internal class ModalHandlerParameterImpl internal constructor(
     override val aggregator = aggregateBuilder.aggregator.toAggregatorFunction(context, ModalEvent::class)
 
     override val nestedAggregatedParameters = aggregateBuilder.optionAggregateBuilders.transform {
-        ModalHandlerParameterImpl(context, it as OptionAggregateBuilderImpl<*>)
+        ModalHandlerParameterImpl(context, executable, it as OptionAggregateBuilderImpl<*>)
     }
 
-    override val options = CommandOptions.transform(
+    override val options = CommandOptions.transform<ModalHandlerInputOptionBuilderImpl, ModalParameterResolver<*, *>>(
         context,
+        executable,
         null,
         aggregateBuilder,
-        optionFinalizer = ::ModalHandlerInputOption
+        optionFinalizer = { optionBuilder, resolver -> ModalHandlerInputOption(executable, optionBuilder, resolver) }
     )
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerParameterImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerParameterImpl.kt
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.modals.options
 
 import io.github.freya022.botcommands.api.modals.ModalEvent
 import io.github.freya022.botcommands.api.parameters.resolvers.ModalParameterResolver
-import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.options.builder.OptionAggregateBuilderImpl
 import io.github.freya022.botcommands.internal.core.reflection.toAggregatorFunction
 import io.github.freya022.botcommands.internal.modals.ModalHandlerInfo
@@ -13,8 +12,7 @@ import io.github.freya022.botcommands.internal.parameters.AbstractMethodParamete
 import io.github.freya022.botcommands.internal.parameters.AggregatedParameterMixin
 
 internal class ModalHandlerParameterImpl internal constructor(
-    context: BContextImpl,
-    executable: ModalHandlerInfo,
+    override val executable: ModalHandlerInfo,
     aggregateBuilder: OptionAggregateBuilderImpl<*>
 ) : AbstractMethodParameter(aggregateBuilder.parameter),
     AggregatedParameterMixin {
@@ -22,7 +20,7 @@ internal class ModalHandlerParameterImpl internal constructor(
     override val aggregator = aggregateBuilder.aggregator.toAggregatorFunction(context, ModalEvent::class)
 
     override val nestedAggregatedParameters = aggregateBuilder.optionAggregateBuilders.transform {
-        ModalHandlerParameterImpl(context, executable, it as OptionAggregateBuilderImpl<*>)
+        ModalHandlerParameterImpl(executable, it as OptionAggregateBuilderImpl<*>)
     }
 
     override val options = CommandOptions.transform<ModalHandlerInputOptionBuilderImpl, ModalParameterResolver<*, *>>(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/builder/ModalHandlerDataOptionBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/builder/ModalHandlerDataOptionBuilderImpl.kt
@@ -1,14 +1,14 @@
 package io.github.freya022.botcommands.internal.modals.options.builder
 
-import io.github.freya022.botcommands.api.core.Executable
+import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import io.github.freya022.botcommands.internal.core.options.builder.AbstractGeneratedOptionBuilderImpl
-import io.github.freya022.botcommands.internal.modals.ModalHandlerInfo
 import io.github.freya022.botcommands.internal.modals.options.ModalHandlerDataOption
+import io.github.freya022.botcommands.internal.modals.options.ModalHandlerParameterImpl
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
 
 internal class ModalHandlerDataOptionBuilderImpl(
     optionParameter: OptionParameter
 ) : AbstractGeneratedOptionBuilderImpl(optionParameter) {
-    override fun toGeneratedOption(executable: Executable) =
-        ModalHandlerDataOption(executable as ModalHandlerInfo, this)
+    override fun toGeneratedOption(parent: AggregatedParameter) =
+        ModalHandlerDataOption(parent as ModalHandlerParameterImpl, this)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/builder/ModalHandlerDataOptionBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/builder/ModalHandlerDataOptionBuilderImpl.kt
@@ -1,11 +1,14 @@
 package io.github.freya022.botcommands.internal.modals.options.builder
 
+import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.internal.core.options.builder.AbstractGeneratedOptionBuilderImpl
+import io.github.freya022.botcommands.internal.modals.ModalHandlerInfo
 import io.github.freya022.botcommands.internal.modals.options.ModalHandlerDataOption
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
 
 internal class ModalHandlerDataOptionBuilderImpl(
     optionParameter: OptionParameter
 ) : AbstractGeneratedOptionBuilderImpl(optionParameter) {
-    override fun toGeneratedOption() = ModalHandlerDataOption(this)
+    override fun toGeneratedOption(executable: Executable) =
+        ModalHandlerDataOption(executable as ModalHandlerInfo, this)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/options/CommandOptions.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/options/CommandOptions.kt
@@ -1,6 +1,7 @@
 package io.github.freya022.botcommands.internal.options
 
 import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.reflect.wrap
 import io.github.freya022.botcommands.api.core.service.getService
@@ -22,6 +23,7 @@ import io.github.freya022.botcommands.internal.utils.throwInternal
 internal object CommandOptions {
     internal inline fun <reified T : OptionBuilderImpl, reified R : IParameterResolver<R>> transform(
         context: BContext,
+        executable: Executable,
         resolverData: ResolverData?,
         aggregateBuilder: OptionAggregateBuilderImpl<*>,
         optionFinalizer: (optionBuilder: T, resolver: R) -> OptionImpl
@@ -44,13 +46,13 @@ internal object CommandOptions {
                     val resolver = resolverContainer.getResolverOfType<R>(ResolverRequest(parameter, resolverData))
                     optionFinalizer(optionBuilder, resolver)
                 }
-                is AbstractGeneratedOptionBuilderImpl -> optionBuilder.toGeneratedOption()
-                is ServiceOptionBuilderImpl -> ServiceMethodOption(optionBuilder.optionParameter, context.serviceContainer)
+                is AbstractGeneratedOptionBuilderImpl -> optionBuilder.toGeneratedOption(executable)
+                is ServiceOptionBuilderImpl -> ServiceMethodOption(executable, optionBuilder.optionParameter, context.serviceContainer)
                 is CustomOptionBuilderImpl -> {
                     val parameter = optionBuilder.innerWrappedParameter
 
                     val resolver = resolverContainer.getResolverOfType<ICustomResolver<*, *>>(ResolverRequest(parameter, resolverData))
-                    CustomMethodOption(optionBuilder.optionParameter, resolver)
+                    CustomMethodOption(executable, optionBuilder.optionParameter, resolver)
                 }
                 else -> throwInternal("Unsupported option builder: $optionBuilder")
             }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/CustomMethodOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/CustomMethodOption.kt
@@ -1,10 +1,12 @@
 package io.github.freya022.botcommands.internal.parameters
 
+import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 
 internal class CustomMethodOption internal constructor(
+    override val executable: Executable,
     optionParameter: OptionParameter,
     val resolver: ICustomResolver<*, *>
 ) : OptionImpl(optionParameter, OptionType.CUSTOM)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/CustomMethodOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/CustomMethodOption.kt
@@ -1,12 +1,15 @@
 package io.github.freya022.botcommands.internal.parameters
 
-import io.github.freya022.botcommands.api.core.Executable
+import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 
 internal class CustomMethodOption internal constructor(
-    override val executable: Executable,
+    override val parent: AggregatedParameter,
     optionParameter: OptionParameter,
     val resolver: ICustomResolver<*, *>
-) : OptionImpl(optionParameter, OptionType.CUSTOM)
+) : OptionImpl(optionParameter, OptionType.CUSTOM) {
+
+    override val executable get() = parent.executable
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ServiceMethodOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ServiceMethodOption.kt
@@ -1,11 +1,13 @@
 package io.github.freya022.botcommands.internal.parameters
 
+import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 import io.github.freya022.botcommands.internal.core.service.tryGetWrappedService
 
 internal class ServiceMethodOption internal constructor(
+    override val executable: Executable,
     optionParameter: OptionParameter,
     private val serviceContainer: ServiceContainer,
 ) : OptionImpl(optionParameter, OptionType.SERVICE) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ServiceMethodOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/ServiceMethodOption.kt
@@ -1,16 +1,19 @@
 package io.github.freya022.botcommands.internal.parameters
 
-import io.github.freya022.botcommands.api.core.Executable
 import io.github.freya022.botcommands.api.core.service.ServiceContainer
+import io.github.freya022.botcommands.api.parameters.AggregatedParameter
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 import io.github.freya022.botcommands.internal.core.service.tryGetWrappedService
 
 internal class ServiceMethodOption internal constructor(
-    override val executable: Executable,
+    override val parent: AggregatedParameter,
     optionParameter: OptionParameter,
     private val serviceContainer: ServiceContainer,
 ) : OptionImpl(optionParameter, OptionType.SERVICE) {
+
+    override val executable get() = parent.executable
+
     private lateinit var cachedService: Any
 
     // Caches the service if:


### PR DESCRIPTION
This PR mostly makes properties visible on a larger scale, this may be useful for resolvers that don't use specific types, such as `ICustomResolver`s

### Deprecations
- Deprecated getting parameters and option by name
  - You can still use the collection methods to achieve the same result

### Changes
- Pulled up `getParameter` and `getOptionByDeclaredName` from `ICommandParameterContainer` to `Executable`
- Pulled up `command` from `CommandOption` to `Option`
- Pulled up `context` and `executable` from `CommandParameter` to `MethodParameter`

### Additions
- Added `Executable#allOptions`
- Added `Executable#allOptionsOrdered` and `AggregatedParameter#allOptionsOrdered`
  - Same as above, except the options are in the order of appearance of the the method declaration
- Added `Executable#context`
- Added `Option#parent`
  - Returns the parameter owning this option