### PR TITLE
Add user-defined service suppliers

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
@@ -24,6 +24,7 @@ interface BServiceConfig {
 
     @Deprecated(message = "For removal, didn't do much in the first place")
     val serviceAnnotations: Set<KClass<out Annotation>>
+    @Deprecated("For removal, replaced by serviceSuppliers")
     val instanceSupplierMap: Map<KClass<*>, InstanceSupplier<*>>
     val serviceSuppliers: Map<KClass<*>, ServiceSupplier<*>>
 }
@@ -36,6 +37,7 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
     override val serviceAnnotations: MutableSet<KClass<out Annotation>> = hashSetOf(BService::class, Command::class, Resolver::class, ResolverFactory::class, Handler::class)
 
     private val _instanceSupplierMap: MutableMap<KClass<*>, InstanceSupplier<*>> = hashMapOf()
+    @Deprecated("For removal, replaced by serviceSuppliers")
     override val instanceSupplierMap: Map<KClass<*>, InstanceSupplier<*>> = _instanceSupplierMap.unmodifiableView()
 
     private val _serviceSuppliers: MutableMap<KClass<*>, ServiceSupplier<*>> = hashMapOf()
@@ -54,6 +56,7 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
      * @param clazz            The primary type as which the service is registered as, other types may be registered with the usual annotations
      * @param instanceSupplier Supplier for the service instance, ran at startup, unless [clazz] is annotated with [@Lazy][Lazy]
      */
+    @Deprecated("For removal, replaced by registerServiceSupplier")
     fun <T : Any> registerInstanceSupplier(clazz: Class<T>, instanceSupplier: InstanceSupplier<T>) {
         _instanceSupplierMap[clazz.kotlin] = instanceSupplier
     }
@@ -93,6 +96,7 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
         override val debug = this@BServiceConfigBuilder.debug
         @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
         override val serviceAnnotations = this@BServiceConfigBuilder.serviceAnnotations.toImmutableSet()
+        @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
         override val instanceSupplierMap = this@BServiceConfigBuilder.instanceSupplierMap.toImmutableMap()
         override val serviceSuppliers = this@BServiceConfigBuilder.serviceSuppliers.toImmutableMap()
     }
@@ -111,6 +115,8 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
  * @param T                The primary type as which the service is registered as, other types may be registered with the usual annotations
  * @param instanceSupplier Supplier for the service instance, ran at startup, unless [T] is annotated with [@Lazy][Lazy]
  */
