### PR TITLE
Fix path to default app command cache on macOS 

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
@@ -420,7 +420,7 @@ class BApplicationConfigBuilder internal constructor() : BApplicationConfig {
             osName.startsWith("Linux") -> envPath("XDG_DATA_HOME", "HOME").resolve(".local/share/BotCommands")
             // https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html
             // https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW1
-            osName.startsWith("Mac") || osName.startsWith("Darwin") -> Path("~/Library/Application Support/io.github.freya022.BotCommands")
+            osName.startsWith("Mac") || osName.startsWith("Darwin") -> envPath("HOME").resolve("Library/Application Support/io.github.freya022.BotCommands")
             else -> {
                 Logging.currentLogger().warn { internalErrorMessage("Unsupported OS '$osName' for file-based application commands cache, using fallback") }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
@@ -364,8 +364,9 @@ class BApplicationConfigBuilder internal constructor() : BApplicationConfig {
      * ### Cache path
      *
      * The default cache folder is at:
-     * - Windows: `%AppData%/BotCommands`
-     * - Unix: `/var/tmp/BotCommands`
+     * - Windows: `%AppData%/BotCommands`,
+     * - Linux: `$XDG_DATA_HOME/BotCommands` (fallbacks to `$HOME/.local/share/BotCommands`),
+     * - macOS: `$HOME/Library/Application Support/io.github.freya022.BotCommands`
      *
      * Each application has a folder inside it, meaning you can safely share this folder with other applications.
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/application/cache/FileApplicationCommandsCacheConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/application/cache/FileApplicationCommandsCacheConfig.kt
@@ -10,9 +10,10 @@ interface FileApplicationCommandsCacheConfig : ApplicationCommandsCacheConfig {
      *
      * Each application has a folder inside it, meaning you can safely share this folder with other applications.
      *
-     * Default: `%AppData%/BotCommands` on Windows,
-     *          `$XDG_DATA_HOME/BotCommands` (fallbacks to `$HOME/.local/share/BotCommands`) on Linux,
-     *          and `~/Library/Application Support/io.github.freya022.BotCommands` on macOS
+     * Defaults:
+     * - Windows: `%AppData%/BotCommands`,
+     * - Linux: `$XDG_DATA_HOME/BotCommands` (fallbacks to `$HOME/.local/share/BotCommands`),
+     * - macOS: `$HOME/Library/Application Support/io.github.freya022.BotCommands`
      *
      * Spring property: `botcommands.application.cache.file.path`
      */


### PR DESCRIPTION
By expanding `~` to the `HOME` env var