### PR TITLE
Remove `append` attributes, merging values from meta-annotations instead

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/annotations/BotPermissions.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/annotations/BotPermissions.kt
@@ -8,6 +8,6 @@ import net.dv8tion.jda.api.Permission
  * **Text commands note:** This applies to the command itself, not only this variation,
  * in other words, this applies to all commands with the same path.
  */
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class BotPermissions(@get:JvmName("value") vararg val permissions: Permission = [], val append: Boolean = false)
+annotation class BotPermissions(@get:JvmName("value") vararg val permissions: Permission)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/annotations/UserPermissions.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/annotations/UserPermissions.kt
@@ -8,6 +8,6 @@ import net.dv8tion.jda.api.Permission
  * **Text commands note:** This applies to the command itself, not only this variation,
  * in other words, this applies to all commands with the same path.
  */
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class UserPermissions(@get:JvmName("value") vararg val permissions: Permission = [], val append: Boolean = false)
+annotation class UserPermissions(@get:JvmName("value") vararg val permissions: Permission)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/annotations/Test.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/annotations/Test.kt
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.api.commands.application.annotations
 
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
 import io.github.freya022.botcommands.api.core.config.BApplicationConfig
-import net.dv8tion.jda.api.entities.Guild
 
 /**
  * Defines an **annotated** application command as being test-only.
@@ -13,18 +12,6 @@ import net.dv8tion.jda.api.entities.Guild
  * **Note:** This only applies to top-level commands, for slash commands,
  * this means the annotation needs to be used alongside [@TopLevelSlashCommandData][TopLevelSlashCommandData].
  */
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Test(
-    /**
-     * Specifies the [Guild] IDs in which the command should try to be inserted in
-     */
-    val guildIds: LongArray = [],
-
-    /**
-     * Whether this should be added to the list of existing test guild IDs
-     *
-     * **Default:** false
-     */
-    val append: Boolean = false
-)
+annotation class Test(@get:JvmName("value") vararg val guildIds: Long)

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/Executable.kt
@@ -81,13 +81,13 @@ interface Executable {
     /**
      * Finds all annotations of type [annotationType] from this executable's function.
      *
-     * The search is breadth-first and considers meta-annotations.
+     * The annotations are not in any specific order, this considers meta-annotations.
      *
      * [@Repeatable][Repeatable] is supported.
      *
-     * @param rootOverride Whether a direct annotation on this element overrides all meta-annotations
+     * @param directOverrides Whether a direct annotation should override meta-annotations of the same type
      */
-    fun <A : Annotation> findAllAnnotations(annotationType: Class<out A>, rootOverride: Boolean) = function.findAllAnnotations(annotationType.kotlin)
+    fun <A : Annotation> findAllAnnotations(annotationType: Class<out A>, directOverrides: Boolean) = function.findAllAnnotations(annotationType.kotlin, directOverrides)
 
     /**
      * Finds all annotations meta-annotated with [annotationType] from this executable's function.
@@ -121,13 +121,13 @@ inline fun <reified A : Annotation> Executable.findAnnotation() = function.findA
 /**
  * Finds all annotations of type [A] from this executable's function.
  *
- * The search is breadth-first and considers meta-annotations.
+ * The annotations are not in any specific order, this considers meta-annotations.
  *
  * [@Repeatable][Repeatable] is supported.
  *
- * @param rootOverride Whether a direct annotation on this element overrides all meta-annotations
+ * @param directOverrides Whether a direct annotation should override meta-annotations of the same type
  */
-inline fun <reified A : Annotation> Executable.findAllAnnotations(rootOverride: Boolean = true) = function.findAllAnnotations<A>(rootOverride)
+inline fun <reified A : Annotation> Executable.findAllAnnotations(directOverrides: Boolean = true) = function.findAllAnnotations<A>(directOverrides)
 
 /**
  * Finds all annotations meta-annotated with [A] from this executable's function.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/utils/Annotations.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/utils/Annotations.kt
@@ -4,6 +4,7 @@ package io.github.freya022.botcommands.api.core.utils
 
 import java.lang.annotation.Inherited
 import java.util.*
+import kotlin.collections.flatMap
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
 import kotlin.reflect.safeCast
@@ -80,55 +81,57 @@ fun <A : Annotation> KAnnotatedElement.findAnnotationRecursive(annotationType: K
 /**
  * Finds all annotations of type [A] from the annotated [element].
  *
- * The search is breadth-first and considers meta-annotations,
+ * The annotations are not in any specific order, this considers meta-annotations,
  * but does not support superclasses via [@Inherited][Inherited].
  *
  * [@Repeatable][Repeatable] is supported.
  *
- * @param rootOverride Whether a direct annotation on this element overrides all meta-annotations
+ * @param directOverrides Whether a direct annotation should override meta-annotations of the same type
  */
 @JvmOverloads
-fun <A : Annotation> findAllAnnotations(element: KAnnotatedElement, annotationType: Class<A>, rootOverride: Boolean = true): List<A> =
-    element.findAllAnnotations(annotationType.kotlin, rootOverride)
+fun <A : Annotation> findAllAnnotations(element: KAnnotatedElement, annotationType: Class<A>, directOverrides: Boolean = true): List<A> =
+    element.findAllAnnotations(annotationType.kotlin, directOverrides)
 
 /**
  * Finds all annotations of type [A] from the annotated element.
  *
- * The search is breadth-first and considers meta-annotations,
+ * The annotations are not in any specific order, this considers meta-annotations,
  * but does not support superclasses via [@Inherited][Inherited].
  *
  * [@Repeatable][Repeatable] is supported.
  *
- * @param rootOverride Whether a direct annotation on this element overrides all meta-annotations
+ * @param directOverrides Whether a direct annotation should override meta-annotations of the same type
  */
 @JvmSynthetic
-inline fun <reified A : Annotation> KAnnotatedElement.findAllAnnotations(rootOverride: Boolean = true): List<A> =
-    findAllAnnotations(A::class, rootOverride)
+inline fun <reified A : Annotation> KAnnotatedElement.findAllAnnotations(directOverrides: Boolean = true): List<A> =
+    findAllAnnotations(A::class, directOverrides)
 
 /**
  * Finds all annotations of type [A] from the annotated element.
  *
- * The search is breadth-first and considers meta-annotations,
+ * The annotations are not in any specific order, this considers meta-annotations,
  * but does not support superclasses via [@Inherited][Inherited].
  *
  * [@Repeatable][Repeatable] is supported.
  *
- * @param rootOverride Whether a direct annotation on this element overrides all meta-annotations
+ * @param directOverrides Whether a direct annotation should override meta-annotations of the same type
  */
 @JvmSynthetic
-fun <A : Annotation> KAnnotatedElement.findAllAnnotations(annotationType: KClass<A>, rootOverride: Boolean = true): List<A> {
-    if (rootOverride) {
-        val directAnnotations = annotations.filterIsInstance(annotationType.java)
-        if (directAnnotations.isNotEmpty())
-            return directAnnotations
+fun <A : Annotation> KAnnotatedElement.findAllAnnotations(annotationType: KClass<A>, directOverrides: Boolean = true): List<A> {
+    return findAllAnnotations(annotationType, directOverrides, hashSetOf())
+}
+
+private fun <A : Annotation> KAnnotatedElement.findAllAnnotations(annotationType: KClass<A>, directOverrides: Boolean, visited: MutableSet<KClass<out Annotation>>): List<A> {
+    val directAnnotations = annotations.filterIsInstance(annotationType.java)
+    if (directOverrides && directAnnotations.isNotEmpty()) {
+        return directAnnotations
     }
 
-    return buildList {
-        bfs(this@findAllAnnotations) {
-            val annotation = annotationType.safeCast(it)
-            if (annotation != null)
-                this += annotation
-            true
+    return directAnnotations + annotations.flatMap {
+        if (visited.add(it.annotationClass)) {
+            it.annotationClass.findAllAnnotations(annotationType, directOverrides, visited)
+        } else {
+            emptyList()
         }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/utils/AnnotationUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/utils/AnnotationUtils.kt
@@ -9,7 +9,6 @@ import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.Filter
 import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.*
-import io.github.freya022.botcommands.internal.utils.ReflectionUtils.declaringClass
 import net.dv8tion.jda.api.Permission
 import java.util.*
 import kotlin.reflect.KClass
@@ -20,68 +19,16 @@ import io.github.freya022.botcommands.api.commands.annotations.Filter as FilterA
 internal object AnnotationUtils {
     internal fun getEffectiveTestGuildIds(context: BContext, func: KFunction<*>): TLongSet {
         val set = TLongHashSet(context.applicationConfig.testGuildIds)
-
-        // Always add class values
-        func.declaringClass.findAnnotationRecursive<Test>()
-            ?.guildIds
-            ?.let(set::addAll)
-
-        // Add function values if present
-        val functionAnnotation = func.findAnnotationRecursive<Test>()
-        if (functionAnnotation != null) {
-            if (functionAnnotation.append) {
-                set.addAll(functionAnnotation.guildIds)
-            } else {
-                set.clear()
-                set.addAll(functionAnnotation.guildIds)
-            }
-        }
-
+        func.findAllAnnotations<Test>().forEach { set.addAll(it.guildIds) }
         return set
     }
 
     internal fun getUserPermissions(func: KFunction<*>): EnumSet<Permission> {
-        val set: EnumSet<Permission> = enumSetOf()
-
-        // Always add class values
-        func.declaringClass.findAnnotationRecursive<UserPermissions>()
-            ?.permissions
-            ?.let(set::addAll)
-
-        // Add function values if present
-        val functionAnnotation = func.findAnnotationRecursive<UserPermissions>()
-        if (functionAnnotation != null) {
-            if (functionAnnotation.append) {
-                set += functionAnnotation.permissions
-            } else {
-                set.clear()
-                set += functionAnnotation.permissions
-            }
-        }
-
-        return set
+        return func.findAllAnnotations<UserPermissions>().flatMapTo(enumSetOf()) { it.permissions }
     }
 
     internal fun getBotPermissions(func: KFunction<*>): EnumSet<Permission> {
-        val set: EnumSet<Permission> = enumSetOf()
-
-        // Always add class values
-        func.declaringClass.findAnnotationRecursive<BotPermissions>()
-            ?.permissions
-            ?.let(set::addAll)
-
-        // Add function values if present
-        val functionAnnotation = func.findAnnotationRecursive<BotPermissions>()
-        if (functionAnnotation != null) {
-            if (functionAnnotation.append) {
-                set += functionAnnotation.permissions
-            } else {
-                set.clear()
-                set += functionAnnotation.permissions
-            }
-        }
-
-        return set
+        return func.findAllAnnotations<BotPermissions>().flatMapTo(enumSetOf()) { it.permissions }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/test/kotlin/io/github/freya022/botcommands/framework/RecursiveAnnotationTests.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/framework/RecursiveAnnotationTests.kt
@@ -3,6 +3,7 @@ package io.github.freya022.botcommands.framework
 import io.github.freya022.botcommands.api.core.utils.findAllAnnotations
 import io.github.freya022.botcommands.api.core.utils.findAnnotationRecursive
 import io.github.freya022.botcommands.api.core.utils.flatMap
+import io.github.freya022.botcommands.api.core.utils.flatMapTo
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Disabled
@@ -68,11 +69,11 @@ private object InheritedAnnotations {
 
 object RecursiveAnnotationTests {
     @Test
-    fun `Find all annotations in order`() {
-        val allAnnotations = FindAllAnnotations.MyClass::class.findAllAnnotations<FindAllAnnotations.MyAnnotation>()
+    fun `Find all annotations, no override`() {
+        val allAnnotations = FindAllAnnotations.MyClass::class.findAllAnnotations<FindAllAnnotations.MyAnnotation>(directOverrides = false)
 
         assertEquals(
-            listOf(
+            setOf(
                 "A",
                 "B",
                 "C",
@@ -81,14 +82,14 @@ object RecursiveAnnotationTests {
                 "F",
                 "G",
             ),
-            allAnnotations.map { it.name }
+            allAnnotations.mapTo(hashSetOf()) { it.name }
         )
     }
 
     @Test
     fun `Override indirect annotations with direct annotation`() {
         val values = OverrideIndirectAnnotations.MultipleValuesAnnotated::class
-            .findAllAnnotations<OverrideIndirectAnnotations.AnnotationWithValues>(rootOverride = true)
+            .findAllAnnotations<OverrideIndirectAnnotations.AnnotationWithValues>(directOverrides = true)
             .flatMap { it.values.toTypedArray() }
 
         assertEquals(listOf(4), values)
@@ -97,7 +98,7 @@ object RecursiveAnnotationTests {
     @Test
     fun `Override indirect annotations with direct repeatable annotation`() {
         val values = OverrideIndirectAnnotations.MultipleValuesAnnotated::class
-            .findAllAnnotations<OverrideIndirectAnnotations.RepeatableAnnotationWithValues>(rootOverride = true)
+            .findAllAnnotations<OverrideIndirectAnnotations.RepeatableAnnotationWithValues>(directOverrides = true)
             .flatMap { it.values.toTypedArray() }
 
         assertEquals(listOf(1, 2), values)
@@ -106,11 +107,10 @@ object RecursiveAnnotationTests {
     @Test
     fun `Merge annotations`() {
         val values = OverrideIndirectAnnotations.MultipleValuesAnnotated::class
-            .findAllAnnotations<OverrideIndirectAnnotations.AnnotationWithValues>(rootOverride = false)
-            .flatMap { it.values.toTypedArray() }
+            .findAllAnnotations<OverrideIndirectAnnotations.AnnotationWithValues>(directOverrides = false)
+            .flatMapTo(hashSetOf()) { it.values.toTypedArray() }
 
-        // BFS order!
-        assertEquals(listOf(4, 3), values)
+        assertEquals(hashSetOf(4, 3), values)
     }
 
     @Disabled("Not implemented yet")

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashBanManual.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashBanManual.kt
@@ -18,7 +18,7 @@ import io.github.freya022.botcommands.test.services.Disabled
 @Disabled
 @Command
 class SlashBanManual : ApplicationCommand(), GuildApplicationCommandProvider {
-    @Test(guildIds = [722891685755093072])
+    @Test(722891685755093072)
     @JDASlashCommand(name = "ban_annotated")
     @TopLevelSlashCommandData(defaultLocked = true, scope = CommandScope.GUILD)
     suspend fun onSlashBan(


### PR DESCRIPTION
You will now have to annotate the affected function directly, to make it clearer what affects a function, however, to reduce repetition, you can use them as meta annotations, combine them and override them.

Affected annotations: `@BotPermissions`, `@UserPermissions`, `@Test`

### Breaking changes
- Removed the `append` attribute
- Removed the `CLASS` target
- If `findAllAnnotations` encounters the target annotation, this will overrides meta-annotations (childs) if `directOverrides` is `true`
- `findAllAnnotations` has no defined order anymore

### Changes
- Added the `ANNOTATION_CLASS` target