+@Suppress("DeprecatedCallableAddReplaceWith", "DEPRECATION")
+@Deprecated("For removal, replaced by registerServiceSupplier")
 inline fun <reified T : Any> BServiceConfigBuilder.registerInstanceSupplier(instanceSupplier: InstanceSupplier<T>) {
     return registerInstanceSupplier(T::class.java, instanceSupplier)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
@@ -1,8 +1,11 @@
 package io.github.freya022.botcommands.api.core.config
 
 import io.github.freya022.botcommands.api.commands.annotations.Command
+import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.annotations.Handler
 import io.github.freya022.botcommands.api.core.service.InstanceSupplier
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
+import io.github.freya022.botcommands.api.core.service.ServiceSupplier
 import io.github.freya022.botcommands.api.core.service.annotations.*
 import io.github.freya022.botcommands.api.core.utils.toImmutableMap
 import io.github.freya022.botcommands.api.core.utils.toImmutableSet
@@ -22,6 +25,7 @@ interface BServiceConfig {
     @Deprecated(message = "For removal, didn't do much in the first place")
     val serviceAnnotations: Set<KClass<out Annotation>>
     val instanceSupplierMap: Map<KClass<*>, InstanceSupplier<*>>
+    val serviceSuppliers: Map<KClass<*>, ServiceSupplier<*>>
 }
 
 @ConfigDSL
@@ -33,6 +37,9 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
 
     private val _instanceSupplierMap: MutableMap<KClass<*>, InstanceSupplier<*>> = hashMapOf()
     override val instanceSupplierMap: Map<KClass<*>, InstanceSupplier<*>> = _instanceSupplierMap.unmodifiableView()
+
+    private val _serviceSuppliers: MutableMap<KClass<*>, ServiceSupplier<*>> = hashMapOf()
+    override val serviceSuppliers: Map<KClass<*>, ServiceSupplier<*>> = _serviceSuppliers.unmodifiableView()
 
     /**
      * Registers a supplier lazily returning an instance of the specified class,
@@ -51,12 +58,43 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
         _instanceSupplierMap[clazz.kotlin] = instanceSupplier
     }
 
+    /**
+     * Registers a supplier which gets loaded in the same manner as annotated service classes/factories.
+     *
+     * **Note:** The [annotations] passed will not be readable using standard reflection,
+     * they are only read when functions
+     * like [ServiceContainer.findAnnotationOnService] or [ServiceContainer.getServiceNamesForAnnotation] are used.
+     *
+     * @param primaryType     The type as which the service will be *registered* as
+     * @param name            The [name][ServiceName] to register the service as
+     * @param additionalTypes [Additional types][ServiceType] this service can be *retrieved* as
+     * @param isPrimary       Whether this service should be a [primary][Primary] service
+     * @param isLazy          Whether this service should be initialized only [when requested][Lazy]
+     * @param priority        The [priority][ServicePriority] of this service
+     * @param annotations     Annotations which should be tied to this service
+     * @param supplier        The function supplying the service
+     */
+    @JvmOverloads
+    fun <T : Any> registerServiceSupplier(
+        primaryType: KClass<T>,
+        name: String = ServiceSupplier.defaultName(primaryType),
+        additionalTypes: Set<KClass<in T>> = emptySet(), // Accept superclasses not subclasses
+        isPrimary: Boolean = false,
+        isLazy: Boolean = false,
+        priority: Int = 0,
+        annotations: List<Annotation> = emptyList(),
+        supplier: (BContext) -> T,
+    ) {
+        _serviceSuppliers[primaryType] = ServiceSupplier(primaryType, name, additionalTypes, isPrimary, isLazy, priority, annotations, supplier)
+    }
+
     @JvmSynthetic
     internal fun build() = object : BServiceConfig {
         override val debug = this@BServiceConfigBuilder.debug
         @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
         override val serviceAnnotations = this@BServiceConfigBuilder.serviceAnnotations.toImmutableSet()
         override val instanceSupplierMap = this@BServiceConfigBuilder.instanceSupplierMap.toImmutableMap()
+        override val serviceSuppliers = this@BServiceConfigBuilder.serviceSuppliers.toImmutableMap()
     }
 }
 
