### PR TITLE
Pass options to resolvers

### DIFF
--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/AttachmentResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/AttachmentResolver.java
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers;
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver;
@@ -28,7 +28,7 @@ public class AttachmentResolver
 
     @Nullable
     @Override
-    public Attachment resolve(@NotNull SlashCommandInfo info, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
+    public Attachment resolve(@NotNull SlashCommandOption option, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
         return optionMapping.getAsAttachment();
     }
 }

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.java
@@ -71,7 +71,7 @@ public class BooleanResolver
 
     @Nullable
     @Override
-    public Boolean resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
+    public Boolean resolve(@NotNull ComponentOption option, @NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
         return parseBoolean(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
+import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
@@ -70,7 +71,7 @@ public class BooleanResolver
 
     @Nullable
     @Override
-    public Boolean resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
+    public Boolean resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
         return parseBoolean(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
+import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
@@ -76,7 +77,7 @@ public class BooleanResolver
 
     @Nullable
     @Override
-    public Boolean resolve(@NotNull String arg) {
+    public Boolean resolve(@NotNull TimeoutOption option, @NotNull String arg) {
         return parseBoolean(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.java
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers;
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
@@ -64,7 +64,7 @@ public class BooleanResolver
 
     @Nullable
     @Override
-    public Boolean resolve(@NotNull SlashCommandInfo info, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
+    public Boolean resolve(@NotNull SlashCommandOption option, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
         return optionMapping.getAsBoolean();
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.java
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.parameters.resolvers;
 
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
@@ -35,7 +34,7 @@ public class BooleanResolver
 
     @Nullable
     @Override
-    public Boolean resolve(@NotNull TextCommandVariation variation, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
+    public Boolean resolve(@NotNull TextCommandOption option, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
         return parseBoolean(args[0]);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
+import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
@@ -78,7 +79,7 @@ public class DoubleResolver
 
     @Nullable
     @Override
-    public Double resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
+    public Double resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
         return Double.valueOf(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.java
@@ -79,7 +79,7 @@ public class DoubleResolver
 
     @Nullable
     @Override
-    public Double resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
+    public Double resolve(@NotNull ComponentOption option, @NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
         return Double.valueOf(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
+import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
@@ -84,7 +85,7 @@ public class DoubleResolver
 
     @Nullable
     @Override
-    public Double resolve(@NotNull String arg) {
+    public Double resolve(@NotNull TimeoutOption option, @NotNull String arg) {
         return Double.valueOf(arg);
     }
 }

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.java
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers;
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
@@ -68,7 +68,7 @@ public class DoubleResolver
 
     @Nullable
     @Override
-    public Double resolve(@NotNull SlashCommandInfo info, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
+    public Double resolve(@NotNull SlashCommandOption option, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
         try {
             return optionMapping.getAsDouble();
         } catch (NumberFormatException e) { //Can't have discord to send us actual input when autocompleting lmao

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.java
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.parameters.resolvers;
 
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
@@ -35,7 +34,7 @@ public class DoubleResolver
 
     @Nullable
     @Override
-    public Double resolve(@NotNull TextCommandVariation variation, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
+    public Double resolve(@NotNull TextCommandOption option, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
         try {
             return Double.valueOf(args[0]);
         } catch (NumberFormatException e) {

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.java
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers;
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
@@ -69,7 +69,7 @@ public class EmojiResolver
 
     @Nullable
     @Override
-    public Emoji resolve(@NotNull SlashCommandInfo info, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
+    public Emoji resolve(@NotNull SlashCommandOption option, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
         return getEmoji(optionMapping.getAsString());
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
+import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
@@ -81,7 +82,7 @@ public class EmojiResolver
 
     @Nullable
     @Override
-    public Emoji resolve(@NotNull String arg) {
+    public Emoji resolve(@NotNull TimeoutOption option, @NotNull String arg) {
         return getEmoji(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.java
@@ -76,7 +76,7 @@ public class EmojiResolver
 
     @Nullable
     @Override
-    public Emoji resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
+    public Emoji resolve(@NotNull ComponentOption option, @NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
         return getEmoji(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
+import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
@@ -75,7 +76,7 @@ public class EmojiResolver
 
     @Nullable
     @Override
-    public Emoji resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
+    public Emoji resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
         return getEmoji(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.java
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.parameters.resolvers;
 
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
@@ -40,7 +39,7 @@ public class EmojiResolver
 
     @Nullable
     @Override
-    public Emoji resolve(@NotNull TextCommandVariation variation, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
+    public Emoji resolve(@NotNull TextCommandOption option, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
         return getEmoji(args[0]);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.java
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers;
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
@@ -64,7 +64,7 @@ public class GuildResolver
 
     @Nullable
     @Override
-    public Guild resolve(@NotNull SlashCommandInfo info, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
+    public Guild resolve(@NotNull SlashCommandOption option, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
         return resolveGuild(event.getJDA(), optionMapping.getAsString());
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.java
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.parameters.resolvers;
 
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
@@ -35,7 +34,7 @@ public class GuildResolver
 
     @Nullable
     @Override
-    public Guild resolve(@NotNull TextCommandVariation variation, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
+    public Guild resolve(@NotNull TextCommandOption option, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
         return resolveGuild(event.getJDA(), args[0]);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
+import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
@@ -70,7 +71,7 @@ public class GuildResolver
 
     @Nullable
     @Override
-    public Guild resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
+    public Guild resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
         return resolveGuild(event.getJDA(), arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.java
@@ -70,7 +70,7 @@ public class GuildResolver
 
     @Nullable
     @Override
-    public Guild resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
+    public Guild resolve(@NotNull ComponentOption option, @NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
         return resolveGuild(event.getJDA(), arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.java
@@ -79,7 +79,7 @@ public class IntegerResolver
 
     @Nullable
     @Override
-    public Integer resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
+    public Integer resolve(@NotNull ComponentOption option, @NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
         return Integer.valueOf(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
+import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
@@ -84,7 +85,7 @@ public class IntegerResolver
 
     @Nullable
     @Override
-    public Integer resolve(@NotNull String arg) {
+    public Integer resolve(@NotNull TimeoutOption option, @NotNull String arg) {
         return Integer.valueOf(arg);
     }
 }

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.java
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.parameters.resolvers;
 
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
@@ -35,7 +34,7 @@ public class IntegerResolver
 
     @Nullable
     @Override
-    public Integer resolve(@NotNull TextCommandVariation variation, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
+    public Integer resolve(@NotNull TextCommandOption option, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
         try {
             return Integer.valueOf(args[0]);
         } catch (NumberFormatException e) {

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
+import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
@@ -78,7 +79,7 @@ public class IntegerResolver
 
     @Nullable
     @Override
-    public Integer resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
+    public Integer resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
         return Integer.valueOf(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.java
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers;
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
@@ -68,7 +68,7 @@ public class IntegerResolver
 
     @Nullable
     @Override
-    public Integer resolve(@NotNull SlashCommandInfo info, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
+    public Integer resolve(@NotNull SlashCommandOption option, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
         try {
             return optionMapping.getAsInt();
         } catch (NumberFormatException e) { //Can't have discord to send us actual input when autocompleting lmao

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
+import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
@@ -84,7 +85,7 @@ public class LongResolver
 
     @Nullable
     @Override
-    public Long resolve(@NotNull String arg) {
+    public Long resolve(@NotNull TimeoutOption option, @NotNull String arg) {
         return Long.valueOf(arg);
     }
 }

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
+import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
@@ -78,7 +79,7 @@ public class LongResolver
 
     @Nullable
     @Override
-    public Long resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
+    public Long resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
         return Long.valueOf(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.java
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.parameters.resolvers;
 
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
@@ -35,7 +34,7 @@ public class LongResolver
 
     @Nullable
     @Override
-    public Long resolve(@NotNull TextCommandVariation variation, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
+    public Long resolve(@NotNull TextCommandOption option, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
         try {
             return Long.valueOf(args[0]);
         } catch (NumberFormatException e) {

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.java
@@ -79,7 +79,7 @@ public class LongResolver
 
     @Nullable
     @Override
-    public Long resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
+    public Long resolve(@NotNull ComponentOption option, @NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
         return Long.valueOf(arg);
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.java
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers;
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
@@ -68,7 +68,7 @@ public class LongResolver
 
     @Nullable
     @Override
-    public Long resolve(@NotNull SlashCommandInfo info, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
+    public Long resolve(@NotNull SlashCommandOption option, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
         try {
             return optionMapping.getAsLong();
         } catch (NumberFormatException e) { //Can't have discord to send us actual input when autocompleting lmao

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/MessageResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/MessageResolver.java
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers;
 
-import io.github.freya022.botcommands.api.commands.application.context.message.MessageCommandInfo;
+import io.github.freya022.botcommands.api.commands.application.context.message.options.MessageContextCommandOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.MessageContextParameterResolver;
@@ -20,7 +20,7 @@ public class MessageResolver
 
     @Nullable
     @Override
-    public Message resolve(@NotNull MessageCommandInfo info, @NotNull MessageContextInteractionEvent event) {
+    public Message resolve(@NotNull MessageContextCommandOption option, @NotNull MessageContextInteractionEvent event) {
         return event.getTarget();
     }
 }

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
+import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver;
@@ -84,7 +85,7 @@ public class RoleResolver
 
     @Nullable
     @Override
-    public Role resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
+    public Role resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
         Objects.requireNonNull(event.getGuild(), "Can't get a role from DMs");
 
         return event.getGuild().getRoleById(arg);

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers;
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
@@ -78,7 +78,7 @@ public class RoleResolver
 
     @Nullable
     @Override
-    public Role resolve(@NotNull SlashCommandInfo info, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
+    public Role resolve(@NotNull SlashCommandOption option, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
         return optionMapping.getAsRole();
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
@@ -84,7 +84,7 @@ public class RoleResolver
 
     @Nullable
     @Override
-    public Role resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
+    public Role resolve(@NotNull ComponentOption option, @NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
         Objects.requireNonNull(event.getGuild(), "Can't get a role from DMs");
 
         return event.getGuild().getRoleById(arg);

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.java
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.parameters.resolvers;
 
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
@@ -39,7 +38,7 @@ public class RoleResolver
 
     @Nullable
     @Override
-    public Role resolve(@NotNull TextCommandVariation variation, @NotNull MessageReceivedEvent event, @Nullable String @NotNull [] args) {
+    public Role resolve(@NotNull TextCommandOption option, @NotNull MessageReceivedEvent event, @Nullable String @NotNull [] args) {
         final var id = args[0] != null ? args[0] : args[1];
         if (id == null) {
             ExceptionsKt.throwInternal("How can it not have either");

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
@@ -78,7 +78,7 @@ public class StringResolver
 
     @Nullable
     @Override
-    public String resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
+    public String resolve(@NotNull ComponentOption option, @NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
         return arg;
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
+import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.modals.ModalEvent;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
@@ -76,7 +77,7 @@ public class StringResolver
 
     @Nullable
     @Override
-    public String resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull String arg) {
+    public String resolve(@NotNull GenericComponentInteractionCreateEvent event, @NotNull ComponentOption option, @NotNull String arg) {
         return arg;
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.parameters.resolvers;
 
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
@@ -35,7 +34,7 @@ public class StringResolver
 
     @Nullable
     @Override
-    public String resolve(@NotNull TextCommandVariation variation, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
+    public String resolve(@NotNull TextCommandOption option, @NotNull MessageReceivedEvent event, @NotNull String @NotNull [] args) {
         return args[0];
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
@@ -7,6 +7,7 @@ import io.github.freya022.botcommands.api.components.options.ComponentOption;
 import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.modals.ModalEvent;
+import io.github.freya022.botcommands.api.modals.options.ModalOption;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
 import io.github.freya022.botcommands.api.parameters.resolvers.*;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
@@ -83,7 +84,7 @@ public class StringResolver
 
     @Nullable
     @Override
-    public String resolve(@NotNull ModalEvent event, @NotNull ModalMapping modalMapping) {
+    public String resolve(@NotNull ModalOption option, @NotNull ModalEvent event, @NotNull ModalMapping modalMapping) {
         return modalMapping.getAsString();
     }
 

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
+import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption;
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver;
 import io.github.freya022.botcommands.api.modals.ModalEvent;
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver;
@@ -88,7 +89,7 @@ public class StringResolver
 
     @NotNull
     @Override
-    public String resolve(@NotNull String arg) {
+    public String resolve(@NotNull TimeoutOption option, @NotNull String arg) {
         return arg;
     }
 }

--- a/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
+++ b/src/main/java/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.java
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers;
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo;
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption;
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent;
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption;
 import io.github.freya022.botcommands.api.components.options.ComponentOption;
@@ -70,7 +70,7 @@ public class StringResolver
 
     @Nullable
     @Override
-    public String resolve(@NotNull SlashCommandInfo info, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
+    public String resolve(@NotNull SlashCommandOption option, @NotNull CommandInteractionPayload event, @NotNull OptionMapping optionMapping) {
         return optionMapping.getAsString();
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/options/ComponentOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/options/ComponentOption.kt
@@ -1,0 +1,12 @@
+package io.github.freya022.botcommands.api.components.options
+
+import io.github.freya022.botcommands.api.components.annotations.ComponentData
+import io.github.freya022.botcommands.api.core.options.Option
+
+/**
+ * A parameter annotated with [@ComponentData][ComponentData] from a persistent component handler.
+ */
+interface ComponentOption : Option {
+
+
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/timeout/options/TimeoutOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/timeout/options/TimeoutOption.kt
@@ -1,0 +1,12 @@
+package io.github.freya022.botcommands.api.components.timeout.options
+
+import io.github.freya022.botcommands.api.components.annotations.TimeoutData
+import io.github.freya022.botcommands.api.core.options.Option
+
+/**
+ * A parameter annotated with [@TimeoutData][TimeoutData] from a persistent timeout handler.
+ */
+interface TimeoutOption : Option {
+
+
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/modals/options/ModalOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/modals/options/ModalOption.kt
@@ -1,0 +1,13 @@
+package io.github.freya022.botcommands.api.modals.options
+
+import io.github.freya022.botcommands.api.core.options.Option
+import io.github.freya022.botcommands.api.modals.annotations.ModalData
+import io.github.freya022.botcommands.api.modals.annotations.ModalHandler
+
+/**
+ * A parameter annotated with [@ModalData][ModalData] from a [modal handler][ModalHandler].
+ */
+interface ModalOption : Option {
+
+
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.api.parameters
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
@@ -70,7 +70,7 @@ internal sealed class AbstractEnumResolver<T : AbstractEnumResolver<T, E>, E : E
     }
 
     override suspend fun resolveSuspend(
-        info: SlashCommandInfo,
+        option: SlashCommandOption,
         event: CommandInteractionPayload,
         optionMapping: OptionMapping
     ): E = getEnumValue(optionMapping.asString)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
@@ -78,7 +78,7 @@ internal sealed class AbstractEnumResolver<T : AbstractEnumResolver<T, E>, E : E
     //endregion
 
     //region Component
-    override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String): E? =
+    override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): E? =
         getEnumValueOrNull(arg)
     //endregion
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver
@@ -82,7 +83,7 @@ internal sealed class AbstractEnumResolver<T : AbstractEnumResolver<T, E>, E : E
     //endregion
 
     //region Timeout
-    override suspend fun resolveSuspend(arg: String): E = getEnumValue(arg)
+    override suspend fun resolveSuspend(option: TimeoutOption, arg: String): E = getEnumValue(arg)
     //endregion
 
     override fun toString(): String {

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.api.parameters
 
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
@@ -35,7 +34,7 @@ internal class TextEnumResolver<E : Enum<E>> internal constructor(
     override fun getHelpExample(option: TextCommandOption, event: BaseCommandEvent): String = testExample
 
     override suspend fun resolveSuspend(
-        variation: TextCommandVariation,
+        option: TextCommandOption,
         event: MessageReceivedEvent,
         args: Array<String?>,
     ): E? = getEnumValueOrNull(args[0]!!)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
+import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.TextParameterResolver
@@ -77,7 +78,7 @@ internal sealed class AbstractEnumResolver<T : AbstractEnumResolver<T, E>, E : E
     //endregion
 
     //region Component
-    override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, arg: String): E? =
+    override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String): E? =
         getEnumValueOrNull(arg)
     //endregion
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolverFactory.kt
@@ -38,7 +38,7 @@ import kotlin.reflect.KType
  * @see ParameterResolver
  */
 @InterfacedService(acceptMultiple = true)
-abstract class ParameterResolverFactory<T : IParameterResolver<T>>(val resolverType: KClass<out T>) {
+abstract class ParameterResolverFactory<out T : IParameterResolver<T>>(val resolverType: KClass<out T>) {
     constructor(resolverType: Class<out T>) : this(resolverType.kotlin)
 
     /**

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/TypedParameterResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/TypedParameterResolverFactory.kt
@@ -22,14 +22,14 @@ import kotlin.reflect.full.withNullability
  * @param type         Type of the objects returned by the parameter resolver
  * @param T            Type of the returned parameter resolver
  */
-abstract class TypedParameterResolverFactory<T : IParameterResolver<T>>(
+abstract class TypedParameterResolverFactory<out T : IParameterResolver<T>>(
     resolverType: KClass<out T>,
     val type: KType
 ) : ParameterResolverFactory<T>(resolverType) {
     override val supportedTypesStr: List<String> = listOf(type.simpleNestedName)
 
-    constructor(resolverType: KClass<T>, type: KClass<*>) : this(resolverType, type.starProjectedType)
-    constructor(resolverType: Class<T>, type: Class<*>) : this(resolverType.kotlin, type.kotlin.starProjectedType)
+    constructor(resolverType: KClass<out T>, type: KClass<*>) : this(resolverType, type.starProjectedType)
+    constructor(resolverType: Class<out T>, type: Class<*>) : this(resolverType.kotlin, type.kotlin.starProjectedType)
 
     init {
         require(!type.isMarkedNullable) {

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
@@ -3,6 +3,7 @@ package io.github.freya022.botcommands.api.parameters.resolvers
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
 import io.github.freya022.botcommands.api.components.annotations.JDASelectMenuListener
 import io.github.freya022.botcommands.api.components.builder.IPersistentActionableComponent
+import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
 import kotlin.reflect.KParameter
@@ -17,9 +18,11 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
+@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
 interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
         where T : ParameterResolver<T, R>,
               T : ComponentParameterResolver<T, R> {
+
     /**
      * Returns a resolved object from this component interaction.
      *
@@ -27,9 +30,14 @@ interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
      * or [optional][KParameter.isOptional], the handler is ignored,
      * but the interaction **must** be acknowledged.
      *
-     * @param event      The corresponding event
-     * @param arg        One of the data passed by the user in [IPersistentActionableComponent.bindTo]
+     * @param event  The corresponding event
+     * @param option The option currently being resolved
+     * @param arg    One of the data passed by the user in [IPersistentActionableComponent.bindTo]
      */
+    fun resolve(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String): R? =
+        resolve(event, arg)
+
+    @Deprecated("Added a ComponentOption parameter")
     fun resolve(event: GenericComponentInteractionCreateEvent, arg: String): R? =
         throw NotImplementedError("${this.javaClass.simpleName} must implement the 'resolve' or 'resolveSuspend' method")
 
@@ -40,9 +48,15 @@ interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
      * or [optional][KParameter.isOptional], the handler is ignored,
      * but the interaction **must** be acknowledged.
      *
-     * @param event      The corresponding event
-     * @param arg        One of the data passed by the user in [IPersistentActionableComponent.bindTo]
+     * @param event  The corresponding event
+     * @param option The option currently being resolved
+     * @param arg    One of the data passed by the user in [IPersistentActionableComponent.bindTo]
      */
+    @JvmSynthetic
+    suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String) =
+        resolveSuspend(event, arg)
+
+    @Deprecated("Added a ComponentOption parameter")
     @JvmSynthetic
     suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, arg: String) =
         resolve(event, arg)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
@@ -30,11 +30,11 @@ interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
      * or [optional][KParameter.isOptional], the handler is ignored,
      * but the interaction **must** be acknowledged.
      *
-     * @param event  The corresponding event
      * @param option The option currently being resolved
+     * @param event  The corresponding event
      * @param arg    One of the data passed by the user in [IPersistentActionableComponent.bindTo]
      */
-    fun resolve(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String): R? =
+    fun resolve(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): R? =
         resolve(event, arg)
 
     @Deprecated("Added a ComponentOption parameter")
@@ -48,13 +48,13 @@ interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
      * or [optional][KParameter.isOptional], the handler is ignored,
      * but the interaction **must** be acknowledged.
      *
-     * @param event  The corresponding event
      * @param option The option currently being resolved
+     * @param event  The corresponding event
      * @param arg    One of the data passed by the user in [IPersistentActionableComponent.bindTo]
      */
     @JvmSynthetic
-    suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String) =
-        resolve(event, option, arg)
+    suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String) =
+        resolve(option, event, arg)
 
     @Deprecated("Added a ComponentOption parameter")
     @JvmSynthetic

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
@@ -54,7 +54,7 @@ interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
      */
     @JvmSynthetic
     suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String) =
-        resolveSuspend(event, arg)
+        resolve(event, option, arg)
 
     @Deprecated("Added a ComponentOption parameter")
     @JvmSynthetic

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ICustomResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ICustomResolver.kt
@@ -1,6 +1,7 @@
 package io.github.freya022.botcommands.api.parameters.resolvers
 
 import io.github.freya022.botcommands.api.core.Executable
+import io.github.freya022.botcommands.api.core.options.Option
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import net.dv8tion.jda.api.events.Event
 
@@ -12,6 +13,7 @@ import net.dv8tion.jda.api.events.Event
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
+@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
 interface ICustomResolver<T, R : Any> : IParameterResolver<T>
         where T : ParameterResolver<T, R>,
               T : ICustomResolver<T, R> {
@@ -24,10 +26,13 @@ interface ICustomResolver<T, R : Any> : IParameterResolver<T>
      * [SlashParameterResolver][SlashParameterResolver.resolve] or
      * [ComponentParameterResolver][ComponentParameterResolver.resolve].
      *
-     * @param executable Basic information about the function using this resolver,
-     * may be any application command, text command, etc...
-     * @param event      The event this resolver is called from
+     * @param option The option currently being resolved, may be from an application command, text command, etc...
+     * @param event  The event triggering this resolver
      */
+    fun resolve(option: Option, event: Event): R? =
+        resolve(option.executable, event)
+
+    @Deprecated("First parameter was replaced with Option")
     fun resolve(executable: Executable, event: Event): R? =
         throw NotImplementedError("${this.javaClass.simpleName} must implement the 'resolve' or 'resolveSuspend' method")
 
@@ -39,10 +44,15 @@ interface ICustomResolver<T, R : Any> : IParameterResolver<T>
      * [SlashParameterResolver][SlashParameterResolver.resolveSuspend] or
      * [ComponentParameterResolver][ComponentParameterResolver.resolveSuspend].
      *
-     * @param executable Basic information about the function using this resolver
-     * @param event      The event this resolver is called from
+     * @param option The option currently being resolved, may be from an application command, text command, etc...
+     * @param event  The event triggering this resolver
      */
     @JvmSynthetic
+    suspend fun resolveSuspend(option: Option, event: Event) =
+        resolveSuspend(option.executable, event)
+
+    @JvmSynthetic
+    @Deprecated("First parameter was replaced with Option")
     suspend fun resolveSuspend(executable: Executable, event: Event) =
         resolve(executable, event)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/MessageContextParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/MessageContextParameterResolver.kt
@@ -48,7 +48,7 @@ interface MessageContextParameterResolver<T, R : Any> : IParameterResolver<T>
      */
     @JvmSynthetic
     suspend fun resolveSuspend(option: MessageContextCommandOption, event: MessageContextInteractionEvent) =
-        resolveSuspend(option.executable, event)
+        resolve(option, event)
 
     @Deprecated("Replaced MessageCommandInfo with MessageContextCommandOption")
     @JvmSynthetic

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/MessageContextParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/MessageContextParameterResolver.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.api.parameters.resolvers
 
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAMessageCommand
 import io.github.freya022.botcommands.api.commands.application.context.message.MessageCommandInfo
+import io.github.freya022.botcommands.api.commands.application.context.message.options.MessageContextCommandOption
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 import kotlin.reflect.KParameter
@@ -15,18 +16,24 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
+@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
 interface MessageContextParameterResolver<T, R : Any> : IParameterResolver<T>
         where T : ParameterResolver<T, R>,
               T : MessageContextParameterResolver<T, R> {
+
     /**
      * Returns a resolved object from this message context interaction.
      *
      * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
-     * @param info  The data of the command being executed
-     * @param event The corresponding event
+     * @param option The option currently being resolved
+     * @param event  The corresponding event
      */
+    fun resolve(option: MessageContextCommandOption, event: MessageContextInteractionEvent): R? =
+        resolve(option.executable, event)
+
+    @Deprecated("Replaced MessageCommandInfo with MessageContextCommandOption")
     fun resolve(info: MessageCommandInfo, event: MessageContextInteractionEvent): R? =
         throw NotImplementedError("${this.javaClass.simpleName} must implement the 'resolve' or 'resolveSuspend' method")
 
@@ -36,9 +43,14 @@ interface MessageContextParameterResolver<T, R : Any> : IParameterResolver<T>
      * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
-     * @param info  The data of the command being executed
-     * @param event The corresponding event
+     * @param option The option currently being resolved
+     * @param event  The corresponding event
      */
+    @JvmSynthetic
+    suspend fun resolveSuspend(option: MessageContextCommandOption, event: MessageContextInteractionEvent) =
+        resolveSuspend(option.executable, event)
+
+    @Deprecated("Replaced MessageCommandInfo with MessageContextCommandOption")
     @JvmSynthetic
     suspend fun resolveSuspend(info: MessageCommandInfo, event: MessageContextInteractionEvent) =
         resolve(info, event)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ModalParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ModalParameterResolver.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.api.parameters.resolvers
 
 import io.github.freya022.botcommands.api.modals.ModalEvent
 import io.github.freya022.botcommands.api.modals.annotations.ModalHandler
+import io.github.freya022.botcommands.api.modals.options.ModalOption
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import net.dv8tion.jda.api.interactions.modals.ModalMapping
 import kotlin.reflect.KParameter
@@ -15,6 +16,7 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
+@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
 interface ModalParameterResolver<T, R : Any> : IParameterResolver<T>
         where T : ParameterResolver<T, R>,
               T : ModalParameterResolver<T, R> {
@@ -24,9 +26,14 @@ interface ModalParameterResolver<T, R : Any> : IParameterResolver<T>
      * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
+     * @param option       The option currently being resolved
      * @param event        The corresponding event
      * @param modalMapping The [ModalMapping] to be resolved
      */
+    fun resolve(option: ModalOption, event: ModalEvent, modalMapping: ModalMapping): R? =
+        resolve(event, modalMapping)
+
+    @Deprecated("Added a TimeoutOption parameter")
     fun resolve(event: ModalEvent, modalMapping: ModalMapping): R? =
         throw NotImplementedError("${this.javaClass.simpleName} must implement the 'resolve' or 'resolveSuspend' method")
 
@@ -36,10 +43,16 @@ interface ModalParameterResolver<T, R : Any> : IParameterResolver<T>
      * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
+     * @param option       The option currently being resolved
      * @param event        The corresponding event
      * @param modalMapping The [ModalMapping] to be resolved
      */
     @JvmSynthetic
+    suspend fun resolveSuspend(option: ModalOption, event: ModalEvent, modalMapping: ModalMapping) =
+        resolveSuspend(event, modalMapping)
+
+    @JvmSynthetic
+    @Deprecated("Added a TimeoutOption parameter")
     suspend fun resolveSuspend(event: ModalEvent, modalMapping: ModalMapping) =
         resolve(event, modalMapping)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ModalParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ModalParameterResolver.kt
@@ -49,7 +49,7 @@ interface ModalParameterResolver<T, R : Any> : IParameterResolver<T>
      */
     @JvmSynthetic
     suspend fun resolveSuspend(option: ModalOption, event: ModalEvent, modalMapping: ModalMapping) =
-        resolveSuspend(event, modalMapping)
+        resolve(option, event, modalMapping)
 
     @JvmSynthetic
     @Deprecated("Added a TimeoutOption parameter")

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/SlashParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/SlashParameterResolver.kt
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.annotations.AutocompleteHandler
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption
 import io.github.freya022.botcommands.api.commands.application.slash.options.builder.SlashCommandOptionBuilder
 import io.github.freya022.botcommands.api.localization.DefaultMessages
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
@@ -26,9 +27,11 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
+@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
 interface SlashParameterResolver<T, R : Any> : IParameterResolver<T>
         where T : ParameterResolver<T, R>,
               T : SlashParameterResolver<T, R> {
+
     /**
      * Returns the corresponding [OptionType] for this slash command parameter.
      */
@@ -58,10 +61,14 @@ interface SlashParameterResolver<T, R : Any> : IParameterResolver<T>
      * If the interaction is not replied to,
      * the handler sends an [unresolvable option error message][DefaultMessages.getSlashCommandUnresolvableOptionMsg].
      *
-     * @param info          The data of the command being executed
+     * @param option        The option currently being resolved
      * @param event         The corresponding event, could be a [SlashCommandInteractionEvent] or a [CommandAutoCompleteInteractionEvent]
      * @param optionMapping The [OptionMapping] to be resolved
      */
+    fun resolve(option: SlashCommandOption, event: CommandInteractionPayload, optionMapping: OptionMapping): R? =
+        resolve(option.executable, event, optionMapping)
+
+    @Deprecated("Replaced SlashCommandInfo with SlashCommandOption")
     fun resolve(info: SlashCommandInfo, event: CommandInteractionPayload, optionMapping: OptionMapping): R? =
         throw NotImplementedError("${this.javaClass.simpleName} must implement the 'resolve' or 'resolveSuspend' method")
 
@@ -75,11 +82,16 @@ interface SlashParameterResolver<T, R : Any> : IParameterResolver<T>
      * If the interaction is not replied to,
      * the handler sends an [unresolvable option error message][DefaultMessages.getSlashCommandUnresolvableOptionMsg].
      *
-     * @param info          The data of the command being executed
+     * @param option        The option currently being resolved
      * @param event         The corresponding event, could be a [SlashCommandInteractionEvent] or a [CommandAutoCompleteInteractionEvent]
      * @param optionMapping The [OptionMapping] to be resolved
      */
     @JvmSynthetic
+    suspend fun resolveSuspend(option: SlashCommandOption, event: CommandInteractionPayload, optionMapping: OptionMapping) =
+        resolveSuspend(option.executable, event, optionMapping)
+
+    @JvmSynthetic
+    @Deprecated("Replaced SlashCommandInfo with SlashCommandOption")
     suspend fun resolveSuspend(info: SlashCommandInfo, event: CommandInteractionPayload, optionMapping: OptionMapping) =
         resolve(info, event, optionMapping)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/SlashParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/SlashParameterResolver.kt
@@ -88,7 +88,7 @@ interface SlashParameterResolver<T, R : Any> : IParameterResolver<T>
      */
     @JvmSynthetic
     suspend fun resolveSuspend(option: SlashCommandOption, event: CommandInteractionPayload, optionMapping: OptionMapping) =
-        resolveSuspend(option.executable, event, optionMapping)
+        resolve(option, event, optionMapping)
 
     @JvmSynthetic
     @Deprecated("Replaced SlashCommandInfo with SlashCommandOption")

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TextParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TextParameterResolver.kt
@@ -18,9 +18,11 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
+@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
 interface TextParameterResolver<T, R : Any> : IParameterResolver<T>
         where T : ParameterResolver<T, R>,
               T : TextParameterResolver<T, R> {
+
     /**
      * Returns a resolved object from this text command.
      *
@@ -29,10 +31,14 @@ interface TextParameterResolver<T, R : Any> : IParameterResolver<T>
      *
      * See the [@JDATextCommandVariation][JDATextCommandVariation] documentation for more details about text command variations.
      *
-     * @param variation The text command variation being executed
-     * @param event     The corresponding event
-     * @param args      The arguments of this parameter, extracted with [pattern]
+     * @param option The option currently being resolved
+     * @param event  The corresponding event
+     * @param args   The arguments of this parameter, extracted with [pattern]
      */
+    fun resolve(option: TextCommandOption, event: MessageReceivedEvent, args: Array<String?>): R? =
+        resolve(option.executable, event, args)
+
+    @Deprecated("Replaced TextCommandVariation with TextCommandOption")
     fun resolve(variation: TextCommandVariation, event: MessageReceivedEvent, args: Array<String?>): R? =
         throw NotImplementedError("${this.javaClass.simpleName} must implement the 'resolve' or 'resolveSuspend' method")
 
@@ -44,10 +50,15 @@ interface TextParameterResolver<T, R : Any> : IParameterResolver<T>
      *
      * See the [@JDATextCommandVariation][JDATextCommandVariation] documentation for more details about text command variations.
      *
-     * @param variation The text command variation being executed
-     * @param event     The corresponding event
-     * @param args      The arguments of this parameter, extracted with [pattern]
+     * @param option The option currently being resolved
+     * @param event  The corresponding event
+     * @param args   The arguments of this parameter, extracted with [pattern]
      */
+    @JvmSynthetic
+    suspend fun resolveSuspend(option: TextCommandOption, event: MessageReceivedEvent, args: Array<String?>) =
+        resolveSuspend(option.executable, event, args)
+
+    @Deprecated("Replaced TextCommandVariation with TextCommandOption")
     @JvmSynthetic
     suspend fun resolveSuspend(variation: TextCommandVariation, event: MessageReceivedEvent, args: Array<String?>) =
         resolve(variation, event, args)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TextParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TextParameterResolver.kt
@@ -56,7 +56,7 @@ interface TextParameterResolver<T, R : Any> : IParameterResolver<T>
      */
     @JvmSynthetic
     suspend fun resolveSuspend(option: TextCommandOption, event: MessageReceivedEvent, args: Array<String?>) =
-        resolveSuspend(option.executable, event, args)
+        resolve(option, event, args)
 
     @Deprecated("Replaced TextCommandVariation with TextCommandOption")
     @JvmSynthetic

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TimeoutParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TimeoutParameterResolver.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.api.parameters.resolvers
 
 import io.github.freya022.botcommands.api.components.annotations.ComponentTimeoutHandler
 import io.github.freya022.botcommands.api.components.annotations.GroupTimeoutHandler
+import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
@@ -14,6 +15,7 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
+@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
 interface TimeoutParameterResolver<T, R : Any> : IParameterResolver<T>
         where T : ParameterResolver<T, R>,
               T : TimeoutParameterResolver<T, R> {
@@ -24,8 +26,13 @@ interface TimeoutParameterResolver<T, R : Any> : IParameterResolver<T>
      * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
      * or [optional][KParameter.isOptional], the handler is ignored.
      *
-     * @param arg The argument to be resolved
+     * @param option The option currently being resolved
+     * @param arg    The argument to be resolved
      */
+    fun resolve(option: TimeoutOption, arg: String): R? =
+        resolve(arg)
+
+    @Deprecated("Added a TimeoutOption parameter")
     fun resolve(arg: String): R? =
         throw NotImplementedError("${this.javaClass.simpleName} must implement the 'resolve' or 'resolveSuspend' method")
 
@@ -35,9 +42,15 @@ interface TimeoutParameterResolver<T, R : Any> : IParameterResolver<T>
      * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
      * or [optional][KParameter.isOptional], the handler is ignored.
      *
-     * @param arg The argument to be resolved
+     * @param option The option currently being resolved
+     * @param arg    The argument to be resolved
      */
     @JvmSynthetic
+    suspend fun resolveSuspend(option: TimeoutOption, arg: String): R? =
+        resolveSuspend(arg)
+
+    @JvmSynthetic
+    @Deprecated("Added a TimeoutOption parameter")
     suspend fun resolveSuspend(arg: String): R? =
         resolve(arg)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TimeoutParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TimeoutParameterResolver.kt
@@ -47,7 +47,7 @@ interface TimeoutParameterResolver<T, R : Any> : IParameterResolver<T>
      */
     @JvmSynthetic
     suspend fun resolveSuspend(option: TimeoutOption, arg: String): R? =
-        resolveSuspend(arg)
+        resolve(option, arg)
 
     @JvmSynthetic
     @Deprecated("Added a TimeoutOption parameter")

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/UserContextParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/UserContextParameterResolver.kt
@@ -48,7 +48,7 @@ interface UserContextParameterResolver<T, R : Any> : IParameterResolver<T>
      */
     @JvmSynthetic
     suspend fun resolveSuspend(option: UserContextCommandOption, event: UserContextInteractionEvent) =
-        resolveSuspend(option.executable, event)
+        resolve(option, event)
 
     @Deprecated("Replaced UserCommandInfo with UserContextCommandOption")
     @JvmSynthetic

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/UserContextParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/UserContextParameterResolver.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.api.parameters.resolvers
 
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAUserCommand
 import io.github.freya022.botcommands.api.commands.application.context.user.UserCommandInfo
+import io.github.freya022.botcommands.api.commands.application.context.user.options.UserContextCommandOption
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEvent
 import kotlin.reflect.KParameter
@@ -15,18 +16,24 @@ import kotlin.reflect.KType
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  */
+@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
 interface UserContextParameterResolver<T, R : Any> : IParameterResolver<T>
         where T : ParameterResolver<T, R>,
               T : UserContextParameterResolver<T, R> {
+
     /**
      * Returns a resolved object from this user context interaction.
      *
      * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
-     * @param info  The data of the command being executed
-     * @param event The corresponding event
+     * @param option The option currently being resolved
+     * @param event  The corresponding event
      */
+    fun resolve(option: UserContextCommandOption, event: UserContextInteractionEvent): R? =
+        resolve(option.executable, event)
+
+    @Deprecated("Replaced UserCommandInfo with UserContextCommandOption")
     fun resolve(info: UserCommandInfo, event: UserContextInteractionEvent): R? =
         throw NotImplementedError("${this.javaClass.simpleName} must implement the 'resolve' or 'resolveSuspend' method")
 
@@ -36,9 +43,14 @@ interface UserContextParameterResolver<T, R : Any> : IParameterResolver<T>
      * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
-     * @param info  The data of the command being executed
-     * @param event The corresponding event
+     * @param option The option currently being resolved
+     * @param event  The corresponding event
      */
+    @JvmSynthetic
+    suspend fun resolveSuspend(option: UserContextCommandOption, event: UserContextInteractionEvent) =
+        resolveSuspend(option.executable, event)
+
+    @Deprecated("Replaced UserCommandInfo with UserContextCommandOption")
     @JvmSynthetic
     suspend fun resolveSuspend(info: UserCommandInfo, event: UserContextInteractionEvent) =
         resolve(info, event)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfoImpl.kt
@@ -77,7 +77,7 @@ internal class MessageCommandInfoImpl internal constructor(
             OptionType.OPTION -> {
                 option as MessageContextCommandOptionImpl
 
-                option.resolver.resolveSuspend(this, event)
+                option.resolver.resolveSuspend(option, event)
             }
             OptionType.CUSTOM -> {
                 option as CustomMethodOption

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/message/MessageCommandInfoImpl.kt
@@ -82,7 +82,7 @@ internal class MessageCommandInfoImpl internal constructor(
             OptionType.CUSTOM -> {
                 option as CustomMethodOption
 
-                option.resolver.resolveSuspend(this, event)
+                option.resolver.resolveSuspend(option, event)
             }
             OptionType.GENERATED -> {
                 option as ApplicationGeneratedOption

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfoImpl.kt
@@ -82,7 +82,7 @@ internal class UserCommandInfoImpl internal constructor(
             OptionType.CUSTOM -> {
                 option as CustomMethodOption
 
-                option.resolver.resolveSuspend(this, event)
+                option.resolver.resolveSuspend(option, event)
             }
             OptionType.GENERATED -> {
                 option as ApplicationGeneratedOption

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/context/user/UserCommandInfoImpl.kt
@@ -77,7 +77,7 @@ internal class UserCommandInfoImpl internal constructor(
             OptionType.OPTION -> {
                 option as UserContextCommandOptionImpl
 
-                option.resolver.resolveSuspend(this, event)
+                option.resolver.resolveSuspend(option, event)
             }
             OptionType.CUSTOM -> {
                 option as CustomMethodOption

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandInfoImpl.kt
@@ -123,7 +123,7 @@ internal sealed class SlashCommandInfoImpl(
             OptionType.CUSTOM -> {
                 option as CustomMethodOption
 
-                option.resolver.resolveSuspend(this, event)
+                option.resolver.resolveSuspend(option, event)
             }
             OptionType.GENERATED -> {
                 option as ApplicationGeneratedOption

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandInfoImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashCommandInfoImpl.kt
@@ -110,7 +110,7 @@ internal sealed class SlashCommandInfoImpl(
                 val optionMapping = event.getOption(optionName)
 
                 if (optionMapping != null) {
-                    option.resolver.resolveSuspend(this, event, optionMapping)
+                    option.resolver.resolveSuspend(option, event, optionMapping)
                         ?: return onUnresolvableOption(option, optionMapping, event)
                 } else if (option.isRequired && event is CommandAutoCompleteInteractionEvent) {
                     return InsertOptionResult.ABORT

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandVariationImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandVariationImpl.kt
@@ -117,7 +117,7 @@ internal class TextCommandVariationImpl internal constructor(
             OptionType.CUSTOM -> {
                 option as CustomMethodOption
 
-                option.resolver.resolveSuspend(this, event)
+                option.resolver.resolveSuspend(option, event)
             }
 
             OptionType.GENERATED -> {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandVariationImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandVariationImpl.kt
@@ -111,7 +111,7 @@ internal class TextCommandVariationImpl internal constructor(
                 option as TextCommandOptionImpl
 
                 val groups: Array<String?> = Array(option.groupCount) { groupsIterator.next()?.value }
-                option.resolver.resolveSuspend(this, event, groups)
+                option.resolver.resolveSuspend(option, event, groups)
             }
 
             OptionType.CUSTOM -> {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerExecutor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerExecutor.kt
@@ -118,7 +118,7 @@ internal class ComponentHandlerExecutor internal constructor(
             OptionType.OPTION -> {
                 option as ComponentHandlerOption
 
-                val obj = userDataIterator.next()?.let { option.resolver.resolveSuspend(event, option, it) }
+                val obj = userDataIterator.next()?.let { option.resolver.resolveSuspend(option, event, it) }
                 if (obj == null && option.isRequired && event.isAcknowledged)
                     return InsertOptionResult.ABORT
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerExecutor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerExecutor.kt
@@ -84,7 +84,7 @@ internal class ComponentHandlerExecutor internal constructor(
 
         with(descriptor) {
             val optionValues = parameters.mapOptions { option ->
-                if (tryInsertOption(event, descriptor, option, this, userDataIterator) == InsertOptionResult.ABORT)
+                if (tryInsertOption(event, option, this, userDataIterator) == InsertOptionResult.ABORT)
                     return false
             }
 
@@ -110,7 +110,6 @@ internal class ComponentHandlerExecutor internal constructor(
 
     private suspend fun tryInsertOption(
         event: GenericComponentInteractionCreateEvent,
-        descriptor: ComponentDescriptor,
         option: OptionImpl,
         optionMap: MutableMap<OptionImpl, Any?>,
         userDataIterator: Iterator<String?>
@@ -119,7 +118,7 @@ internal class ComponentHandlerExecutor internal constructor(
             OptionType.OPTION -> {
                 option as ComponentHandlerOption
 
-                val obj = userDataIterator.next()?.let { option.resolver.resolveSuspend(event, it) }
+                val obj = userDataIterator.next()?.let { option.resolver.resolveSuspend(event, option, it) }
                 if (obj == null && option.isRequired && event.isAcknowledged)
                     return InsertOptionResult.ABORT
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerExecutor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerExecutor.kt
@@ -128,7 +128,7 @@ internal class ComponentHandlerExecutor internal constructor(
             OptionType.CUSTOM -> {
                 option as CustomMethodOption
 
-                option.resolver.resolveSuspend(descriptor, event)
+                option.resolver.resolveSuspend(option, event)
             }
             OptionType.SERVICE -> (option as ServiceMethodOption).getService()
             OptionType.GENERATED, OptionType.CONSTANT -> throwInternal("${option.optionType} has not been implemented")

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentTimeoutExecutor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentTimeoutExecutor.kt
@@ -92,7 +92,7 @@ internal class ComponentTimeoutExecutor internal constructor(
             OptionType.OPTION -> {
                 option as TimeoutHandlerOption
 
-                userDataIterator.next()?.let { option.resolver.resolveSuspend(it) }
+                userDataIterator.next()?.let { option.resolver.resolveSuspend(option, it) }
             }
 
             OptionType.SERVICE -> (option as ServiceMethodOption).getService()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/options/ComponentHandlerOption.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.internal.components.handler.options
 
+import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 import io.github.freya022.botcommands.internal.components.handler.options.builder.ComponentHandlerOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
@@ -9,7 +10,8 @@ internal class ComponentHandlerOption internal constructor(
     override val parent: ComponentHandlerParameterImpl,
     optionBuilder: ComponentHandlerOptionBuilderImpl,
     internal val resolver: ComponentParameterResolver<*, *>
-) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION) {
+) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION),
+    ComponentOption {
 
     override val executable get() = parent.executable
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/timeout/options/TimeoutHandlerOption.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.internal.components.timeout.options
 
+import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
 import io.github.freya022.botcommands.internal.components.timeout.options.builder.TimeoutHandlerOptionBuilderImpl
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
@@ -9,7 +10,8 @@ internal class TimeoutHandlerOption internal constructor(
     override val parent: TimeoutHandlerParameter,
     optionBuilder: TimeoutHandlerOptionBuilderImpl,
     val resolver: TimeoutParameterResolver<*, *>
-) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION) {
+) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION),
+    TimeoutOption {
 
     override val executable get() = parent.executable
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
@@ -117,7 +117,7 @@ internal class ModalHandlerInfo internal constructor(
                 val modalMapping = event.getValue(ModalMaps.getInputId(inputId))
                     ?: throwUser("Modal input ID '$inputId' was not found on the event")
 
-                option.resolver.resolveSuspend(event, modalMapping).also { obj ->
+                option.resolver.resolveSuspend(option, event, modalMapping).also { obj ->
                     // Technically not required, but provides additional info
                     requireUser(obj != null || option.isOptionalOrNullable) {
                         "The parameter '${option.declaredName}' of value '${modalMapping.asString}' could not be resolved into a ${option.type.simpleNestedName}"

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalHandlerInfo.kt
@@ -143,7 +143,7 @@ internal class ModalHandlerInfo internal constructor(
 
             OptionType.CUSTOM -> {
                 option as CustomMethodOption
-                option.resolver.resolveSuspend(this, event)
+                option.resolver.resolveSuspend(option, event)
             }
 
             OptionType.SERVICE -> (option as ServiceMethodOption).getService()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerOption.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/modals/options/ModalHandlerOption.kt
@@ -1,9 +1,11 @@
 package io.github.freya022.botcommands.internal.modals.options
 
+import io.github.freya022.botcommands.api.modals.options.ModalOption
 import io.github.freya022.botcommands.internal.core.options.OptionImpl
 import io.github.freya022.botcommands.internal.core.options.OptionType
 import io.github.freya022.botcommands.internal.core.options.builder.OptionBuilderImpl
 
 internal abstract class ModalHandlerOption internal constructor(
     optionBuilder: OptionBuilderImpl
-) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION)
+) : OptionImpl(optionBuilder.optionParameter, OptionType.OPTION),
+    ModalOption

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
@@ -69,7 +69,7 @@ internal sealed class AbstractUserSnowflakeResolver<T : AbstractUserSnowflakeRes
         optionMapping: OptionMapping
     ): R? = transformEntities(optionMapping.asUser, optionMapping.asMember)
 
-    final override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String): R? {
+    final override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): R? {
         val id = arg.toLongOrNull() ?: throwArgument("Invalid user id: $arg")
         val entity = retrieveOrNull(id, event.message)
         if (entity == null)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
@@ -4,7 +4,6 @@ import dev.minn.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.application.context.user.options.UserContextCommandOption
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.core.BContext
@@ -54,7 +53,7 @@ internal sealed class AbstractUserSnowflakeResolver<T : AbstractUserSnowflakeRes
     final override val optionType: OptionType = OptionType.USER
 
     final override suspend fun resolveSuspend(
-        variation: TextCommandVariation,
+        option: TextCommandOption,
         event: MessageReceivedEvent,
         args: Array<String?>
     ): R? {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
@@ -2,7 +2,7 @@ package io.github.freya022.botcommands.internal.parameters.resolvers
 
 import dev.minn.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.application.context.user.options.UserContextCommandOption
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
@@ -63,8 +63,8 @@ internal sealed class AbstractUserSnowflakeResolver<T : AbstractUserSnowflakeRes
         return retrieveOrNull(id, event.message)
     }
 
-    final override fun resolve(
-        info: SlashCommandInfo,
+    final override suspend fun resolveSuspend(
+        option: SlashCommandOption,
         event: CommandInteractionPayload,
         optionMapping: OptionMapping
     ): R? = transformEntities(optionMapping.asUser, optionMapping.asMember)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
@@ -6,6 +6,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
+import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.traceNull
@@ -69,7 +70,7 @@ internal sealed class AbstractUserSnowflakeResolver<T : AbstractUserSnowflakeRes
         optionMapping: OptionMapping
     ): R? = transformEntities(optionMapping.asUser, optionMapping.asMember)
 
-    final override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, arg: String): R? {
+    final override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String): R? {
         val id = arg.toLongOrNull() ?: throwArgument("Invalid user id: $arg")
         val entity = retrieveOrNull(id, event.message)
         if (entity == null)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
@@ -1,7 +1,7 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers
 
 import dev.minn.jda.ktx.messages.reply_
-import io.github.freya022.botcommands.api.commands.application.context.user.UserCommandInfo
+import io.github.freya022.botcommands.api.commands.application.context.user.options.UserContextCommandOption
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
@@ -79,7 +79,7 @@ internal sealed class AbstractUserSnowflakeResolver<T : AbstractUserSnowflakeRes
         return entity
     }
 
-    final override fun resolve(info: UserCommandInfo, event: UserContextInteractionEvent): R? =
+    final override fun resolve(option: UserContextCommandOption, event: UserContextInteractionEvent): R? =
         transformEntities(event.target, event.targetMember)
 
     private suspend fun retrieveOrNull(userId: Long, message: Message): R? {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -106,7 +106,7 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
         //endregion
 
         //region Component
-        override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String): GuildChannel? {
+        override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): GuildChannel? {
             val guild = event.guild ?: throwArgument("Cannot resolve a channel outside of a guild")
             val channelId = arg.toLong()
             val channel = guild.getChannelById(type, channelId)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -7,6 +7,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
+import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.exceptions.InvalidChannelTypeException
 import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
@@ -106,7 +107,7 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
         //endregion
 
         //region Component
-        override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, arg: String): GuildChannel? {
+        override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String): GuildChannel? {
             val guild = event.guild ?: throwArgument("Cannot resolve a channel outside of a guild")
             val channelId = arg.toLong()
             val channel = guild.getChannelById(type, channelId)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -2,8 +2,8 @@ package io.github.freya022.botcommands.internal.parameters.resolvers
 
 import dev.minn.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.application.checkGuildOnly
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.ChannelTypes
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
@@ -92,7 +92,7 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
         override val optionType: OptionType = OptionType.CHANNEL
 
         override suspend fun resolveSuspend(
-            info: SlashCommandInfo,
+            option: SlashCommandOption,
             event: CommandInteractionPayload,
             optionMapping: OptionMapping
         ): GuildChannel {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -5,7 +5,6 @@ import io.github.freya022.botcommands.api.commands.application.checkGuildOnly
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.ChannelTypes
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.core.BContext
@@ -72,7 +71,7 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
             event.channel.asMention
 
         override suspend fun resolveSuspend(
-            variation: TextCommandVariation,
+            option: TextCommandOption,
             event: MessageReceivedEvent,
             args: Array<String?>
         ): GuildChannel? {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IMentionableResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IMentionableResolver.kt
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
@@ -74,7 +74,7 @@ internal object IMentionableResolver : ClassParameterResolver<IMentionableResolv
     override val optionType: OptionType = OptionType.MENTIONABLE
 
     override suspend fun resolveSuspend(
-        info: SlashCommandInfo,
+        option: SlashCommandOption,
         event: CommandInteractionPayload,
         optionMapping: OptionMapping
     ): IMentionable = optionMapping.asMentionable

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IMentionableResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IMentionableResolver.kt
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.parameters.resolvers
 
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.core.utils.enumSetOf
@@ -36,7 +35,7 @@ internal object IMentionableResolver : ClassParameterResolver<IMentionableResolv
     }
 
     override suspend fun resolveSuspend(
-        variation: TextCommandVariation,
+        option: TextCommandOption,
         event: MessageReceivedEvent,
         args: Array<String?>
     ): IMentionable? {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/MentionsStringResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/MentionsStringResolverFactory.kt
@@ -1,8 +1,8 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers
 
 import io.github.freya022.botcommands.api.commands.application.checkGuildOnly
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.MentionsString
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption
 import io.github.freya022.botcommands.api.core.entities.InputUser
 import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
 import io.github.freya022.botcommands.api.core.reflect.hasAnnotation
@@ -46,7 +46,7 @@ internal object MentionsStringResolverFactory : ParameterResolverFactory<Mention
         override val optionType: OptionType = OptionType.STRING
 
         override suspend fun resolveSuspend(
-            info: SlashCommandInfo,
+            option: SlashCommandOption,
             event: CommandInteractionPayload,
             optionMapping: OptionMapping
         ): List<IMentionable> = optionMapping.mentions.getMentions(*mentionTypes).mapNotNull(transform)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
@@ -1,7 +1,7 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers
 
 import io.github.freya022.botcommands.api.commands.application.context.user.options.UserContextCommandOption
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
@@ -41,7 +41,7 @@ internal object UserSnowflakeResolver :
         UserSnowflake.fromId(arg)
 
     override suspend fun resolveSuspend(
-        info: SlashCommandInfo,
+        option: SlashCommandOption,
         event: CommandInteractionPayload,
         optionMapping: OptionMapping,
     ): UserSnowflake = optionMapping.asUser

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
@@ -3,7 +3,6 @@ package io.github.freya022.botcommands.internal.parameters.resolvers
 import io.github.freya022.botcommands.api.commands.application.context.user.options.UserContextCommandOption
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
@@ -48,7 +47,7 @@ internal object UserSnowflakeResolver :
     ): UserSnowflake = optionMapping.asUser
 
     override suspend fun resolveSuspend(
-        variation: TextCommandVariation,
+        option: TextCommandOption,
         event: MessageReceivedEvent,
         args: Array<String?>,
     ): UserSnowflake {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.SlashComman
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
+import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
@@ -37,7 +38,7 @@ internal object UserSnowflakeResolver :
         return event.member.asMention
     }
 
-    override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, arg: String): UserSnowflake =
+    override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String): UserSnowflake =
         UserSnowflake.fromId(arg)
 
     override suspend fun resolveSuspend(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
@@ -37,7 +37,7 @@ internal object UserSnowflakeResolver :
         return event.member.asMention
     }
 
-    override suspend fun resolveSuspend(event: GenericComponentInteractionCreateEvent, option: ComponentOption, arg: String): UserSnowflake =
+    override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): UserSnowflake =
         UserSnowflake.fromId(arg)
 
     override suspend fun resolveSuspend(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers
 
-import io.github.freya022.botcommands.api.commands.application.context.user.UserCommandInfo
+import io.github.freya022.botcommands.api.commands.application.context.user.options.UserContextCommandOption
 import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.TextCommandVariation
@@ -58,6 +58,6 @@ internal object UserSnowflakeResolver :
         return UserSnowflake.fromId(id)
     }
 
-    override suspend fun resolveSuspend(info: UserCommandInfo, event: UserContextInteractionEvent): UserSnowflake =
+    override suspend fun resolveSuspend(option: UserContextCommandOption, event: UserContextInteractionEvent): UserSnowflake =
         event.target
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/localization/LocalizationContextResolvers.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/localization/LocalizationContextResolvers.kt
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.internal.parameters.resolvers.localization
 
-import io.github.freya022.botcommands.api.core.Executable
+import io.github.freya022.botcommands.api.core.options.Option
 import io.github.freya022.botcommands.api.localization.context.AppLocalizationContext
 import io.github.freya022.botcommands.api.localization.context.TextLocalizationContext
 import io.github.freya022.botcommands.api.localization.interaction.GuildLocaleProvider
@@ -22,7 +22,7 @@ internal class AppLocalizationContextResolver(
 ) : ClassParameterResolver<AppLocalizationContextResolver, AppLocalizationContext>(AppLocalizationContext::class),
     ICustomResolver<AppLocalizationContextResolver, AppLocalizationContext> {
 
-    override suspend fun resolveSuspend(executable: Executable, event: Event): AppLocalizationContext {
+    override suspend fun resolveSuspend(option: Option, event: Event): AppLocalizationContext {
         return when (event) {
             is Interaction -> baseContext.withLocales(guildLocaleProvider.getDiscordLocale(event), userLocaleProvider.getDiscordLocale(event))
             //MessageReceivedEvent does not provide user locale
@@ -39,7 +39,7 @@ internal class TextLocalizationContextResolver(
 ) : ClassParameterResolver<TextLocalizationContextResolver, TextLocalizationContext>(TextLocalizationContext::class),
     ICustomResolver<TextLocalizationContextResolver, TextLocalizationContext> {
 
-    override suspend fun resolveSuspend(executable: Executable, event: Event): TextLocalizationContext {
+    override suspend fun resolveSuspend(option: Option, event: Event): TextLocalizationContext {
         return when (event) {
             is Interaction -> baseContext.withLocales(guildLocaleProvider.getDiscordLocale(event), userLocaleProvider.getDiscordLocale(event))
             is MessageReceivedEvent -> when {

--- a/src/test/kotlin/doc/kotlin/examples/parameters/MyCustomLocalizationResolverProvider.kt
+++ b/src/test/kotlin/doc/kotlin/examples/parameters/MyCustomLocalizationResolverProvider.kt
@@ -1,6 +1,6 @@
 package doc.kotlin.examples.parameters
 
-import io.github.freya022.botcommands.api.core.Executable
+import io.github.freya022.botcommands.api.core.options.Option
 import io.github.freya022.botcommands.api.core.reflect.findAnnotation
 import io.github.freya022.botcommands.api.core.service.annotations.BConfiguration
 import io.github.freya022.botcommands.api.core.service.annotations.BService
@@ -51,7 +51,7 @@ object MyCustomLocalizationResolverProvider {
         ICustomResolver<MyCustomLocalizationResolver, MyCustomLocalization> {
 
         // Called when a command is used
-        override suspend fun resolveSuspend(executable: Executable, event: Event): MyCustomLocalization {
+        override suspend fun resolveSuspend(option: Option, event: Event): MyCustomLocalization {
             return if (event is Interaction) {
                 val guild = event.guild
                     ?: throw IllegalStateException("Cannot get localization outside of guilds")
@@ -71,10 +71,10 @@ object MyCustomLocalizationResolverProvider {
     // The returned factory is used on each command/handler parameter of type "MyCustomLocalization",
     // which is the same type as what MyCustomLocalizationResolver returns
     @ResolverFactory
-    fun myCustomLocalizationResolverProvider(localizationService: LocalizationService, guildSettingsService: GuildSettingsService) = resolverFactory { parameter ->
+    fun myCustomLocalizationResolverProvider(localizationService: LocalizationService, guildSettingsService: GuildSettingsService) = resolverFactory { request ->
         // Find @LocalizationBundle on the parameter
-        val bundle = parameter.parameter.findAnnotation<LocalizationBundle>()
-            ?: throw IllegalArgumentException("Parameter ${parameter.parameter} must be annotated with LocalizationBundle")
+        val bundle = request.parameter.findAnnotation<LocalizationBundle>()
+            ?: throw IllegalArgumentException("Parameter ${request.parameter} must be annotated with LocalizationBundle")
 
         // Return our resolver for that parameter
         MyCustomLocalizationResolver(localizationService, guildSettingsService, bundle.value, bundle.prefix.nullIfBlank())

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/text/TextAttachmentParameters.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/text/TextAttachmentParameters.kt
@@ -1,0 +1,49 @@
+package io.github.freya022.botcommands.test.commands.text
+
+import io.github.freya022.botcommands.api.commands.annotations.Command
+import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
+import io.github.freya022.botcommands.api.commands.text.TextCommand
+import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
+import io.github.freya022.botcommands.api.core.options.Option
+import io.github.freya022.botcommands.api.core.service.annotations.Resolver
+import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
+import net.dv8tion.jda.api.entities.Message.Attachment
+import net.dv8tion.jda.api.events.Event
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+import kotlin.reflect.jvm.jvmErasure
+
+@Resolver
+class TextAttachmentResolver :
+        ClassParameterResolver<TextAttachmentResolver, Attachment>(Attachment::class),
+        ICustomResolver<TextAttachmentResolver, Attachment> {
+
+    override suspend fun resolveSuspend(option: Option, event: Event): Attachment? {
+        if (event !is MessageReceivedEvent) return null
+
+        val command = option.executable
+        val myIndex = command.allOptionsOrdered
+            .filter { it.type.jvmErasure == Attachment::class }
+            .indexOf(option)
+
+        return event.message.attachments.getOrNull(myIndex)
+    }
+}
+
+/**
+ * Only a PoC for ordered options, required to bind attachments to the right place
+ */
+@Command
+class TextAttachmentParameters : TextCommand() {
+
+    @JvmInline
+    value class MyAttachment(val attachment: Attachment)
+
+    @JDATextCommandVariation(path = ["attachment_parameters"])
+    fun onTextAttachmentParameters(event: BaseCommandEvent, specialAttachment: MyAttachment, anyAttachment: Attachment) {
+        event.reply("""
+            My attachment: ${specialAttachment.attachment.proxyUrl}
+            Any attachment: ${anyAttachment.proxyUrl}
+        """.trimIndent()).queue()
+    }
+}

--- a/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/CustomObjectResolver.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/CustomObjectResolver.kt
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.test.resolvers
 
-import io.github.freya022.botcommands.api.core.Executable
+import io.github.freya022.botcommands.api.core.options.Option
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.ICustomResolver
@@ -12,7 +12,7 @@ class CustomObjectResolver :
     ClassParameterResolver<CustomObjectResolver, CustomObject>(CustomObject::class),
     ICustomResolver<CustomObjectResolver, CustomObject> {
 
-    override suspend fun resolveSuspend(executable: Executable, event: Event): CustomObject {
+    override suspend fun resolveSuspend(option: Option, event: Event): CustomObject {
         return CustomObject()
     }
 }

--- a/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/ListResolver.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/ListResolver.kt
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.test.resolvers
 
-import io.github.freya022.botcommands.api.commands.application.slash.SlashCommandInfo
+import io.github.freya022.botcommands.api.commands.application.slash.options.SlashCommandOption
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.TypedParameterResolver
@@ -18,7 +18,7 @@ object ListResolver :
     override val optionType: OptionType = OptionType.NUMBER
 
     override suspend fun resolveSuspend(
-        info: SlashCommandInfo,
+        option: SlashCommandOption,
         event: CommandInteractionPayload,
         optionMapping: OptionMapping
     ): List<Double> = listOf(optionMapping.asDouble * 2)

--- a/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/MapResolver.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/resolvers/MapResolver.kt
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.test.resolvers
 
-import io.github.freya022.botcommands.api.core.Executable
+import io.github.freya022.botcommands.api.core.options.Option
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.parameters.ParameterResolverFactory
@@ -18,7 +18,7 @@ sealed class MapResolver<R : Map<*, *>>(
     ICustomResolver<MapResolver<R>, R>
 
 object StringDoubleMapResolver : MapResolver<Map<String, Double>>(typeOf<Map<String, Double>>()) {
-    override suspend fun resolveSuspend(executable: Executable, event: Event): Map<String, Double> =
+    override suspend fun resolveSuspend(option: Option, event: Event): Map<String, Double> =
         mapOf("lol" to 3.14159)
 }
 


### PR DESCRIPTION
This PR passes options as the first parameter of all resolvers.

Command objects that were replaced with the option can be retrieved back with their `executable` property.

### Deprecations
- All `resolve` and `resolveSuspend` functions were deprecated
  - Add/modify the option into the new function