### PR TITLE
Add and use jda-emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -382,3 +382,5 @@ but where having a `Member` triggers additional checks, such as in ban commands.
 [emoji-java](https://github.com/MinnDevelopment/emoji-java) has been replaced with [JEmoji](https://github.com/felldo/JEmoji),
 providing a more up-to-date emoji list, 
 also allowing dropping `org.json` and fixing issues with emoji indexes, and incorrect fitzpatrick formats.
+
+[jda-emojis](https://github.com/freya022/jda-emojis) was also added to get `UnicodeEmoji`s directly.

--- a/README.md
+++ b/README.md
@@ -174,18 +174,20 @@ Here is how you would create a slash command that sends a message in a specified
 <summary>Kotlin</summary>
 
 ```kt
-private val wastebasket: UnicodeEmoji by lazyUnicodeEmoji { Emojis.WASTEBASKET }
-
 @Command
-@RequiresComponents // Disables the command if components are not enabled
-class SlashSay(private val buttons: Buttons) : ApplicationCommand() {
+@RequiresComponents // (Optional) Disables the command if components are not enabled
+class SlashSay(
+    private val buttons: Buttons // Factory for buttons
+) : ApplicationCommand() {
+
+    // The descriptions can also be moved to localization files, reducing noise
     @JDASlashCommand(name = "say", description = "Sends a message in a channel")
     suspend fun onSlashSay(
         event: GuildSlashEvent,
         @SlashOption(description = "Channel to send the message in") channel: TextChannel,
         @SlashOption(description = "What to say") content: String
     ) {
-        val deleteButton = buttons.danger(wastebasket).ephemeral {
+        val deleteButton = buttons.danger(UnicodeEmojis.WASTEBASKET).ephemeral {
             bindTo { buttonEvent ->
                 buttonEvent.deferEdit().queue()
                 buttonEvent.hook.deleteOriginal().await()
@@ -208,13 +210,14 @@ class SlashSay(private val buttons: Buttons) : ApplicationCommand() {
 <summary>Kotlin (DSL)</summary>
 
 ```kt
-private val wastebasket: UnicodeEmoji by lazyUnicodeEmoji { Emojis.WASTEBASKET }
-
 @Command
-@RequiresComponents // Disables the command if components are not enabled
-class SlashSay(private val buttons: Buttons) : GlobalApplicationCommandProvider {
+@RequiresComponents // (Optional) Disables the command if components are not enabled
+class SlashSay(
+    private val buttons: Buttons // Factory for buttons
+) : GlobalApplicationCommandProvider {
+
     suspend fun onSlashSay(event: GuildSlashEvent, channel: TextChannel, content: String) {
-        val deleteButton = buttons.danger(wastebasket).ephemeral {
+        val deleteButton = buttons.danger(UnicodeEmojis.WASTEBASKET).ephemeral {
             bindTo { buttonEvent ->
                 buttonEvent.deferEdit().queue()
                 buttonEvent.hook.deleteOriginal().await()
@@ -230,11 +233,12 @@ class SlashSay(private val buttons: Buttons) : GlobalApplicationCommandProvider 
             .await()
     }
 
-    // This is nice if you need to run your own code to declare commands
+    // This is nice if you need to run your own code to declare commands.
     // For example, a loop to create commands based on an enum
     // If you don't need any dynamic stuff, just stick to annotations
     override fun declareGlobalApplicationCommands(manager: GlobalApplicationCommandManager) {
         manager.slashCommand("say", function = ::onSlashSay) {
+            // The descriptions can also be moved to localization files
             description = "Sends a message in a channel"
 
             option("channel") {
@@ -255,26 +259,23 @@ class SlashSay(private val buttons: Buttons) : GlobalApplicationCommandProvider 
 
 ```java
 @Command
-@RequiresComponents // Disables the command if components are not enabled
-public class SlashSay extends ApplicationCommand {
-    // Little trick to get the emoji lazily, this will reduce the startup impact
-    static class Emojis {
-        private static final UnicodeEmoji WASTEBASKET = EmojiUtils.asUnicodeEmoji(net.fellbaum.jemoji.Emojis.WASTEBASKET);
-    }
+@RequiresComponents // (Optional) Disables the command if components are not enabled
+public class SlashSayJava extends ApplicationCommand {
 
-    private final Buttons buttons;
+    private final Buttons buttons; // Factory for buttons
 
     public SlashSay(Buttons buttons) {
         this.buttons = buttons;
     }
 
+    // The descriptions can also be moved to localization files, reducing noise
     @JDASlashCommand(name = "say", description = "Sends a message in a channel")
     public void onSlashSay(
             GuildSlashEvent event,
             @SlashOption(description = "Channel to send the message in") TextChannel channel,
             @SlashOption(description = "What to say") String content
     ) {
-        final Button deleteButton = buttons.danger(Emojis.WASTEBASKET).ephemeral()
+        final Button deleteButton = buttons.danger(UnicodeEmojis.WASTEBASKET).ephemeral()
                 .bindTo(buttonEvent -> {
                     buttonEvent.deferEdit().queue();
                     buttonEvent.getHook().deleteOriginal().queue();

--- a/pom.xml
+++ b/pom.xml
@@ -510,6 +510,11 @@
             <version>1.6.0</version>
         </dependency>
         <dependency>
+            <groupId>dev.freya02</groupId>
+            <artifactId>jda-emojis</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>24.1.0</version>

--- a/src/main/java/io/github/freya022/botcommands/api/utils/EmojiUtils.java
+++ b/src/main/java/io/github/freya022/botcommands/api/utils/EmojiUtils.java
@@ -1,5 +1,7 @@
 package io.github.freya022.botcommands.api.utils;
 
+import dev.freya02.jda.emojis.Emojis;
+import dev.freya02.jda.emojis.UnicodeEmojis;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.entities.emoji.UnicodeEmoji;
 import net.fellbaum.jemoji.EmojiManager;
@@ -121,15 +123,10 @@ public class EmojiUtils {
     /**
      * Converts the provided {@link net.fellbaum.jemoji.Emoji Emoji} into a JDA {@link UnicodeEmoji}.
      *
-     * <p>I highly recommend putting your emojis in a class that is loaded only when necessary,
-     * avoiding any unnecessary startup delay.
-     * You can do so by using a static inner class, for example:
+     * <p>I highly recommend using the emojis in-place, not putting them in constants/fields,
+     * so that they are loaded only when used.
      *
-     * <pre><code>
-     * static class Emojis {
-     *     private static final UnicodeEmoji WASTEBASKET = EmojiUtils.asUnicodeEmoji(net.fellbaum.jemoji.Emojis.WASTEBASKET);
-     * }
-     * </code></pre>
+     * <p><b>Note:</b> If you use the emoji constants, you can instead use the constants from {@link Emojis} or {@link UnicodeEmojis}.
      *
      * @param emoji The {@link net.fellbaum.jemoji.Emoji Emoji} to convert
      *

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/Buttons.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/Buttons.kt
@@ -1,10 +1,10 @@
 package io.github.freya022.botcommands.api.components
 
+import dev.freya02.jda.emojis.Emojis
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.components.builder.button.ButtonFactory
 import io.github.freya022.botcommands.api.components.utils.ButtonContent
 import io.github.freya022.botcommands.api.core.service.annotations.BService
-import io.github.freya022.botcommands.api.utils.EmojiUtils
 import io.github.freya022.botcommands.internal.components.controller.ComponentController
 import net.dv8tion.jda.api.entities.emoji.Emoji
 import net.dv8tion.jda.api.interactions.components.buttons.Button
@@ -171,7 +171,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * You can use [ButtonFactory.persistent] or [ButtonFactory.ephemeral] to then start building a button.
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      * @see ButtonFactory.withEmoji
      */
     @CheckReturnValue
@@ -185,7 +185,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * @throws IllegalArgumentException If the label is empty
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      * @see ButtonFactory.withEmoji
      */
     @CheckReturnValue
@@ -199,7 +199,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * @throws IllegalArgumentException If the label is null/blank and the emoji isn't set
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      * @see ButtonContent.withEmoji
      */
     @CheckReturnValue
@@ -224,7 +224,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * You can use [ButtonFactory.persistent] or [ButtonFactory.ephemeral] to then start building a button.
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      * @see ButtonFactory.withEmoji
      */
     @CheckReturnValue
@@ -238,7 +238,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * @throws IllegalArgumentException If the label is empty
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      * @see ButtonFactory.withEmoji
      */
     @CheckReturnValue
@@ -263,7 +263,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * You can use [ButtonFactory.persistent] or [ButtonFactory.ephemeral] to then start building a button.
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      * @see ButtonFactory.withEmoji
      */
     @CheckReturnValue
@@ -277,7 +277,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * @throws IllegalArgumentException If the label is empty
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      * @see ButtonFactory.withEmoji
      */
     @CheckReturnValue
@@ -302,7 +302,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * You can use [ButtonFactory.persistent] or [ButtonFactory.ephemeral] to then start building a button.
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      * @see ButtonFactory.withEmoji
      */
     @CheckReturnValue
@@ -316,7 +316,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * @throws IllegalArgumentException If the label is empty
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      * @see ButtonFactory.withEmoji
      */
     @CheckReturnValue
@@ -341,7 +341,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * You can use [ButtonFactory.persistent] or [ButtonFactory.ephemeral] to then start building a button.
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      * @see ButtonFactory.withEmoji
      */
     @CheckReturnValue
@@ -355,7 +355,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * @throws IllegalArgumentException If the label is empty
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      * @see ButtonFactory.withEmoji
      */
     @CheckReturnValue
@@ -380,7 +380,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * @throws IllegalArgumentException If the url is empty
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      */
     @CheckReturnValue
     fun link(url: String, emoji: Emoji): Button =
@@ -393,7 +393,7 @@ class Buttons internal constructor(componentController: ComponentController) : A
      *
      * @throws IllegalArgumentException If the url/label is empty
      *
-     * @see EmojiUtils.resolveJDAEmoji
+     * @see Emojis
      */
     @CheckReturnValue
     fun link(url: String, label: String, emoji: Emoji): Button =

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/button/ButtonFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/button/ButtonFactory.kt
@@ -62,6 +62,12 @@ class ButtonFactory internal constructor(
     }
 
     /**
+     * Creates a new button factory with the provided JDA emoji.
+     */
+    @CheckReturnValue
+    fun withEmoji(emoji: Emoji?): ButtonFactory = ButtonFactory(componentController, style, label, emoji)
+
+    /**
      * Creates an ephemeral button builder.
      *
      * As a reminder, a [default timeout][Components.defaultEphemeralTimeout] is set.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/utils/ButtonContent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/utils/ButtonContent.kt
@@ -50,6 +50,12 @@ data class ButtonContent(val style: ButtonStyle, val label: String?, val emoji: 
         return ButtonContent(style, label, newEmoji)
     }
 
+    /**
+     * Creates a new button content with the provided JDA emoji.
+     */
+    @CheckReturnValue
+    fun withEmoji(emoji: Emoji?): ButtonContent = ButtonContent(style, label, emoji)
+
     companion object {
         /**
          * Constructs a [ButtonContent] with a label.

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/utils/ButtonContent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/utils/ButtonContent.kt
@@ -93,24 +93,42 @@ data class ButtonContent(val style: ButtonStyle, val label: String?, val emoji: 
         /**
          * Constructs a [ButtonContent] with a label and an unicode emoji,
          * see [Emoji.fromUnicode] for accepted formats.
+         *
+         * @see <a href="https://github.com/freya022/jda-emojis" target="_blank">jda-emojis</a>
          */
         @JvmStatic
+        @Deprecated(
+            message = "Prefer using emojis from the jda-emojis library, and pass them to fromEmoji",
+            replaceWith = ReplaceWith(expression = "fromEmoji(style, label, Emojis.)", imports = ["dev.freya02.jda.emojis.Emojis"])
+        )
         fun fromUnicode(style: ButtonStyle, label: String, unicode: String): ButtonContent {
             return ButtonContent(style, label, Emoji.fromUnicode(unicode))
         }
 
         /**
          * Constructs a [ButtonContent] from a shortcode emoji, such as `:joy:`.
+         *
+         * @see <a href="https://github.com/freya022/jda-emojis" target="_blank">jda-emojis</a>
          */
         @JvmStatic
+        @Deprecated(
+            message = "Prefer using emojis from the jda-emojis library, and pass them to fromEmoji",
+            replaceWith = ReplaceWith(expression = "fromEmoji(style, Emojis.)", imports = ["dev.freya02.jda.emojis.Emojis"])
+        )
         fun fromShortcode(style: ButtonStyle, shortcode: String): ButtonContent {
             return ButtonContent(style, null, EmojiUtils.resolveJDAEmoji(shortcode))
         }
 
         /**
          * Constructs a [ButtonContent] from a [String] and a shortcode emoji, such as `:joy:`.
+         *
+         * @see <a href="https://github.com/freya022/jda-emojis" target="_blank">jda-emojis</a>
          */
         @JvmStatic
+        @Deprecated(
+            message = "Prefer using emojis from the jda-emojis library, and pass them to fromEmoji",
+            replaceWith = ReplaceWith(expression = "fromEmoji(style, text, Emojis.)", imports = ["dev.freya02.jda.emojis.Emojis"])
+        )
         fun fromShortcode(style: ButtonStyle, text: String, shortcode: String): ButtonContent {
             return ButtonContent(style, text, EmojiUtils.resolveJDAEmoji(shortcode))
         }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BTextConfig.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BTextConfig.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.api.core.config
 
+import dev.freya02.jda.emojis.Emojis
 import io.github.freya022.botcommands.api.commands.text.IHelpCommand
 import io.github.freya022.botcommands.api.commands.text.TextPrefixSupplier
 import io.github.freya022.botcommands.api.commands.text.annotations.RequiresTextCommands
@@ -106,7 +107,7 @@ class BTextConfigBuilder internal constructor() : BTextConfig {
         set(value) {
             dmClosedEmojiSupplier = { value }
         }
-    var dmClosedEmojiSupplier: () -> Emoji = { Emoji.fromUnicode("\uD83D\uDCEA") } // mailbox_closed
+    var dmClosedEmojiSupplier: () -> Emoji = { Emojis.MAILBOX_CLOSED }
 
     @JvmSynthetic
     internal fun build() = object : BTextConfig {

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/utils/Emojis.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/utils/Emojis.kt
@@ -1,11 +1,15 @@
 package io.github.freya022.botcommands.api.core.utils
 
+import dev.freya02.jda.emojis.Emojis
+import dev.freya02.jda.emojis.UnicodeEmojis
 import net.dv8tion.jda.api.entities.emoji.Emoji
 import net.dv8tion.jda.api.entities.emoji.UnicodeEmoji
 import net.fellbaum.jemoji.Emoji as JEmoji
 
 /**
  * Converts this JEmoji [Emoji][JEmoji] into a JDA [UnicodeEmoji].
+ *
+ * **Note:** If you use the emoji constants, you can instead use the constants from [Emojis] or [UnicodeEmojis].
  *
  * @see lazyUnicodeEmoji
  */
@@ -14,7 +18,23 @@ fun JEmoji.asUnicodeEmoji(): UnicodeEmoji = Emoji.fromUnicode(emoji)
 /**
  * Lazily converts the supplied [Emoji][JEmoji] into a JDA [UnicodeEmoji].
  *
+ * **Note:** If you use the emoji constants, you can instead use the constants from [Emojis] or [UnicodeEmojis].
+ *
  * This is useful to load JEmoji only when it's necessary, avoiding any startup delay.
+ *
+ * An alternative is to use the emoji in-place, i.e., where is it actually used.
  */
+@JvmName("lazyJEmojiUnicodeEmoji")
 fun lazyUnicodeEmoji(supplier: () -> JEmoji): Lazy<UnicodeEmoji> =
     lazy { supplier().asUnicodeEmoji() }
+
+/**
+ * Lazily converts the supplied [Emoji] into a JDA [UnicodeEmoji].
+ *
+ * This is useful to load emojis only when it's necessary, avoiding any startup delay.
+ *
+ * An alternative is to use the emoji in-place, i.e., where is it actually used.
+ */
+@JvmName("lazyJdaUnicodeEmoji")
+fun lazyUnicodeEmoji(supplier: () -> UnicodeEmoji): Lazy<UnicodeEmoji> =
+    lazy { supplier() }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/BaseCommandEventImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/BaseCommandEventImpl.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.internal.commands.text
 
+import dev.freya02.jda.emojis.Emojis
 import io.github.freya022.botcommands.api.commands.ratelimit.CancellableRateLimit
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.core.BContext
@@ -12,7 +13,6 @@ import net.dv8tion.jda.api.Permission.MESSAGE_HISTORY
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
-import net.dv8tion.jda.api.entities.emoji.Emoji
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.requests.RestAction
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
@@ -22,9 +22,6 @@ import java.util.function.Consumer
 import javax.annotation.CheckReturnValue
 
 private val logger = KotlinLogging.loggerOf<BaseCommandEvent>()
-
-private val SUCCESS = Emoji.fromUnicode("✅") // white_check_mark
-private val ERROR = Emoji.fromUnicode("❌") // x
 
 internal open class BaseCommandEventImpl(
     private val context: BContext,
@@ -88,10 +85,10 @@ internal open class BaseCommandEventImpl(
     }
 
     @CheckReturnValue
-    override fun reactSuccess(): RestAction<Void> = channel.addReactionById(messageId, SUCCESS)
+    override fun reactSuccess(): RestAction<Void> = channel.addReactionById(messageId, Emojis.WHITE_CHECK_MARK)
 
     @CheckReturnValue
-    override fun reactError(): RestAction<Void> = channel.addReactionById(messageId, ERROR)
+    override fun reactError(): RestAction<Void> = channel.addReactionById(messageId, Emojis.X)
 
     override fun respond(text: CharSequence): MessageCreateAction = channel.sendMessage(text)
 

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashSay.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashSay.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.test.commands.slash
 
+import dev.freya02.jda.emojis.UnicodeEmojis
 import dev.minn.jda.ktx.coroutines.await
 import dev.minn.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
@@ -12,24 +13,23 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.components.Buttons
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.core.utils.deleteDelayed
-import io.github.freya022.botcommands.api.core.utils.lazyUnicodeEmoji
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
-import net.dv8tion.jda.api.entities.emoji.UnicodeEmoji
-import net.fellbaum.jemoji.Emojis
 import kotlin.time.Duration.Companion.seconds
 
-private val wastebasket: UnicodeEmoji by lazyUnicodeEmoji { Emojis.WASTEBASKET }
-
 @Command
-@RequiresComponents // Disables the command if components are not enabled
-class SlashSay(private val buttons: Buttons) : ApplicationCommand() {
+@RequiresComponents // (Optional) Disables the command if components are not enabled
+class SlashSay(
+    private val buttons: Buttons // Factory for buttons
+) : ApplicationCommand() {
+
+    // The descriptions can also be moved to localization files, reducing noise
     @JDASlashCommand(name = "say", description = "Sends a message in a channel")
     suspend fun onSlashSay(
         event: GuildSlashEvent,
         @SlashOption(description = "Channel to send the message in") channel: TextChannel,
         @SlashOption(description = "What to say") content: String
     ) {
-        val deleteButton = buttons.danger(wastebasket).ephemeral {
+        val deleteButton = buttons.danger(UnicodeEmojis.WASTEBASKET).ephemeral {
             bindTo { buttonEvent ->
                 buttonEvent.deferEdit().queue()
                 buttonEvent.hook.deleteOriginal().await()
@@ -47,10 +47,13 @@ class SlashSay(private val buttons: Buttons) : ApplicationCommand() {
 }
 
 @Command
-@RequiresComponents // Disables the command if components are not enabled
-class SlashSayDsl(private val buttons: Buttons) : GlobalApplicationCommandProvider {
+@RequiresComponents // (Optional) Disables the command if components are not enabled
+class SlashSayDsl(
+    private val buttons: Buttons // Factory for buttons
+) : GlobalApplicationCommandProvider {
+
     suspend fun onSlashSay(event: GuildSlashEvent, channel: TextChannel, content: String) {
-        val deleteButton = buttons.danger(wastebasket).ephemeral {
+        val deleteButton = buttons.danger(UnicodeEmojis.WASTEBASKET).ephemeral {
             bindTo { buttonEvent ->
                 buttonEvent.deferEdit().queue()
                 buttonEvent.hook.deleteOriginal().await()
@@ -66,11 +69,12 @@ class SlashSayDsl(private val buttons: Buttons) : GlobalApplicationCommandProvid
             .await()
     }
 
-    // This is nice if you need to run your own code to declare commands
+    // This is nice if you need to run your own code to declare commands.
     // For example, a loop to create commands based on an enum
     // If you don't need any dynamic stuff, just stick to annotations
     override fun declareGlobalApplicationCommands(manager: GlobalApplicationCommandManager) {
         manager.slashCommand("say_dsl", function = ::onSlashSay) {
+            // The descriptions can also be moved to localization files, reducing noise
             description = "Sends a message in a channel"
 
             option("channel") {

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashSayJava.java
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashSayJava.java
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.test.commands.slash;
 
+import dev.freya02.jda.emojis.UnicodeEmojis;
 import io.github.freya022.botcommands.api.commands.annotations.Command;
 import io.github.freya022.botcommands.api.commands.application.ApplicationCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent;
@@ -8,34 +9,29 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.components.Button;
 import io.github.freya022.botcommands.api.components.Buttons;
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents;
-import io.github.freya022.botcommands.api.utils.EmojiUtils;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
-import net.dv8tion.jda.api.entities.emoji.UnicodeEmoji;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 
 import java.time.Duration;
 
 @Command
-@RequiresComponents // Disables the command if components are not enabled
+@RequiresComponents // (Optional) Disables the command if components are not enabled
 public class SlashSayJava extends ApplicationCommand {
-    // Little trick to get the emoji lazily, this will reduce the startup impact
-    static class Emojis {
-        private static final UnicodeEmoji WASTEBASKET = EmojiUtils.asUnicodeEmoji(net.fellbaum.jemoji.Emojis.WASTEBASKET);
-    }
 
-    private final Buttons buttons;
+    private final Buttons buttons; // Factory for buttons
 
     public SlashSayJava(Buttons buttons) {
         this.buttons = buttons;
     }
 
+    // The descriptions can also be moved to localization files, reducing noise
     @JDASlashCommand(name = "say_java", description = "Sends a message in a channel")
     public void onSlashSay(
             GuildSlashEvent event,
             @SlashOption(description = "Channel to send the message in") TextChannel channel,
             @SlashOption(description = "What to say") String content
     ) {
-        final Button deleteButton = buttons.danger(Emojis.WASTEBASKET).ephemeral()
+        final Button deleteButton = buttons.danger(UnicodeEmojis.WASTEBASKET).ephemeral()
                 .bindTo(buttonEvent -> {
                     buttonEvent.deferEdit().queue();
                     buttonEvent.getHook().deleteOriginal().queue();


### PR DESCRIPTION
### Deprecations
- `ButtonContent`: `fromUnicode`, `fromShortcode`

### New features
- Added an `withEmoji` overload with JDA's `Emoji` in `ButtonContent`/`ButtonFactory` (when building a button)