@@ -75,4 +113,32 @@ class BServiceConfigBuilder internal constructor() : BServiceConfig {
  */
 inline fun <reified T : Any> BServiceConfigBuilder.registerInstanceSupplier(instanceSupplier: InstanceSupplier<T>) {
     return registerInstanceSupplier(T::class.java, instanceSupplier)
+}
+
+/**
+ * Registers a supplier which gets loaded in the same manner as annotated service classes/factories.
+ *
+ * **Note:** The [annotations] passed will not be readable using standard reflection,
+ * they are only read when functions
+ * like [ServiceContainer.findAnnotationOnService] or [ServiceContainer.getServiceNamesForAnnotation] are used.
+ *
+ * @param T               The type as which the service will be *registered* as
+ * @param name            The [name][ServiceName] to register the service as
+ * @param additionalTypes [Additional types][ServiceType] this service can be *retrieved* as
+ * @param isPrimary       Whether this service should be a [primary][Primary] service
+ * @param isLazy          Whether this service should be initialized only [when requested][Lazy]
+ * @param priority        The [priority][ServicePriority] of this service
+ * @param annotations     Annotations which should be tied to this service
+ * @param supplier        The function supplying the service
+ */
+inline fun <reified T : Any> BServiceConfigBuilder.registerServiceSupplier(
+    name: String = ServiceSupplier.defaultName(T::class),
+    additionalTypes: Set<KClass<in T>> = emptySet(), // Accept superclasses not subclasses
+    isPrimary: Boolean = false,
+    isLazy: Boolean = false,
+    priority: Int = 0,
+    annotations: List<Annotation> = emptyList(),
+    noinline supplier: (BContext) -> T,
+) {
+    return registerServiceSupplier(T::class, name, additionalTypes, isPrimary, isLazy, priority, annotations, supplier)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/service/ClassGraphProcessor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/service/ClassGraphProcessor.kt
@@ -6,9 +6,10 @@ import java.lang.reflect.Executable
 import kotlin.reflect.KClass
 
 interface ClassGraphProcessor {
-    fun processClass(classInfo: ClassInfo, kClass: KClass<*>, isService: Boolean) {}
+    fun processClass(serviceContainer: ServiceContainer, classInfo: ClassInfo, kClass: KClass<*>, isService: Boolean) {}
 
     fun processMethod(
+        serviceContainer: ServiceContainer,
         methodInfo: MethodInfo,
         method: Executable,
         classInfo: ClassInfo,
@@ -16,5 +17,5 @@ interface ClassGraphProcessor {
         isServiceFactory: Boolean,
     ) {}
 
-    fun postProcess() {}
+    fun postProcess(serviceContainer: ServiceContainer) {}
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/service/DefaultServiceContainer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/service/DefaultServiceContainer.kt
@@ -18,6 +18,8 @@ interface DefaultServiceContainer : ServiceContainer {
 
     override fun putService(t: Any, name: String): Unit = putService(t, t::class, name)
     override fun putService(t: Any): Unit = putService(t, t::class)
+
+    fun putSuppliedService(serviceSupplier: ServiceSupplier<*>)
 }
 
 inline fun <reified T : Any> DefaultServiceContainer.putServiceAs(

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/service/InstanceSupplier.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/service/InstanceSupplier.kt
@@ -10,6 +10,7 @@ import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder
  *
  * @see BServiceConfigBuilder.registerInstanceSupplier
  */
+@Deprecated("For removal, replaced by ServiceSupplier")
 fun interface InstanceSupplier<T : Any> {
     fun supply(context: BContext): T
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/service/ServiceSupplier.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/service/ServiceSupplier.kt
@@ -1,0 +1,44 @@
+package io.github.freya022.botcommands.api.core.service
+
+import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.utils.simpleNestedName
+import kotlin.reflect.KClass
+
+class ServiceSupplier<T : Any> @JvmOverloads constructor(
+    val primaryType: KClass<T>,
+    val name: String = defaultName(primaryType),
+    val additionalTypes: Set<KClass<in T>> = emptySet(), // Accept superclasses not subclasses
+    val isPrimary: Boolean = false,
+    val isLazy: Boolean = false,
+    val priority: Int = 0,
+    val annotations: List<Annotation> = emptyList(),
+    val supplier: (BContext) -> T,
+) {
+
+    @JvmOverloads
+    constructor(
+        primaryType: Class<T>,
+        name: String = defaultName(primaryType.kotlin),
+        additionalTypes: Set<Class<in T>> = emptySet(), // Accept superclasses not subclasses
+        isPrimary: Boolean = false,
+        isLazy: Boolean = false,
+        priority: Int = 0,
+        annotations: List<Annotation> = emptyList(),
+        supplier: (BContext) -> T,
+    ) : this(primaryType.kotlin, name, additionalTypes.mapTo(hashSetOf()) { it.kotlin }, isPrimary, isLazy, priority, annotations, supplier)
+
+    override fun toString(): String {
+        return "ServiceSupplier(primaryType=$primaryType, name='$name', additionalTypes=$additionalTypes, isPrimary=$isPrimary, isLazy=$isLazy, priority=$priority, annotations=$annotations)"
+    }
+
+    companion object {
+        fun defaultName(clazz: KClass<*>): String {
+            return clazz.simpleNestedName.replaceFirstChar { it.lowercase() }
+        }
+
+        @JvmStatic
+        fun defaultName(clazz: Class<*>): String {
+            return clazz.simpleNestedName.replaceFirstChar { it.lowercase() }
+        }
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/service/ServiceSupplier.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/service/ServiceSupplier.kt
@@ -1,9 +1,29 @@
 package io.github.freya022.botcommands.api.core.service
 
 import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.config.BServiceConfigBuilder
+import io.github.freya022.botcommands.api.core.service.annotations.*
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import kotlin.reflect.KClass
 
+/**
+ * Represents the attributes and initializer of a given service type.
+ *
+ * **Note:** The [annotations] passed will not be readable using standard reflection,
+ * they are only read when functions
+ * like [ServiceContainer.findAnnotationOnService] or [ServiceContainer.getServiceNamesForAnnotation] are used.
+ *
+ * @property primaryType     The type as which the service will be *registered* as
+ * @property name            The [name][ServiceName] to register the service as
+ * @property additionalTypes [Additional types][ServiceType] this service can be *retrieved* as
+ * @property isPrimary       Whether this service should be a [primary][Primary] service
+ * @property isLazy          Whether this service should be initialized only [when requested][Lazy]
+ * @property priority        The [priority][ServicePriority] of this service
+ * @property annotations     Annotations which should be tied to this service
+ * @property supplier        The function supplying the service
+ *
+ * @see BServiceConfigBuilder.registerServiceSupplier
+ */
 class ServiceSupplier<T : Any> @JvmOverloads constructor(
     val primaryType: KClass<T>,
     val name: String = defaultName(primaryType),
@@ -15,6 +35,22 @@ class ServiceSupplier<T : Any> @JvmOverloads constructor(
     val supplier: (BContext) -> T,
 ) {
 
+    /**
+     * Constructs a [ServiceSupplier].
+     *
+     * **Note:** The [annotations] passed will not be readable using standard reflection,
+     * they are only read when functions
+     * like [ServiceContainer.findAnnotationOnService] or [ServiceContainer.getServiceNamesForAnnotation] are used.
+     *
+     * @param primaryType     The type as which the service will be *registered* as
+     * @param name            The [name][ServiceName] to register the service as
+     * @param additionalTypes [Additional types][ServiceType] this service can be *retrieved* as
+     * @param isPrimary       Whether this service should be a [primary][Primary] service
+     * @param isLazy          Whether this service should be initialized only [when requested][Lazy]
+     * @param priority        The [priority][ServicePriority] of this service
+     * @param annotations     Annotations which should be tied to this service
+     * @param supplier        The function supplying the service
+     */
     @JvmOverloads
     constructor(
         primaryType: Class<T>,

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/CommandsPresenceChecker.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/CommandsPresenceChecker.kt
@@ -11,6 +11,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.provider.TextCommandProvider
 import io.github.freya022.botcommands.api.core.service.ClassGraphProcessor
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.utils.joinAsList
 import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
 import io.github.freya022.botcommands.api.core.utils.shortSignature
@@ -37,7 +38,12 @@ internal class CommandsPresenceChecker : ClassGraphProcessor {
     private val noDeclarationClasses: MutableList<String> = arrayListOf()
     private val noAnnotationMethods: MutableList<MethodInfo> = arrayListOf()
 
-    override fun processClass(classInfo: ClassInfo, kClass: KClass<*>, isService: Boolean) {
+    override fun processClass(
+        serviceContainer: ServiceContainer,
+        classInfo: ClassInfo,
+        kClass: KClass<*>,
+        isService: Boolean
+    ) {
         if (classInfo.isAbstract) return
 
         val isCommand = classInfo.hasAnnotation(Command::class.java)
@@ -58,7 +64,7 @@ internal class CommandsPresenceChecker : ClassGraphProcessor {
         }
     }
 
-    override fun postProcess() {
+    override fun postProcess(serviceContainer: ServiceContainer) {
         if (noDeclarationClasses.isNotEmpty()) {
             logger.warn {
                 val refs = noDeclarationClasses.joinAsList()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/HandlersPresenceChecker.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/HandlersPresenceChecker.kt
@@ -8,6 +8,7 @@ import io.github.freya022.botcommands.api.components.annotations.JDAButtonListen
 import io.github.freya022.botcommands.api.components.annotations.JDASelectMenuListener
 import io.github.freya022.botcommands.api.core.annotations.Handler
 import io.github.freya022.botcommands.api.core.service.ClassGraphProcessor
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.utils.joinAsList
 import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
 import io.github.freya022.botcommands.api.core.utils.shortSignature
@@ -29,7 +30,12 @@ internal class HandlersPresenceChecker : ClassGraphProcessor {
     private val noDeclarationClasses: MutableList<String> = arrayListOf()
     private val noAnnotationMethods: MutableList<MethodInfo> = arrayListOf()
 
-    override fun processClass(classInfo: ClassInfo, kClass: KClass<*>, isService: Boolean) {
+    override fun processClass(
+        serviceContainer: ServiceContainer,
+        classInfo: ClassInfo,
+        kClass: KClass<*>,
+        isService: Boolean
+    ) {
         if (classInfo.isAbstract) return
 
         val isCommand = classInfo.hasAnnotation(Command::class.java)
@@ -50,7 +56,7 @@ internal class HandlersPresenceChecker : ClassGraphProcessor {
         }
     }
 
-    override fun postProcess() {
+    override fun postProcess(serviceContainer: ServiceContainer) {
         if (noDeclarationClasses.isNotEmpty()) {
             logger.warn {
                 val refs = noDeclarationClasses.joinAsList()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/ConditionalObjectChecker.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/ConditionalObjectChecker.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.internal.core.service
 
 import io.github.classgraph.ClassInfo
 import io.github.freya022.botcommands.api.core.service.ClassGraphProcessor
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.utils.hasAnnotationRecursive
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.internal.core.service.annotations.HardcodedCondition
@@ -9,7 +10,12 @@ import io.github.freya022.botcommands.internal.utils.isObject
 import kotlin.reflect.KClass
 
 internal class ConditionalObjectChecker : ClassGraphProcessor {
-    override fun processClass(classInfo: ClassInfo, kClass: KClass<*>, isService: Boolean) {
+    override fun processClass(
+        serviceContainer: ServiceContainer,
+        classInfo: ClassInfo,
+        kClass: KClass<*>,
+        isService: Boolean
+    ) {
         if (!isService) return
         if (!kClass.isObject) return
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/DefaultServiceContainerImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/DefaultServiceContainerImpl.kt
@@ -8,10 +8,7 @@ import io.github.freya022.botcommands.api.core.service.annotations.MissingServic
 import io.github.freya022.botcommands.api.core.service.annotations.ServiceName
 import io.github.freya022.botcommands.api.core.utils.*
 import io.github.freya022.botcommands.internal.core.exceptions.ServiceException
-import io.github.freya022.botcommands.internal.core.service.provider.ProvidedServiceProvider
-import io.github.freya022.botcommands.internal.core.service.provider.ServiceProvider
-import io.github.freya022.botcommands.internal.core.service.provider.ServiceProviders
-import io.github.freya022.botcommands.internal.core.service.provider.TimedInstantiation
+import io.github.freya022.botcommands.internal.core.service.provider.*
 import io.github.freya022.botcommands.internal.core.service.stack.DefaultServiceCreationStack
 import io.github.freya022.botcommands.internal.core.service.stack.TracedServiceCreationStack
 import io.github.freya022.botcommands.internal.utils.*
@@ -207,6 +204,10 @@ internal class DefaultServiceContainerImpl internal constructor(internal val ser
         typeAliases: Set<KClass<*>>
     ) {
         serviceProviders.putServiceProvider(ProvidedServiceProvider(t, clazz, name, isPrimary, priority, annotations, typeAliases))
+    }
+
+    override fun putSuppliedService(serviceSupplier: ServiceSupplier<*>) {
+        serviceProviders.putServiceProvider(SuppliedServiceProvider(serviceSupplier))
     }
 
     override fun canCreateService(name: String, requiredType: KClass<*>): ServiceError? {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ClassServiceProvider.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ClassServiceProvider.kt
@@ -3,6 +3,7 @@ package io.github.freya022.botcommands.internal.core.service.provider
 import io.github.freya022.botcommands.api.core.service.ServiceError
 import io.github.freya022.botcommands.api.core.service.ServiceError.ErrorType
 import io.github.freya022.botcommands.api.core.service.ServiceResult
+import io.github.freya022.botcommands.api.core.service.ServiceSupplier
 import io.github.freya022.botcommands.api.core.service.annotations.Lazy
 import io.github.freya022.botcommands.api.core.service.annotations.Primary
 import io.github.freya022.botcommands.api.core.utils.getAllAnnotations
@@ -137,4 +138,4 @@ internal class ClassServiceProvider internal constructor(
 
 @PublishedApi
 internal fun ServiceProvider.getServiceName(clazz: KClass<*>) =
-    getAnnotatedServiceName() ?: clazz.simpleNestedName.replaceFirstChar { it.lowercase() }
+    getAnnotatedServiceName() ?: ServiceSupplier.defaultName(clazz)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ServiceProviders.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ServiceProviders.kt
@@ -5,6 +5,7 @@ import io.github.classgraph.MethodInfo
 import io.github.freya022.botcommands.api.core.config.BServiceConfig
 import io.github.freya022.botcommands.api.core.service.ClassGraphProcessor
 import io.github.freya022.botcommands.api.core.service.ServiceContainer
+import io.github.freya022.botcommands.api.core.service.ServiceSupplier
 import io.github.freya022.botcommands.api.core.utils.joinAsList
 import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
 import io.github.freya022.botcommands.internal.utils.throwArgument
@@ -46,7 +47,7 @@ internal class ServiceProviders(private val serviceConfig: BServiceConfig) : Cla
 
         val instanceSupplier = serviceConfig.instanceSupplierMap[kClass]
         if (instanceSupplier != null) {
-            putServiceProvider(SuppliedServiceProvider(kClass, instanceSupplier))
+            putServiceProvider(SuppliedServiceProvider(ServiceSupplier(kClass) { instanceSupplier.supply(it) }))
             return
         }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ServiceProviders.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ServiceProviders.kt
@@ -4,6 +4,7 @@ import io.github.classgraph.ClassInfo
 import io.github.classgraph.MethodInfo
 import io.github.freya022.botcommands.api.core.config.BServiceConfig
 import io.github.freya022.botcommands.api.core.service.ClassGraphProcessor
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.utils.joinAsList
 import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
 import io.github.freya022.botcommands.internal.utils.throwArgument
@@ -34,7 +35,15 @@ internal class ServiceProviders(private val serviceConfig: BServiceConfig) : Cla
     internal fun findAllForType(type: KClass<*>): Set<ServiceProvider> = typeMap[type] ?: emptySet()
     internal fun findAllForName(name: String): Set<ServiceProvider> = nameMap[name] ?: emptySet()
 
-    override fun processClass(classInfo: ClassInfo, kClass: KClass<*>, isService: Boolean) {
+    override fun processClass(
+        serviceContainer: ServiceContainer,
+        classInfo: ClassInfo,
+        kClass: KClass<*>,
+        isService: Boolean
+    ) {
+        @Suppress("UNCHECKED_CAST")
+        kClass as KClass<Any> // so ServiceSupplier doesnt complain
+
         val instanceSupplier = serviceConfig.instanceSupplierMap[kClass]
         if (instanceSupplier != null) {
             putServiceProvider(SuppliedServiceProvider(kClass, instanceSupplier))
@@ -47,6 +56,7 @@ internal class ServiceProviders(private val serviceConfig: BServiceConfig) : Cla
     }
 
     override fun processMethod(
+        serviceContainer: ServiceContainer,
         methodInfo: MethodInfo,
         method: Executable,
         classInfo: ClassInfo,
@@ -66,7 +76,7 @@ internal class ServiceProviders(private val serviceConfig: BServiceConfig) : Cla
         putServiceProvider(FunctionServiceProvider(function))
     }
 
-    override fun postProcess() {
+    override fun postProcess(serviceContainer: ServiceContainer) {
         val missingSuppliedProviders = serviceConfig.instanceSupplierMap.keys - typeMap.keys
         check(missingSuppliedProviders.isEmpty()) {
             "Some instance suppliers were registered but their class were not in the search path:\n${missingSuppliedProviders.joinAsList { it.shortQualifiedName } }"

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/SuppliedServiceProvider.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/SuppliedServiceProvider.kt
@@ -1,31 +1,30 @@
 package io.github.freya022.botcommands.internal.core.service.provider
 
-import io.github.freya022.botcommands.api.core.service.InstanceSupplier
 import io.github.freya022.botcommands.api.core.service.ServiceError
-import io.github.freya022.botcommands.api.core.service.annotations.Lazy
-import io.github.freya022.botcommands.api.core.service.annotations.Primary
+import io.github.freya022.botcommands.api.core.service.ServiceSupplier
 import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
 import io.github.freya022.botcommands.internal.core.service.DefaultServiceContainerImpl
 import io.github.freya022.botcommands.internal.utils.throwInternal
-import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.jvm.jvmName
 
 internal class SuppliedServiceProvider internal constructor(
-    private val clazz: KClass<*>,
-    private val supplier: InstanceSupplier<*>
+    serviceSupplier: ServiceSupplier<*>,
 ) : ServiceProvider {
+    private var serviceSupplier: ServiceSupplier<*>? = serviceSupplier
     override var instance: Any? = null
 
-    override val annotations = clazz.annotations
-    override val name = getServiceName(clazz)
-    override val providerKey = clazz.jvmName
+    private val clazz = serviceSupplier.primaryType
+
+    override val annotations = serviceSupplier.annotations
+    override val name = serviceSupplier.name
+    override val providerKey get() = clazz.jvmName
     override val primaryType get() = clazz
-    override val types = getServiceTypes(primaryType)
-    override val isPrimary = hasAnnotation<Primary>()
-    override val isLazy = hasAnnotation<Lazy>()
-    override val priority = getAnnotatedServicePriority()
+    override val types = serviceSupplier.additionalTypes
+    override val isPrimary = serviceSupplier.isPrimary
+    override val isLazy = serviceSupplier.isLazy
+    override val priority = serviceSupplier.priority
 
     override fun canInstantiate(serviceContainer: DefaultServiceContainerImpl): ServiceError? {
         return null
@@ -42,7 +41,9 @@ internal class SuppliedServiceProvider internal constructor(
 
     private fun createInstanceNonCached(serviceContainer: DefaultServiceContainerImpl): TimedInstantiation<*> {
         return measureTimedInstantiation {
-            supplier.supply(serviceContainer.getService())
+            val service = serviceSupplier!!.supplier(serviceContainer.getService())
+            serviceSupplier = null // Let GC take what wont be used anymore
+            service
         }
     }
 
@@ -50,7 +51,5 @@ internal class SuppliedServiceProvider internal constructor(
 
     override fun getProviderSignature(): String = "<supplied ${clazz.shortQualifiedName}>"
 
-    override fun toString(): String {
-        return "SuppliedServiceProvider(supplier=$supplier, clazz=$clazz, instance=$instance)"
-    }
+    override fun toString(): String = providerKey
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/emojis/AppEmojiContainerProcessor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/emojis/AppEmojiContainerProcessor.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.internal.emojis
 
 import io.github.classgraph.ClassInfo
 import io.github.freya022.botcommands.api.core.service.ClassGraphProcessor
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.utils.findAnnotationRecursive
 import io.github.freya022.botcommands.api.emojis.annotations.AppEmojiContainer
 import org.jetbrains.annotations.TestOnly
@@ -11,7 +12,12 @@ internal object AppEmojiContainerProcessor : ClassGraphProcessor {
 
     internal val emojiClasses = arrayListOf<AppEmojiContainerData>()
 
-    override fun processClass(classInfo: ClassInfo, kClass: KClass<*>, isService: Boolean) {
+    override fun processClass(
+        serviceContainer: ServiceContainer,
+        classInfo: ClassInfo,
+        kClass: KClass<*>,
+        isService: Boolean
+    ) {
         kClass.findAnnotationRecursive<AppEmojiContainer>()?.let {
             emojiClasses += AppEmojiContainerData(kClass, it)
         }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ResolverSupertypeChecker.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ResolverSupertypeChecker.kt
@@ -3,6 +3,7 @@ package io.github.freya022.botcommands.internal.parameters.resolvers
 import io.github.classgraph.ClassInfo
 import io.github.classgraph.MethodInfo
 import io.github.freya022.botcommands.api.core.service.ClassGraphProcessor
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
 import io.github.freya022.botcommands.api.core.utils.*
@@ -38,7 +39,12 @@ internal class ResolverSupertypeChecker internal constructor(): ClassGraphProces
     private val missingResolverFactoryAnnotationMessages: MutableList<String> = arrayListOf()
     private val missingResolverFactorySuperclassMessages: MutableList<String> = arrayListOf()
 
-    override fun processClass(classInfo: ClassInfo, kClass: KClass<*>, isService: Boolean) {
+    override fun processClass(
+        serviceContainer: ServiceContainer,
+        classInfo: ClassInfo,
+        kClass: KClass<*>,
+        isService: Boolean
+    ) {
         if (classInfo.isAbstract) return
 
         val isResolverFactoryAnnotated = classInfo.hasAnnotation(ResolverFactory::class.java)
@@ -80,6 +86,7 @@ internal class ResolverSupertypeChecker internal constructor(): ClassGraphProces
     }
 
     override fun processMethod(
+        serviceContainer: ServiceContainer,
         methodInfo: MethodInfo,
         method: Executable,
         classInfo: ClassInfo,
@@ -150,7 +157,7 @@ internal class ResolverSupertypeChecker internal constructor(): ClassGraphProces
             }
     }
 
-    override fun postProcess() {
+    override fun postProcess(serviceContainer: ServiceContainer) {
         tasks.forEach { it.invoke() }
 
         if (missingResolverAnnotationMessages.isNotEmpty()) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ReflectionMetadata.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ReflectionMetadata.kt
@@ -134,7 +134,7 @@ private class ReflectionMetadataScanner private constructor(
                     }
                     .processClasses()
 
-                classGraphProcessors.forEach(ClassGraphProcessor::postProcess)
+                classGraphProcessors.forEach { it.postProcess(bootstrap.serviceContainer) }
             }
     }
 
@@ -205,7 +205,7 @@ private class ReflectionMetadataScanner private constructor(
                 classMetadataMap[kClass.java] = ClassMetadata(classInfo.sourceFile)
 
                 val isService = bootstrap.isService(classInfo)
-                classGraphProcessors.forEach { it.processClass(classInfo, kClass, isService) }
+                classGraphProcessors.forEach { it.processClass(bootstrap.serviceContainer, classInfo, kClass, isService) }
             } catch (e: Throwable) {
                 e.rethrow("An exception occurred while scanning class: ${classInfo.name}")
             }
@@ -248,7 +248,7 @@ private class ReflectionMetadataScanner private constructor(
             methodMetadataMap[method] = MethodMetadata(methodInfo.minLineNum, nullabilities)
 
             val isServiceFactory = bootstrap.isServiceFactory(methodInfo)
-            classGraphProcessors.forEach { it.processMethod(methodInfo, method, classInfo, kClass, isServiceFactory) }
+            classGraphProcessors.forEach { it.processMethod(bootstrap.serviceContainer, methodInfo, method, classInfo, kClass, isServiceFactory) }
         }
     }
 


### PR DESCRIPTION
### Deprecations
- Deprecated instance suppliers
  - `InstanceSupplier`
  - `BServiceConfig#instanceSupplierMap`
  - `BServiceConfigBuilder#registerInstanceSupplier`

### Changes
- Passed a `ServiceContainer` in `ClassGraphProcessor` methods
- Annotations are no longer read from classes supplied by `InstanceSupplier`s
  - This shouldn't affect anyone as you would use a service factory instead

### New features
- Added `ServiceSupplier`
  - This lets you configure a service with a bit more depth
- Added `DefaultServiceContainer#putSuppliedService(ServiceSupplier)`
  - You should be able to call this from a `ClassGraphProcessor`, for example, if you want to register proxied interfaces as services
- Added `BServiceConfigBuilder#registerServiceSupplier(...)`