### PR TITLE
Inject interaction filters with star projections

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/ApplicationCommandListener.kt
@@ -52,17 +52,19 @@ internal class ApplicationCommandListener internal constructor(
     private val defaultMessagesFactory: DefaultMessagesFactory,
     private val localizableInteractionFactory: LocalizableInteractionFactory,
     private val rateLimitHandler: RateLimitHandler,
-    filters: List<ApplicationCommandFilter<Any>>,
-    rejectionHandler: ApplicationCommandRejectionHandler<Any>?
+    filters: List<ApplicationCommandFilter<*>>,
+    rejectionHandler: ApplicationCommandRejectionHandler<*>?
 ) {
     private val scope = context.coroutineScopesConfig.applicationCommandsScope
     private val exceptionHandler = ExceptionHandler(context, logger)
 
     // Types are crosschecked anyway
-    private val globalFilters: List<ApplicationCommandFilter<Any>> = filters.filter { it.global }
-    private val rejectionHandler: ApplicationCommandRejectionHandler<Any>? = when {
+    @Suppress("UNCHECKED_CAST")
+    private val globalFilters = filters.filter { it.global } as List<ApplicationCommandFilter<Any>>
+    @Suppress("UNCHECKED_CAST")
+    private val rejectionHandler = when {
         filters.isEmpty() -> null
-        else -> rejectionHandler
+        else -> rejectionHandler as ApplicationCommandRejectionHandler<Any>?
             ?: throwState("A ${classRef<ApplicationCommandRejectionHandler<*>>()} must be available if ${classRef<ApplicationCommandFilter<*>>()} is used")
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandsListener.kt
@@ -43,8 +43,8 @@ internal class TextCommandsListener internal constructor(
     private val textCommandsContext: TextCommandsContextImpl,
     private val localizableTextCommandFactory: LocalizableTextCommandFactory,
     private val rateLimitHandler: RateLimitHandler,
-    filters: List<TextCommandFilter<Any>>,
-    rejectionHandler: TextCommandRejectionHandler<Any>?,
+    filters: List<TextCommandFilter<*>>,
+    rejectionHandler: TextCommandRejectionHandler<*>?,
     private val suggestionSupplier: TextSuggestionSupplier,
     private val helpCommand: IHelpCommand?
 ) {
@@ -54,10 +54,12 @@ internal class TextCommandsListener internal constructor(
     private val exceptionHandler = ExceptionHandler(context, logger)
 
     // Types are crosschecked anyway
-    private val globalFilters: List<TextCommandFilter<Any>> = filters.filter { it.global }
-    private val rejectionHandler: TextCommandRejectionHandler<Any>? = when {
+    @Suppress("UNCHECKED_CAST")
+    private val globalFilters = filters.filter { it.global } as List<TextCommandFilter<Any>>
+    @Suppress("UNCHECKED_CAST")
+    private val rejectionHandler = when {
         globalFilters.isEmpty() -> null
-        else -> rejectionHandler
+        else -> rejectionHandler as TextCommandRejectionHandler<Any>?
             ?: throwState("A ${classRef<TextCommandRejectionHandler<*>>()} must be available if ${classRef<TextCommandFilter<*>>()} is used")
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
@@ -40,8 +40,8 @@ internal class ComponentsListener(
     private val defaultMessagesFactory: DefaultMessagesFactory,
     private val localizableInteractionFactory: LocalizableInteractionFactory,
     private val rateLimitHandler: RateLimitHandler,
-    filters: List<ComponentInteractionFilter<Any>>,
-    rejectionHandler: ComponentInteractionRejectionHandler<Any>?,
+    filters: List<ComponentInteractionFilter<*>>,
+    rejectionHandler: ComponentInteractionRejectionHandler<*>?,
     private val componentController: ComponentController,
     private val continuationManager: ComponentContinuationManager,
     private val componentHandlerExecutor: ComponentHandlerExecutor,
@@ -50,10 +50,12 @@ internal class ComponentsListener(
     private val exceptionHandler = ExceptionHandler(context, logger)
 
     // Types are crosschecked anyway
-    private val globalFilters: List<ComponentInteractionFilter<Any>> = filters.filter { it.global }
-    private val rejectionHandler: ComponentInteractionRejectionHandler<Any>? = when {
+    @Suppress("UNCHECKED_CAST")
+    private val globalFilters = filters.filter { it.global } as List<ComponentInteractionFilter<Any>>
+    @Suppress("UNCHECKED_CAST")
+    private val rejectionHandler = when {
         globalFilters.isEmpty() -> null
-        else -> rejectionHandler
+        else -> rejectionHandler as ComponentInteractionRejectionHandler<Any>?
             ?: throwState("A ${classRef<ComponentInteractionRejectionHandler<*>>()} must be available if ${classRef<ComponentInteractionFilter<*>>()} is used")
     }
 


### PR DESCRIPTION
Spring considers generics for injection, this caused it to only inject filters of type `Any`.