### PR TITLE
Add support for component data deserialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,11 @@
             <version>2.17.2</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>2.17.2</version>
+        </dependency>
+        <dependency>
             <groupId>club.minnced</groupId>
             <artifactId>jda-ktx</artifactId>
             <version>0.12.0</version>
@@ -582,12 +587,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.17.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-kotlin</artifactId>
             <version>2.17.2</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -586,6 +586,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>2.17.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.11.4</version>

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/ComponentData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/ComponentData.kt
@@ -1,15 +1,25 @@
 package io.github.freya022.botcommands.api.components.annotations
 
 import io.github.freya022.botcommands.api.components.builder.IPersistentActionableComponent
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableComponentData
+import io.github.freya022.botcommands.api.parameters.ParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 
 /**
  * Sets this parameter as data coming from [IPersistentActionableComponent.bindTo].
  *
  * The order and types of the passed data must match with the handler parameters.
  *
+ * ### Requirements
+ * A compatible [ComponentParameterResolver] must exist for the annotated parameter,
+ * the default supported types can be seen in [ParameterResolver].
+ *
+ * If your parameter is a serializable object,
+ * you can instead use [@SerializableComponentData][SerializableComponentData].
+ *
  * @see JDAButtonListener @JDAButtonListener
  * @see JDASelectMenuListener @JDASelectMenuListener
  */
-@Target(AnnotationTarget.VALUE_PARAMETER)
+@Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class ComponentData

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/TimeoutData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/TimeoutData.kt
@@ -1,15 +1,25 @@
 package io.github.freya022.botcommands.api.components.annotations
 
 import io.github.freya022.botcommands.api.components.builder.IPersistentTimeoutableComponent
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableTimeoutData
+import io.github.freya022.botcommands.api.parameters.ParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
 
 /**
  * Sets this parameter as data coming from [IPersistentTimeoutableComponent.timeout].
  *
  * The order and types of the passed data must match with the handler parameters.
  *
+ * ### Requirements
+ * A compatible [TimeoutParameterResolver] must exist for the annotated parameter,
+ * the default supported types can be seen in [ParameterResolver].
+ *
+ * If your parameter is a serializable object,
+ * you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
+ *
  * @see ComponentTimeoutHandler @ComponentTimeoutHandler
  * @see GroupTimeoutHandler @GroupTimeoutHandler
  */
-@Target(AnnotationTarget.VALUE_PARAMETER)
+@Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class TimeoutData

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/IActionableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/IActionableComponent.kt
@@ -99,11 +99,11 @@ interface IPersistentActionableComponent<T : IPersistentActionableComponent<T>> 
      *
      * ### Handler data
      * The data passed is [serialized][ComponentParameterResolver.serialize]
-     * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+     * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
      *
      * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
      *
-     * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+     * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
      * you must annotate your parameter with [@ComponentData][ComponentData].
      *
      * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -120,11 +120,11 @@ interface IPersistentActionableComponent<T : IPersistentActionableComponent<T>> 
      *
      * ### Handler data
      * The data passed is [serialized][ComponentParameterResolver.serialize]
-     * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+     * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
      *
      * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
      *
-     * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+     * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
      * you must annotate your parameter with [@ComponentData][ComponentData].
      *
      * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -176,11 +176,11 @@ interface IEphemeralActionableComponent<T : IEphemeralActionableComponent<T, E>,
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -197,11 +197,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -218,11 +218,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -239,11 +239,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -258,11 +258,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -277,11 +277,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -296,11 +296,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -315,11 +315,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -334,11 +334,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -353,11 +353,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -372,11 +372,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -391,11 +391,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -410,11 +410,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -429,11 +429,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -448,11 +448,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -467,11 +467,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -486,11 +486,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -505,11 +505,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -524,11 +524,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -543,11 +543,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -562,11 +562,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -581,11 +581,11 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -604,11 +604,11 @@ private fun <C : IPersistentActionableComponent<C>> C.bindWithBoundCallable(func
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -623,11 +623,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -642,11 +642,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -661,11 +661,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -680,11 +680,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -699,11 +699,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -718,11 +718,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -737,11 +737,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -756,11 +756,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -775,11 +775,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -794,11 +794,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -813,11 +813,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -832,11 +832,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -851,11 +851,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -870,11 +870,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -889,11 +889,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -908,11 +908,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -927,11 +927,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -946,11 +946,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -965,11 +965,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -984,11 +984,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
@@ -1003,11 +1003,11 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  *
  * ### Handler data
  * The data passed is [serialized][ComponentParameterResolver.serialize]
- * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [ComponentParameterResolver]s,
  * you must annotate your parameter with [@ComponentData][ComponentData].
  *
  * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/IActionableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/IActionableComponent.kt
@@ -9,16 +9,17 @@ import io.github.freya022.botcommands.api.components.annotations.JDAButtonListen
 import io.github.freya022.botcommands.api.components.annotations.JDASelectMenuListener
 import io.github.freya022.botcommands.api.components.annotations.getEffectiveName
 import io.github.freya022.botcommands.api.components.ratelimit.ComponentRateLimitReference
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableComponentData
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.findAnnotationRecursive
 import io.github.freya022.botcommands.api.core.utils.isSubclassOf
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
+import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 import io.github.freya022.botcommands.internal.utils.annotationRef
 import io.github.freya022.botcommands.internal.utils.javaMethodInternal
 import io.github.freya022.botcommands.internal.utils.throwArgument
-import net.dv8tion.jda.api.entities.ISnowflake
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
 import java.util.function.Consumer
@@ -97,12 +98,15 @@ interface IPersistentActionableComponent<T : IPersistentActionableComponent<T>> 
      * Binds the given handler name with its arguments to this component.
      *
      * ### Handler data
-     * The data passed is transformed with [toString][Object.toString],
-     * except [snowflakes][ISnowflake] which get their IDs stored.
+     * The data passed is [serialized][ComponentParameterResolver.serialize]
+     * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
      *
-     * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+     * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
      *
-     * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+     * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+     * you must annotate your parameter with [@ComponentData][ComponentData].
+     *
+     * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
      *
      * @param handlerName The name of the handler to run when the button is clicked,
      * defined by either [JDAButtonListener] or [JDASelectMenuListener]
@@ -115,12 +119,15 @@ interface IPersistentActionableComponent<T : IPersistentActionableComponent<T>> 
      * Binds the given handler name with its arguments to this component.
      *
      * ### Handler data
-     * The data passed is transformed with [toString][Object.toString],
-     * except [snowflakes][ISnowflake] which get their IDs stored.
+     * The data passed is [serialized][ComponentParameterResolver.serialize]
+     * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
      *
-     * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+     * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
      *
-     * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+     * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+     * you must annotate your parameter with [@ComponentData][ComponentData].
+     *
+     * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
      *
      * @param handlerName The name of the handler to run when the button is clicked,
      * defined by either [JDAButtonListener] or [JDASelectMenuListener]
@@ -168,10 +175,15 @@ interface IEphemeralActionableComponent<T : IEphemeralActionableComponent<T, E>,
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
+ *
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  *
  * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
  */
@@ -184,10 +196,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
+ *
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  *
  * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
  */
@@ -200,10 +217,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
+ *
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  *
  * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
  */
@@ -216,12 +238,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallable")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1> C.bindWith(func: KFunction2<E, T1, Unit>, arg1: T1): C {
@@ -232,12 +257,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallableSuspend")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2> C.bindWith(func: KSuspendFunction3<E, T1, T2, Unit>, arg1: T1, arg2: T2): C {
@@ -248,12 +276,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallable")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2> C.bindWith(func: KFunction3<E, T1, T2, Unit>, arg1: T1, arg2: T2): C {
@@ -264,12 +295,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallableSuspend")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3> C.bindWith(func: KSuspendFunction4<E, T1, T2, T3, Unit>, arg1: T1, arg2: T2, arg3: T3): C {
@@ -280,12 +314,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallable")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3> C.bindWith(func: KFunction4<E, T1, T2, T3, Unit>, arg1: T1, arg2: T2, arg3: T3): C {
@@ -296,12 +333,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallableSuspend")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4> C.bindWith(func: KSuspendFunction5<E, T1, T2, T3, T4, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4): C {
@@ -312,12 +352,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallable")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4> C.bindWith(func: KFunction5<E, T1, T2, T3, T4, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4): C {
@@ -328,12 +371,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallableSuspend")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5> C.bindWith(func: KSuspendFunction6<E, T1, T2, T3, T4, T5, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): C {
@@ -344,12 +390,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallable")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5> C.bindWith(func: KFunction6<E, T1, T2, T3, T4, T5, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): C {
@@ -360,12 +409,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallableSuspend")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6> C.bindWith(func: KSuspendFunction7<E, T1, T2, T3, T4, T5, T6, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): C {
@@ -376,12 +428,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallable")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6> C.bindWith(func: KFunction7<E, T1, T2, T3, T4, T5, T6, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): C {
@@ -392,12 +447,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallableSuspend")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7> C.bindWith(func: KSuspendFunction8<E, T1, T2, T3, T4, T5, T6, T7, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): C {
@@ -408,12 +466,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallable")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7> C.bindWith(func: KFunction8<E, T1, T2, T3, T4, T5, T6, T7, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): C {
@@ -424,12 +485,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallableSuspend")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8> C.bindWith(func: KSuspendFunction9<E, T1, T2, T3, T4, T5, T6, T7, T8, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): C {
@@ -440,12 +504,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallable")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8> C.bindWith(func: KFunction9<E, T1, T2, T3, T4, T5, T6, T7, T8, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): C {
@@ -456,12 +523,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallableSuspend")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8, T9> C.bindWith(func: KSuspendFunction10<E, T1, T2, T3, T4, T5, T6, T7, T8, T9, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): C {
@@ -472,12 +542,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallable")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8, T9> C.bindWith(func: KFunction10<E, T1, T2, T3, T4, T5, T6, T7, T8, T9, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): C {
@@ -488,12 +561,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallableSuspend")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> C.bindWith(func: KSuspendFunction11<E, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): C {
@@ -504,12 +580,15 @@ fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreat
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithBoundCallable")
 fun <C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> C.bindWith(func: KFunction11<E, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): C {
@@ -524,12 +603,15 @@ private fun <C : IPersistentActionableComponent<C>> C.bindWithBoundCallable(func
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallableSuspend")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent> C.bindWith(func: KSuspendFunction2<T, E, Unit>): C {
@@ -540,12 +622,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallable")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent> C.bindWith(func: KFunction2<T, E, Unit>): C {
@@ -556,12 +641,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallableSuspend")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1> C.bindWith(func: KSuspendFunction3<T, E, T1, Unit>, arg1: T1): C {
@@ -572,12 +660,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallable")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1> C.bindWith(func: KFunction3<T, E, T1, Unit>, arg1: T1): C {
@@ -588,12 +679,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallableSuspend")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2> C.bindWith(func: KSuspendFunction4<T, E, T1, T2, Unit>, arg1: T1, arg2: T2): C {
@@ -604,12 +698,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallable")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2> C.bindWith(func: KFunction4<T, E, T1, T2, Unit>, arg1: T1, arg2: T2): C {
@@ -620,12 +717,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallableSuspend")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3> C.bindWith(func: KSuspendFunction5<T, E, T1, T2, T3, Unit>, arg1: T1, arg2: T2, arg3: T3): C {
@@ -636,12 +736,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallable")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3> C.bindWith(func: KFunction5<T, E, T1, T2, T3, Unit>, arg1: T1, arg2: T2, arg3: T3): C {
@@ -652,12 +755,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallableSuspend")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4> C.bindWith(func: KSuspendFunction6<T, E, T1, T2, T3, T4, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4): C {
@@ -668,12 +774,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallable")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4> C.bindWith(func: KFunction6<T, E, T1, T2, T3, T4, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4): C {
@@ -684,12 +793,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallableSuspend")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5> C.bindWith(func: KSuspendFunction7<T, E, T1, T2, T3, T4, T5, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): C {
@@ -700,12 +812,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallable")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5> C.bindWith(func: KFunction7<T, E, T1, T2, T3, T4, T5, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): C {
@@ -716,12 +831,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallableSuspend")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6> C.bindWith(func: KSuspendFunction8<T, E, T1, T2, T3, T4, T5, T6, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): C {
@@ -732,12 +850,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallable")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6> C.bindWith(func: KFunction8<T, E, T1, T2, T3, T4, T5, T6, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): C {
@@ -748,12 +869,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallableSuspend")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7> C.bindWith(func: KSuspendFunction9<T, E, T1, T2, T3, T4, T5, T6, T7, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): C {
@@ -764,12 +888,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallable")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7> C.bindWith(func: KFunction9<T, E, T1, T2, T3, T4, T5, T6, T7, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): C {
@@ -780,12 +907,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallableSuspend")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8> C.bindWith(func: KSuspendFunction10<T, E, T1, T2, T3, T4, T5, T6, T7, T8, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): C {
@@ -796,12 +926,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallable")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8> C.bindWith(func: KFunction10<T, E, T1, T2, T3, T4, T5, T6, T7, T8, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): C {
@@ -812,12 +945,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallableSuspend")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8, T9> C.bindWith(func: KSuspendFunction11<T, E, T1, T2, T3, T4, T5, T6, T7, T8, T9, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): C {
@@ -828,12 +964,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallable")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8, T9> C.bindWith(func: KFunction11<T, E, T1, T2, T3, T4, T5, T6, T7, T8, T9, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): C {
@@ -844,12 +983,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallableSuspend")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> C.bindWith(func: KSuspendFunction12<T, E, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): C {
@@ -860,12 +1002,15 @@ fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInterac
  * Binds the given handler to this component.
  *
  * ### Handler data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][ComponentParameterResolver.serialize]
+ * and [deserialized][ComponentParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [ComponentParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@ComponentData][ComponentData].
+ * For objects supported by default (see [ParameterResolver]) and other [ComponentParameterResolver]s,
+ * you must annotate your parameter with [@ComponentData][ComponentData].
+ *
+ * For serializable objects, you can instead use [@SerializableComponentData][SerializableComponentData].
  */
 @JvmName("bindWithClassCallable")
 fun <T : Any, C : IPersistentActionableComponent<C>, E : GenericComponentInteractionCreateEvent, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> C.bindWith(func: KFunction12<T, E, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): C {

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/ITimeoutableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/ITimeoutableComponent.kt
@@ -142,11 +142,11 @@ interface IPersistentTimeoutableComponent<T : IPersistentTimeoutableComponent<T>
      *
      * ### Timeout data
      * The data passed is [serialized][TimeoutParameterResolver.serialize]
-     * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+     * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
      *
      * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
      *
-     * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+     * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
      * you must annotate your parameter with [@TimeoutData][TimeoutData].
      *
      * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -180,11 +180,11 @@ interface IPersistentTimeoutableComponent<T : IPersistentTimeoutableComponent<T>
      *
      * ### Timeout data
      * The data passed is [serialized][TimeoutParameterResolver.serialize]
-     * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+     * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
      *
      * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
      *
-     * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+     * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
      * you must annotate your parameter with [@TimeoutData][TimeoutData].
      *
      * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -217,11 +217,11 @@ interface IPersistentTimeoutableComponent<T : IPersistentTimeoutableComponent<T>
      *
      * ### Timeout data
      * The data passed is [serialized][TimeoutParameterResolver.serialize]
-     * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+     * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
      *
      * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
      *
-     * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+     * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
      * you must annotate your parameter with [@TimeoutData][TimeoutData].
      *
      * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -341,11 +341,11 @@ interface IEphemeralTimeoutableComponent<T : IEphemeralTimeoutableComponent<T>> 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -371,11 +371,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeoutWith(dur
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -401,11 +401,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeoutWith(dur
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -431,11 +431,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.timeoutWith
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -461,11 +461,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.timeoutWith
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -491,11 +491,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> C.timeout
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -521,11 +521,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> C.timeout
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -551,11 +551,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3> C.tim
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -581,11 +581,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3> C.tim
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -611,11 +611,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4> C
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -641,11 +641,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4> C
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -671,11 +671,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -701,11 +701,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -731,11 +731,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -761,11 +761,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -791,11 +791,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -821,11 +821,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -851,11 +851,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -881,11 +881,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -911,11 +911,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -941,11 +941,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -971,11 +971,11 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1005,11 +1005,11 @@ private fun <C : IPersistentTimeoutableComponent<C>> C.timeoutWithBoundCallable(
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1035,11 +1035,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeou
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1065,11 +1065,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeou
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1095,11 +1095,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.ti
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1125,11 +1125,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.ti
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1155,11 +1155,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1185,11 +1185,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1215,11 +1215,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1245,11 +1245,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1275,11 +1275,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1305,11 +1305,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1335,11 +1335,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1365,11 +1365,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1395,11 +1395,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1425,11 +1425,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1455,11 +1455,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1485,11 +1485,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1515,11 +1515,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1545,11 +1545,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1575,11 +1575,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1605,11 +1605,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
@@ -1635,11 +1635,11 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  *
  * ### Timeout data
  * The data passed is [serialized][TimeoutParameterResolver.serialize]
- * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
+ * and later [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
  * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * For objects supported by default (see [ParameterResolver]) and by other [TimeoutParameterResolver]s,
  * you must annotate your parameter with [@TimeoutData][TimeoutData].
  *
  * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/ITimeoutableComponent.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/builder/ITimeoutableComponent.kt
@@ -6,15 +6,16 @@ import io.github.freya022.botcommands.api.components.annotations.GroupTimeoutHan
 import io.github.freya022.botcommands.api.components.annotations.TimeoutData
 import io.github.freya022.botcommands.api.components.annotations.getEffectiveName
 import io.github.freya022.botcommands.api.components.data.ITimeoutData
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableTimeoutData
 import io.github.freya022.botcommands.api.core.utils.findAnnotationRecursive
 import io.github.freya022.botcommands.api.core.utils.isSubclassOf
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
+import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
 import io.github.freya022.botcommands.internal.utils.annotationRef
 import io.github.freya022.botcommands.internal.utils.javaMethodInternal
 import io.github.freya022.botcommands.internal.utils.throwArgument
 import kotlinx.coroutines.runBlocking
-import net.dv8tion.jda.api.entities.ISnowflake
 import net.dv8tion.jda.api.entities.User
 import java.util.concurrent.TimeUnit
 import javax.annotation.CheckReturnValue
@@ -140,18 +141,21 @@ interface IPersistentTimeoutableComponent<T : IPersistentTimeoutableComponent<T>
      * - If the component is inside a group, then all the group's components will also be deleted.
      *
      * ### Timeout data
-     * The data passed is transformed with [toString][Object.toString],
-     * except [snowflakes][ISnowflake] which get their IDs stored.
+     * The data passed is [serialized][TimeoutParameterResolver.serialize]
+     * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
      *
-     * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+     * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
      *
-     * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+     * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+     * you must annotate your parameter with [@TimeoutData][TimeoutData].
+     *
+     * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
      *
      * @param timeout The value of the timeout
      * @param timeoutUnit The unit of the timeout
-     * @param handlerName The name of the handler to run when the button is clicked,
+     * @param handlerName The name of the handler to run when the component expires,
      * defined by either [@ComponentTimeoutHandler][ComponentTimeoutHandler] or [@GroupTimeoutHandler][GroupTimeoutHandler] depending on the type
-     * @param data The data to pass to the component handler
+     * @param data The data to pass to the timeout handler
      *
      * @see ComponentTimeoutHandler @ComponentTimeoutHandler
      * @see GroupTimeoutHandler @GroupTimeoutHandler
@@ -175,17 +179,20 @@ interface IPersistentTimeoutableComponent<T : IPersistentTimeoutableComponent<T>
      * - If the component is inside a group, then all the group's components will also be deleted.
      *
      * ### Timeout data
-     * The data passed is transformed with [toString][Object.toString],
-     * except [snowflakes][ISnowflake] which get their IDs stored.
+     * The data passed is [serialized][TimeoutParameterResolver.serialize]
+     * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
      *
-     * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+     * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
      *
-     * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+     * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+     * you must annotate your parameter with [@TimeoutData][TimeoutData].
+     *
+     * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
      *
      * @param timeout The duration of the timeout
-     * @param handlerName The name of the handler to run when the button is clicked,
+     * @param handlerName The name of the handler to run when the component expires,
      * defined by either [@ComponentTimeoutHandler][ComponentTimeoutHandler] or [@GroupTimeoutHandler][GroupTimeoutHandler] depending on the type
-     * @param data The data to pass to the component handler
+     * @param data The data to pass to the timeout handler
      *
      * @see ComponentTimeoutHandler @ComponentTimeoutHandler
      * @see GroupTimeoutHandler @GroupTimeoutHandler
@@ -209,17 +216,20 @@ interface IPersistentTimeoutableComponent<T : IPersistentTimeoutableComponent<T>
      * - If the component is inside a group, then all the group's components will also be deleted.
      *
      * ### Timeout data
-     * The data passed is transformed with [toString][Object.toString],
-     * except [snowflakes][ISnowflake] which get their IDs stored.
+     * The data passed is [serialized][TimeoutParameterResolver.serialize]
+     * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
      *
-     * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+     * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
      *
-     * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+     * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+     * you must annotate your parameter with [@TimeoutData][TimeoutData].
+     *
+     * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
      *
      * @param timeout The duration of the timeout
-     * @param handlerName The name of the handler to run when the button is clicked,
+     * @param handlerName The name of the handler to run when the component expires,
      * defined by either [@ComponentTimeoutHandler][ComponentTimeoutHandler] or [@GroupTimeoutHandler][GroupTimeoutHandler] depending on the type
-     * @param data The data to pass to the component handler
+     * @param data The data to pass to the timeout handler
      *
      * @see ComponentTimeoutHandler @ComponentTimeoutHandler
      * @see GroupTimeoutHandler @GroupTimeoutHandler
@@ -255,7 +265,7 @@ interface IEphemeralTimeoutableComponent<T : IEphemeralTimeoutableComponent<T>> 
      * as [they can stop being updated by JDA](https://jda.wiki/using-jda/troubleshooting/#cannot-get-reference-as-it-has-already-been-garbage-collected).
      *
      * @param timeout The duration before timeout
-     * @param handler The handler to run when the button is clicked
+     * @param handler The handler to run when the component expires
      */
     @CheckReturnValue
     fun timeout(timeout: JavaDuration, handler: Runnable): T =
@@ -281,7 +291,7 @@ interface IEphemeralTimeoutableComponent<T : IEphemeralTimeoutableComponent<T>> 
      *
      * @param timeout The value of the timeout
      * @param timeoutUnit The unit of the timeout
-     * @param handler The handler to run when the button is clicked
+     * @param handler The handler to run when the component expires
      */
     @CheckReturnValue
     fun timeout(timeout: Long, timeoutUnit: TimeUnit, handler: Runnable): T =
@@ -309,7 +319,7 @@ interface IEphemeralTimeoutableComponent<T : IEphemeralTimeoutableComponent<T>> 
      * even though it will return you an outdated object if the entity cannot be found anymore.
      *
      * @param timeout The duration of the timeout
-     * @param handler The handler to run when the button is clicked
+     * @param handler The handler to run when the component expires
      */
     @JvmSynthetic
     fun timeout(timeout: Duration, handler: suspend () -> Unit): T
@@ -330,12 +340,15 @@ interface IEphemeralTimeoutableComponent<T : IEphemeralTimeoutableComponent<T>> 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallableSuspend")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeoutWith(duration: Duration, func: KSuspendFunction1<E, Unit>): C {
@@ -357,12 +370,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeoutWith(dur
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallable")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeoutWith(duration: Duration, func: KFunction1<E, Unit>): C {
@@ -384,12 +400,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeoutWith(dur
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallableSuspend")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.timeoutWith(duration: Duration, func: KSuspendFunction2<E, T1, Unit>, arg1: T1): C {
@@ -411,12 +430,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.timeoutWith
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallable")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.timeoutWith(duration: Duration, func: KFunction2<E, T1, Unit>, arg1: T1): C {
@@ -438,12 +460,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.timeoutWith
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallableSuspend")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> C.timeoutWith(duration: Duration, func: KSuspendFunction3<E, T1, T2, Unit>, arg1: T1, arg2: T2): C {
@@ -465,12 +490,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> C.timeout
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallable")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> C.timeoutWith(duration: Duration, func: KFunction3<E, T1, T2, Unit>, arg1: T1, arg2: T2): C {
@@ -492,12 +520,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> C.timeout
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallableSuspend")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3> C.timeoutWith(duration: Duration, func: KSuspendFunction4<E, T1, T2, T3, Unit>, arg1: T1, arg2: T2, arg3: T3): C {
@@ -519,12 +550,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3> C.tim
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallable")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3> C.timeoutWith(duration: Duration, func: KFunction4<E, T1, T2, T3, Unit>, arg1: T1, arg2: T2, arg3: T3): C {
@@ -546,12 +580,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3> C.tim
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallableSuspend")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4> C.timeoutWith(duration: Duration, func: KSuspendFunction5<E, T1, T2, T3, T4, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4): C {
@@ -573,12 +610,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4> C
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallable")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4> C.timeoutWith(duration: Duration, func: KFunction5<E, T1, T2, T3, T4, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4): C {
@@ -600,12 +640,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4> C
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallableSuspend")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5> C.timeoutWith(duration: Duration, func: KSuspendFunction6<E, T1, T2, T3, T4, T5, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): C {
@@ -627,12 +670,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallable")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5> C.timeoutWith(duration: Duration, func: KFunction6<E, T1, T2, T3, T4, T5, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): C {
@@ -654,12 +700,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallableSuspend")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6> C.timeoutWith(duration: Duration, func: KSuspendFunction7<E, T1, T2, T3, T4, T5, T6, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): C {
@@ -681,12 +730,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallable")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6> C.timeoutWith(duration: Duration, func: KFunction7<E, T1, T2, T3, T4, T5, T6, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): C {
@@ -708,12 +760,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallableSuspend")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7> C.timeoutWith(duration: Duration, func: KSuspendFunction8<E, T1, T2, T3, T4, T5, T6, T7, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): C {
@@ -735,12 +790,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallable")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7> C.timeoutWith(duration: Duration, func: KFunction8<E, T1, T2, T3, T4, T5, T6, T7, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): C {
@@ -762,12 +820,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallableSuspend")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8> C.timeoutWith(duration: Duration, func: KSuspendFunction9<E, T1, T2, T3, T4, T5, T6, T7, T8, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): C {
@@ -789,12 +850,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallable")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8> C.timeoutWith(duration: Duration, func: KFunction9<E, T1, T2, T3, T4, T5, T6, T7, T8, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): C {
@@ -816,12 +880,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallableSuspend")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8, T9> C.timeoutWith(duration: Duration, func: KSuspendFunction10<E, T1, T2, T3, T4, T5, T6, T7, T8, T9, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): C {
@@ -843,12 +910,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallable")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8, T9> C.timeoutWith(duration: Duration, func: KFunction10<E, T1, T2, T3, T4, T5, T6, T7, T8, T9, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): C {
@@ -870,12 +940,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallableSuspend")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> C.timeoutWith(duration: Duration, func: KSuspendFunction11<E, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): C {
@@ -897,12 +970,15 @@ fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithBoundCallable")
 fun <C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> C.timeoutWith(duration: Duration, func: KFunction11<E, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): C {
@@ -928,12 +1004,15 @@ private fun <C : IPersistentTimeoutableComponent<C>> C.timeoutWithBoundCallable(
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallableSuspend")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeoutWith(duration: Duration, func: KSuspendFunction2<T, E, Unit>): C {
@@ -955,12 +1034,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeou
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallable")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeoutWith(duration: Duration, func: KFunction2<T, E, Unit>): C {
@@ -982,12 +1064,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData> C.timeou
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallableSuspend")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.timeoutWith(duration: Duration, func: KSuspendFunction3<T, E, T1, Unit>, arg1: T1): C {
@@ -1009,12 +1094,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.ti
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallable")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.timeoutWith(duration: Duration, func: KFunction3<T, E, T1, Unit>, arg1: T1): C {
@@ -1036,12 +1124,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1> C.ti
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallableSuspend")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> C.timeoutWith(duration: Duration, func: KSuspendFunction4<T, E, T1, T2, Unit>, arg1: T1, arg2: T2): C {
@@ -1063,12 +1154,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallable")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> C.timeoutWith(duration: Duration, func: KFunction4<T, E, T1, T2, Unit>, arg1: T1, arg2: T2): C {
@@ -1090,12 +1184,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2> 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallableSuspend")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3> C.timeoutWith(duration: Duration, func: KSuspendFunction5<T, E, T1, T2, T3, Unit>, arg1: T1, arg2: T2, arg3: T3): C {
@@ -1117,12 +1214,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallable")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3> C.timeoutWith(duration: Duration, func: KFunction5<T, E, T1, T2, T3, Unit>, arg1: T1, arg2: T2, arg3: T3): C {
@@ -1144,12 +1244,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallableSuspend")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4> C.timeoutWith(duration: Duration, func: KSuspendFunction6<T, E, T1, T2, T3, T4, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4): C {
@@ -1171,12 +1274,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallable")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4> C.timeoutWith(duration: Duration, func: KFunction6<T, E, T1, T2, T3, T4, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4): C {
@@ -1198,12 +1304,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallableSuspend")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5> C.timeoutWith(duration: Duration, func: KSuspendFunction7<T, E, T1, T2, T3, T4, T5, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): C {
@@ -1225,12 +1334,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallable")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5> C.timeoutWith(duration: Duration, func: KFunction7<T, E, T1, T2, T3, T4, T5, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): C {
@@ -1252,12 +1364,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallableSuspend")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6> C.timeoutWith(duration: Duration, func: KSuspendFunction8<T, E, T1, T2, T3, T4, T5, T6, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): C {
@@ -1279,12 +1394,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallable")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6> C.timeoutWith(duration: Duration, func: KFunction8<T, E, T1, T2, T3, T4, T5, T6, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): C {
@@ -1306,12 +1424,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallableSuspend")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7> C.timeoutWith(duration: Duration, func: KSuspendFunction9<T, E, T1, T2, T3, T4, T5, T6, T7, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): C {
@@ -1333,12 +1454,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallable")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7> C.timeoutWith(duration: Duration, func: KFunction9<T, E, T1, T2, T3, T4, T5, T6, T7, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): C {
@@ -1360,12 +1484,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallableSuspend")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8> C.timeoutWith(duration: Duration, func: KSuspendFunction10<T, E, T1, T2, T3, T4, T5, T6, T7, T8, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): C {
@@ -1387,12 +1514,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallable")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8> C.timeoutWith(duration: Duration, func: KFunction10<T, E, T1, T2, T3, T4, T5, T6, T7, T8, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): C {
@@ -1414,12 +1544,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallableSuspend")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8, T9> C.timeoutWith(duration: Duration, func: KSuspendFunction11<T, E, T1, T2, T3, T4, T5, T6, T7, T8, T9, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): C {
@@ -1441,12 +1574,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallable")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8, T9> C.timeoutWith(duration: Duration, func: KFunction11<T, E, T1, T2, T3, T4, T5, T6, T7, T8, T9, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): C {
@@ -1468,12 +1604,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallableSuspend")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> C.timeoutWith(duration: Duration, func: KSuspendFunction12<T, E, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): C {
@@ -1495,12 +1634,15 @@ fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, 
  * - If the component is inside a group, then all the group's components will also be deleted.
  *
  * ### Timeout data
- * The data passed is transformed with [toString][Object.toString],
- * except [snowflakes][ISnowflake] which get their IDs stored.
+ * The data passed is [serialized][TimeoutParameterResolver.serialize]
+ * and [deserialized][TimeoutParameterResolver.resolveSuspend] using their resolver.
  *
- * The data can only be reconstructed if a [TimeoutParameterResolver] exists for the handler's parameter type.
+ * Each passed object needs to correspond to a parameter of the function (in the declaration order, excluding non-data parameters).
  *
- * Remember the parameters need to be annotated with [@TimeoutData][TimeoutData].
+ * For objects supported by default (see [ParameterResolver]) and other [TimeoutParameterResolver]s,
+ * you must annotate your parameter with [@TimeoutData][TimeoutData].
+ *
+ * For serializable objects, you can instead use [@SerializableTimeoutData][SerializableTimeoutData].
  */
 @JvmName("timeoutWithClassCallable")
 fun <T : Any, C : IPersistentTimeoutableComponent<C>, E : ITimeoutData, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> C.timeoutWith(duration: Duration, func: KFunction12<T, E, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Unit>, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): C {

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/GlobalComponentDataSerializer.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/GlobalComponentDataSerializer.kt
@@ -1,0 +1,60 @@
+package io.github.freya022.botcommands.api.components.serialization
+
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableComponentData
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableTimeoutData
+import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
+import io.github.freya022.botcommands.api.core.service.annotations.InterfacedService
+
+/**
+ * Serializes and deserializes data from parameters annotated with [@SerializableComponentData][SerializableComponentData]
+ * and [@SerializableTimeoutData][SerializableTimeoutData].
+ *
+ * ### Default implementation
+ * By default, a Jackson-based serializer with the Kotlin module is used.
+ *
+ * ### Overriding the default instance
+ * You can override the default instance by creating a service implementing this interface,
+ * in which you can use any serialization library you want.
+ *
+ * **Tip:** You will generally need to get the type of the to-be-deserialized parameter,
+ * which you can get from the [ParameterWrapper].
+ *
+ * Here's an example with [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization):
+ *
+ * ```kt
+ * @BService
+ * class KotlinxComponentDataSerializer : GlobalComponentDataSerializer {
+ *
+ *     // Default instance, you can customize it later
+ *     private val json = Json
+ *
+ *     override fun deserialize(parameter: ParameterWrapper, data: SerializedComponentData): Any {
+ *         return json.decodeFromString(serializer(parameter.type), data.asString())!!
+ *     }
+ *
+ *     override fun serialize(parameter: ParameterWrapper, obj: Any): SerializedComponentData {
+ *         val json = json.encodeToString(serializer(parameter.type), obj)
+ *         return SerializedComponentData.fromString(json)
+ *     }
+ * }
+ * ```
+ */
+@InterfacedService(acceptMultiple = false)
+interface GlobalComponentDataSerializer {
+
+    /**
+     * Serializes the given object into a [SerializedComponentData].
+     *
+     * @param parameter The parameter which this value is serialized for
+     * @param obj       The data to be serialized
+     */
+    fun serialize(parameter: ParameterWrapper, obj: Any): SerializedComponentData
+
+    /**
+     * Deserializes the [data] into an object compatible with the [parameter].
+     *
+     * @param parameter The parameter which this value is deserialized for
+     * @param data      The data to be deserialized into a compatible object
+     */
+    fun deserialize(parameter: ParameterWrapper, data: SerializedComponentData): Any
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/SerializedComponentData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/SerializedComponentData.kt
@@ -1,0 +1,64 @@
+package io.github.freya022.botcommands.api.components.serialization
+
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData.Companion.fromBytes
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData.Companion.fromString
+import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
+
+/**
+ * Contains the serialized data of a component argument.
+ *
+ * @see fromString
+ * @see fromBytes
+ *
+ * @see ComponentParameterResolver.serialize
+ */
+class SerializedComponentData private constructor(
+    private val bytes: ByteArray,
+) {
+
+    /**
+     * Returns the underlying byte array.
+     */
+    fun asBytes(): ByteArray = bytes.clone()
+
+    /**
+     * Decodes the data as a UTF-8 string.
+     */
+    fun asString() = bytes.decodeToString()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SerializedComponentData
+
+        return bytes.contentEquals(other.bytes)
+    }
+
+    override fun hashCode(): Int {
+        return bytes.contentHashCode()
+    }
+
+    override fun toString(): String {
+        return "SerializedComponentData(bytes=${bytes.contentToString()})"
+    }
+
+    companion object {
+
+        /**
+         * Creates a [SerializedComponentData] from the given bytes.
+         */
+        @JvmStatic
+        fun fromBytes(bytes: ByteArray): SerializedComponentData {
+            return SerializedComponentData(bytes.clone())
+        }
+
+        /**
+         * Creates a [SerializedComponentData] from the given string.
+         */
+        @JvmStatic
+        fun fromString(string: String): SerializedComponentData {
+            return SerializedComponentData(string.encodeToByteArray())
+        }
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/SerializedComponentData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/SerializedComponentData.kt
@@ -1,7 +1,10 @@
 package io.github.freya022.botcommands.api.components.serialization
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData.Companion.fromBytes
 import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData.Companion.fromString
+import io.github.freya022.botcommands.api.core.reflect.KotlinTypeToken
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 
 /**
@@ -62,3 +65,21 @@ class SerializedComponentData private constructor(
         }
     }
 }
+
+/**
+ * Serializes the given [value] as a [SerializedComponentData] encoded as a UTF-8 string.
+ */
+fun ObjectMapper.writeValueAsComponentData(value: Any): SerializedComponentData =
+    fromBytes(writeValueAsBytes(value))
+
+/**
+ * Deserializes the given UTF-8 encoded JSON object [data] as a [T] instance.
+ */
+inline fun <reified T : Any> ObjectMapper.readValue(data: SerializedComponentData): T =
+    readValue(data.asBytes())
+
+/**
+ * Deserializes the given UTF-8 encoded JSON object [data] as a [T] instance.
+ */
+fun <T : Any> ObjectMapper.readValue(data: SerializedComponentData, typeToken: KotlinTypeToken<T>): T =
+    readValue(data.asBytes(), constructType(typeToken.javaType))

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/SerializedComponentData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/SerializedComponentData.kt
@@ -14,6 +14,8 @@ import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParamete
  * @see fromBytes
  *
  * @see ComponentParameterResolver.serialize
+ * @see GlobalComponentDataSerializer.serialize
+ * @see GlobalComponentDataSerializer.deserialize
  */
 class SerializedComponentData private constructor(
     private val bytes: ByteArray,

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/annotations/SerializableComponentData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/annotations/SerializableComponentData.kt
@@ -1,0 +1,12 @@
+package io.github.freya022.botcommands.api.components.serialization.annotations
+
+import io.github.freya022.botcommands.api.components.annotations.ComponentData
+import io.github.freya022.botcommands.api.components.serialization.GlobalComponentDataSerializer
+
+/**
+ * Same as [@ComponentData][ComponentData],
+ * but also generates a resolver which (de)serializes the value using the [GlobalComponentDataSerializer].
+ */
+@ComponentData
+@Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.ANNOTATION_CLASS)
+annotation class SerializableComponentData

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/annotations/SerializableTimeoutData.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/annotations/SerializableTimeoutData.kt
@@ -1,0 +1,12 @@
+package io.github.freya022.botcommands.api.components.serialization.annotations
+
+import io.github.freya022.botcommands.api.components.annotations.TimeoutData
+import io.github.freya022.botcommands.api.components.serialization.GlobalComponentDataSerializer
+
+/**
+ * Same as [@TimeoutData][TimeoutData],
+ * but also generates a resolver which (de)serializes the value using the [GlobalComponentDataSerializer].
+ */
+@TimeoutData
+@Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.ANNOTATION_CLASS)
+annotation class SerializableTimeoutData

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/exceptions/ComponentSerializationException.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/exceptions/ComponentSerializationException.kt
@@ -1,9 +1,10 @@
 package io.github.freya022.botcommands.api.components.serialization.exceptions
 
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
 
 /**
- * An exception thrown when [ComponentParameterResolver.serialize] fails.
+ * An exception thrown when [ComponentParameterResolver.serialize] or [TimeoutParameterResolver.serialize] fails.
  */
 class ComponentSerializationException : RuntimeException {
 

--- a/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/exceptions/ComponentSerializationException.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/components/serialization/exceptions/ComponentSerializationException.kt
@@ -1,0 +1,12 @@
+package io.github.freya022.botcommands.api.components.serialization.exceptions
+
+import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
+
+/**
+ * An exception thrown when [ComponentParameterResolver.serialize] fails.
+ */
+class ComponentSerializationException : RuntimeException {
+
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/core/utils/Collections.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/core/utils/Collections.kt
@@ -81,3 +81,8 @@ inline fun <T, R, C : MutableCollection<in R>> Iterable<T>.flatMapTo(destination
     }
     return destination
 }
+
+inline fun <T, reified R> Collection<T>.mapToArray(transform: (T) -> R): Array<R> {
+    val iterator = iterator()
+    return Array(size) { _ -> transform(iterator.next()) }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
@@ -78,10 +79,10 @@ internal sealed class AbstractEnumResolver<T : AbstractEnumResolver<T, E>, E : E
     //endregion
 
     //region Component
-    override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): E? =
-        getEnumValueOrNull(arg)
+    override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, data: SerializedComponentData): E? =
+        getEnumValueOrNull(data.asString())
 
-    override fun serialize(obj: E): String = obj.name
+    override fun serialize(obj: E) = SerializedComponentData.fromString(obj.name)
     //endregion
 
     //region Timeout

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
@@ -80,6 +80,8 @@ internal sealed class AbstractEnumResolver<T : AbstractEnumResolver<T, E>, E : E
     //region Component
     override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): E? =
         getEnumValueOrNull(arg)
+
+    override fun serialize(obj: E): String = obj.name
     //endregion
 
     //region Timeout

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/EnumResolver.kt
@@ -86,7 +86,7 @@ internal sealed class AbstractEnumResolver<T : AbstractEnumResolver<T, E>, E : E
     //endregion
 
     //region Timeout
-    override suspend fun resolveSuspend(option: TimeoutOption, arg: String): E = getEnumValue(arg)
+    override suspend fun resolveSuspend(option: TimeoutOption, data: SerializedComponentData): E = getEnumValue(data.asString())
     //endregion
 
     override fun toString(): String {

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/ParameterResolver.kt
@@ -12,9 +12,19 @@ import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
 import net.dv8tion.jda.api.entities.emoji.Emoji
 
 /**
- * Base class for parameter resolvers used in text commands, application commands, and component callbacks.
+ * Base class for parameter resolvers,
+ * needs to be implemented alongside the interface of at least one interaction type:
+ * - Text commands: [TextParameterResolver] or [QuotableTextParameterResolver]
+ * - Slash commands: [SlashParameterResolver]
+ * - Message context commands: [MessageContextParameterResolver]
+ * - User context commands: [UserContextParameterResolver]
+ * - Components: [ComponentParameterResolver]
+ * - Component timeouts: [TimeoutParameterResolver]
+ * - Modal handlers: [ModalParameterResolver]
+ * - Custom parameter types: [ICustomResolver]
  *
- * You need to extend [ClassParameterResolver] or [TypedParameterResolver] instead.
+ * ### Usage
+ * As this class is sealed, you need to extend [ClassParameterResolver] or [TypedParameterResolver] instead.
  *
  * ### Default parameter resolvers
  *
@@ -49,18 +59,7 @@ import net.dv8tion.jda.api.entities.emoji.Emoji
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects
  *
- * @see ClassParameterResolver
- *
  * @see ParameterResolverFactory
- *
- * @see TextParameterResolver
- * @see QuotableTextParameterResolver
- * @see ComponentParameterResolver
- * @see SlashParameterResolver
- * @see MessageContextParameterResolver
- * @see UserContextParameterResolver
- * @see TimeoutParameterResolver
- * @see ICustomResolver
  *
  * @see Resolvers
  */

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.components.annotations.JDAButtonListen
 import io.github.freya022.botcommands.api.components.annotations.JDASelectMenuListener
 import io.github.freya022.botcommands.api.components.builder.IPersistentActionableComponent
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
 import kotlin.reflect.KParameter
@@ -31,9 +32,9 @@ interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
      *
      * @param option The option currently being resolved
      * @param event  The corresponding event
-     * @param arg    One of the data passed by the user in [IPersistentActionableComponent.bindTo]
+     * @param data   A serialized representation of an argument passed in [IPersistentActionableComponent.bindTo]
      */
-    fun resolve(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): R? =
+    fun resolve(option: ComponentOption, event: GenericComponentInteractionCreateEvent, data: SerializedComponentData): R? =
         throw NotImplementedError("${this.javaClass.simpleName} must implement the 'resolve' or 'resolveSuspend' method")
 
     /**
@@ -45,11 +46,11 @@ interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
      *
      * @param option The option currently being resolved
      * @param event  The corresponding event
-     * @param arg    One of the data passed by the user in [IPersistentActionableComponent.bindTo]
+     * @param data   A serialized representation of an argument passed in [IPersistentActionableComponent.bindTo]
      */
     @JvmSynthetic
-    suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String) =
-        resolve(option, event, arg)
+    suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, data: SerializedComponentData) =
+        resolve(option, event, data)
 
     /**
      * Serializes an instance of the resolvable object.
@@ -57,5 +58,5 @@ interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
      * The given instance can be serialized in any way you want,
      * remember you must be able to deserialize it in [resolve]/[resolveSuspend].
      */
-    fun serialize(obj: R): String
+    fun serialize(obj: R): SerializedComponentData
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
@@ -50,4 +50,12 @@ interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
     @JvmSynthetic
     suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String) =
         resolve(option, event, arg)
+
+    /**
+     * Serializes an instance of the resolvable object.
+     *
+     * The given instance can be serialized in any way you want,
+     * remember you must be able to deserialize it in [resolve]/[resolveSuspend].
+     */
+    fun serialize(obj: R): String
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.components.annotations.JDASelectMenuLi
 import io.github.freya022.botcommands.api.components.builder.IPersistentActionableComponent
 import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableComponentData
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
 import kotlin.reflect.KParameter
@@ -15,6 +16,11 @@ import kotlin.reflect.KType
  * and [@JDASelectMenuListener][JDASelectMenuListener].
  *
  * Needs to be implemented alongside a [ParameterResolver] subclass.
+ *
+ * ### Use case - Supporting serializable objects
+ * If you need to pass **serializable** objects to your components,
+ * you can instead use [@SerializableComponentData][SerializableComponentData]
+ * and let it generate a resolver for you.
  *
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TimeoutParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TimeoutParameterResolver.kt
@@ -2,6 +2,8 @@ package io.github.freya022.botcommands.api.parameters.resolvers
 
 import io.github.freya022.botcommands.api.components.annotations.ComponentTimeoutHandler
 import io.github.freya022.botcommands.api.components.annotations.GroupTimeoutHandler
+import io.github.freya022.botcommands.api.components.builder.IPersistentTimeoutableComponent
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import kotlin.reflect.KParameter
@@ -26,9 +28,9 @@ interface TimeoutParameterResolver<T, R : Any> : IParameterResolver<T>
      * or [optional][KParameter.isOptional], the handler is ignored.
      *
      * @param option The option currently being resolved
-     * @param arg    The argument to be resolved
+     * @param data   A serialized representation of an argument passed in [IPersistentTimeoutableComponent.timeout]
      */
-    fun resolve(option: TimeoutOption, arg: String): R? =
+    fun resolve(option: TimeoutOption, data: SerializedComponentData): R? =
         throw NotImplementedError("${this.javaClass.simpleName} must implement the 'resolve' or 'resolveSuspend' method")
 
     /**
@@ -38,9 +40,17 @@ interface TimeoutParameterResolver<T, R : Any> : IParameterResolver<T>
      * or [optional][KParameter.isOptional], the handler is ignored.
      *
      * @param option The option currently being resolved
-     * @param arg    The argument to be resolved
+     * @param data   A serialized representation of an argument passed in [IPersistentTimeoutableComponent.timeout]
      */
     @JvmSynthetic
-    suspend fun resolveSuspend(option: TimeoutOption, arg: String): R? =
-        resolve(option, arg)
+    suspend fun resolveSuspend(option: TimeoutOption, data: SerializedComponentData): R? =
+        resolve(option, data)
+
+    /**
+     * Serializes an instance of the resolvable object.
+     *
+     * The given instance can be serialized in any way you want,
+     * remember you must be able to deserialize it in [resolve]/[resolveSuspend].
+     */
+    fun serialize(obj: R): SerializedComponentData
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TimeoutParameterResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TimeoutParameterResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.components.annotations.ComponentTimeou
 import io.github.freya022.botcommands.api.components.annotations.GroupTimeoutHandler
 import io.github.freya022.botcommands.api.components.builder.IPersistentTimeoutableComponent
 import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableTimeoutData
 import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import kotlin.reflect.KParameter
@@ -13,6 +14,11 @@ import kotlin.reflect.KType
  * Parameter resolver for parameters of [@ComponentTimeoutHandler][ComponentTimeoutHandler] and [@GroupTimeoutHandler][GroupTimeoutHandler].
  *
  * Needs to be implemented alongside a [ParameterResolver] subclass.
+ *
+ * ### Use case - Supporting serializable objects
+ * If you need to pass **serializable** objects to your components,
+ * you can instead use [@SerializableTimeoutData][SerializableTimeoutData]
+ * and let it generate a resolver for you.
  *
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/button/PersistentButtonBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/button/PersistentButtonBuilderImpl.kt
@@ -21,15 +21,8 @@ internal class PersistentButtonBuilderImpl internal constructor(
     instanceRetriever: InstanceRetriever<PersistentButtonBuilder>
 ) : AbstractButtonBuilder<PersistentButtonBuilder>(componentController, style, label, emoji, disabled, instanceRetriever),
     PersistentButtonBuilder,
-    IPersistentActionableComponentMixin<PersistentButtonBuilder> by PersistentActionableComponentImpl(
-        componentController.context,
-        instanceRetriever
-    ),
-    IPersistentTimeoutableComponentMixin<PersistentButtonBuilder> by PersistentTimeoutableComponentImpl(
-        componentController.context,
-        ComponentType.BUTTON,
-        instanceRetriever
-    ) {
+    IPersistentActionableComponentMixin<PersistentButtonBuilder> by PersistentActionableComponentImpl(componentController.context, ComponentType.BUTTON, instanceRetriever),
+    IPersistentTimeoutableComponentMixin<PersistentButtonBuilder> by PersistentTimeoutableComponentImpl(componentController.context, ComponentType.BUTTON, instanceRetriever) {
 
     override val lifetimeType: LifetimeType get() = LifetimeType.PERSISTENT
     override val instance: PersistentButtonBuilderImpl get() = this

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/button/PersistentButtonBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/button/PersistentButtonBuilderImpl.kt
@@ -1,6 +1,7 @@
 package io.github.freya022.botcommands.internal.components.builder.button
 
 import io.github.freya022.botcommands.api.components.builder.button.PersistentButtonBuilder
+import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.LifetimeType
 import io.github.freya022.botcommands.internal.components.builder.InstanceRetriever
 import io.github.freya022.botcommands.internal.components.builder.mixin.IPersistentActionableComponentMixin
@@ -25,6 +26,8 @@ internal class PersistentButtonBuilderImpl internal constructor(
         instanceRetriever
     ),
     IPersistentTimeoutableComponentMixin<PersistentButtonBuilder> by PersistentTimeoutableComponentImpl(
+        componentController.context,
+        ComponentType.BUTTON,
         instanceRetriever
     ) {
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/group/PersistentComponentGroupBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/group/PersistentComponentGroupBuilderImpl.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.internal.components.builder.group
 
 import io.github.freya022.botcommands.api.components.IGroupHolder
 import io.github.freya022.botcommands.api.components.builder.group.PersistentComponentGroupBuilder
+import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.LifetimeType
 import io.github.freya022.botcommands.internal.components.builder.InstanceRetriever
 import io.github.freya022.botcommands.internal.components.builder.mixin.IPersistentTimeoutableComponentMixin
@@ -14,7 +15,7 @@ internal class PersistentComponentGroupBuilderImpl internal constructor(
     instanceRetriever: InstanceRetriever<PersistentComponentGroupBuilder>
 ) : AbstractComponentGroupBuilder<PersistentComponentGroupBuilder>(componentController, components),
     PersistentComponentGroupBuilder,
-    IPersistentTimeoutableComponentMixin<PersistentComponentGroupBuilder> by PersistentTimeoutableComponentImpl(instanceRetriever) {
+    IPersistentTimeoutableComponentMixin<PersistentComponentGroupBuilder> by PersistentTimeoutableComponentImpl(componentController.context, ComponentType.GROUP, instanceRetriever) {
 
     override val lifetimeType: LifetimeType get() = LifetimeType.PERSISTENT
     override val instance: PersistentComponentGroupBuilderImpl get() = this

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/mixin/impl/PersistentActionableComponentImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/mixin/impl/PersistentActionableComponentImpl.kt
@@ -17,6 +17,6 @@ internal class PersistentActionableComponentImpl<T : IPersistentActionableCompon
         private set
 
     override fun bindTo(handlerName: String, data: List<Any?>): T = applyInstance {
-        this.handler = PersistentHandler.create(handlerName, data)
+        this.handler = PersistentHandler.create(context, handlerName, data)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/mixin/impl/PersistentActionableComponentImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/mixin/impl/PersistentActionableComponentImpl.kt
@@ -2,6 +2,7 @@ package io.github.freya022.botcommands.internal.components.builder.mixin.impl
 
 import io.github.freya022.botcommands.api.components.builder.IPersistentActionableComponent
 import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.builder.AbstractActionableComponent
 import io.github.freya022.botcommands.internal.components.builder.InstanceRetriever
 import io.github.freya022.botcommands.internal.components.builder.mixin.IPersistentActionableComponentMixin
@@ -9,6 +10,7 @@ import io.github.freya022.botcommands.internal.components.handler.PersistentHand
 
 internal class PersistentActionableComponentImpl<T : IPersistentActionableComponent<T>> internal constructor(
     context: BContext,
+    private val componentType: ComponentType,
     instanceRetriever: InstanceRetriever<T>
 ) : AbstractActionableComponent<T>(context, instanceRetriever),
     IPersistentActionableComponentMixin<T> {
@@ -17,6 +19,6 @@ internal class PersistentActionableComponentImpl<T : IPersistentActionableCompon
         private set
 
     override fun bindTo(handlerName: String, data: List<Any?>): T = applyInstance {
-        this.handler = PersistentHandler.create(context, handlerName, data)
+        this.handler = PersistentHandler.create(context, componentType, handlerName, data)
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/mixin/impl/PersistentTimeoutableComponentImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/mixin/impl/PersistentTimeoutableComponentImpl.kt
@@ -2,6 +2,8 @@ package io.github.freya022.botcommands.internal.components.builder.mixin.impl
 
 import io.github.freya022.botcommands.api.components.Components
 import io.github.freya022.botcommands.api.components.builder.IPersistentTimeoutableComponent
+import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.builder.BuilderInstanceHolderImpl
 import io.github.freya022.botcommands.internal.components.builder.InstanceRetriever
 import io.github.freya022.botcommands.internal.components.builder.mixin.IPersistentTimeoutableComponentMixin
@@ -11,6 +13,8 @@ import io.github.freya022.botcommands.internal.utils.takeIfFinite
 import kotlin.time.Duration
 
 internal class PersistentTimeoutableComponentImpl<T : IPersistentTimeoutableComponent<T>> internal constructor(
+    private val context: BContext,
+    private val componentType: ComponentType,
     override val instanceRetriever: InstanceRetriever<T>
 ) : BuilderInstanceHolderImpl<T>(),
     IPersistentTimeoutableComponentMixin<T> {
@@ -42,6 +46,6 @@ internal class PersistentTimeoutableComponentImpl<T : IPersistentTimeoutableComp
         Checks.checkFitInt(timeout, "timeout")
 
         this.timeoutDuration = timeout
-        this.timeout = PersistentTimeout.create(handlerName, data.toList())
+        this.timeout = PersistentTimeout.create(context, componentType, handlerName, data.toList())
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/select/persistent/PersistentEntitySelectBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/select/persistent/PersistentEntitySelectBuilderImpl.kt
@@ -26,7 +26,7 @@ internal class PersistentEntitySelectBuilderImpl internal constructor(
     IConstrainableComponentMixin<PersistentEntitySelectBuilder> by ConstrainableComponentImpl(instanceRetriever),
     IUniqueComponentMixin<PersistentEntitySelectBuilder> by UniqueComponentImpl(instanceRetriever),
     IPersistentActionableComponentMixin<PersistentEntitySelectBuilder> by PersistentActionableComponentImpl(componentController.context, instanceRetriever),
-    IPersistentTimeoutableComponentMixin<PersistentEntitySelectBuilder> by PersistentTimeoutableComponentImpl(instanceRetriever) {
+    IPersistentTimeoutableComponentMixin<PersistentEntitySelectBuilder> by PersistentTimeoutableComponentImpl(componentController.context, ComponentType.SELECT_MENU, instanceRetriever) {
 
     override val componentType: ComponentType get() = ComponentType.SELECT_MENU
     override val lifetimeType: LifetimeType get() = LifetimeType.PERSISTENT

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/select/persistent/PersistentEntitySelectBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/select/persistent/PersistentEntitySelectBuilderImpl.kt
@@ -25,7 +25,7 @@ internal class PersistentEntitySelectBuilderImpl internal constructor(
     BaseComponentBuilderMixin<PersistentEntitySelectBuilder>,
     IConstrainableComponentMixin<PersistentEntitySelectBuilder> by ConstrainableComponentImpl(instanceRetriever),
     IUniqueComponentMixin<PersistentEntitySelectBuilder> by UniqueComponentImpl(instanceRetriever),
-    IPersistentActionableComponentMixin<PersistentEntitySelectBuilder> by PersistentActionableComponentImpl(componentController.context, instanceRetriever),
+    IPersistentActionableComponentMixin<PersistentEntitySelectBuilder> by PersistentActionableComponentImpl(componentController.context, ComponentType.SELECT_MENU, instanceRetriever),
     IPersistentTimeoutableComponentMixin<PersistentEntitySelectBuilder> by PersistentTimeoutableComponentImpl(componentController.context, ComponentType.SELECT_MENU, instanceRetriever) {
 
     override val componentType: ComponentType get() = ComponentType.SELECT_MENU

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/select/persistent/PersistentStringSelectBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/select/persistent/PersistentStringSelectBuilderImpl.kt
@@ -24,7 +24,7 @@ internal class PersistentStringSelectBuilderImpl internal constructor(
     BaseComponentBuilderMixin<PersistentStringSelectBuilder>,
     IConstrainableComponentMixin<PersistentStringSelectBuilder> by ConstrainableComponentImpl(instanceRetriever),
     IUniqueComponentMixin<PersistentStringSelectBuilder> by UniqueComponentImpl(instanceRetriever),
-    IPersistentActionableComponentMixin<PersistentStringSelectBuilder> by PersistentActionableComponentImpl(componentController.context, instanceRetriever),
+    IPersistentActionableComponentMixin<PersistentStringSelectBuilder> by PersistentActionableComponentImpl(componentController.context, ComponentType.SELECT_MENU, instanceRetriever),
     IPersistentTimeoutableComponentMixin<PersistentStringSelectBuilder> by PersistentTimeoutableComponentImpl(componentController.context, ComponentType.SELECT_MENU, instanceRetriever) {
 
     override val componentType: ComponentType get() = ComponentType.SELECT_MENU

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/select/persistent/PersistentStringSelectBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/builder/select/persistent/PersistentStringSelectBuilderImpl.kt
@@ -25,7 +25,7 @@ internal class PersistentStringSelectBuilderImpl internal constructor(
     IConstrainableComponentMixin<PersistentStringSelectBuilder> by ConstrainableComponentImpl(instanceRetriever),
     IUniqueComponentMixin<PersistentStringSelectBuilder> by UniqueComponentImpl(instanceRetriever),
     IPersistentActionableComponentMixin<PersistentStringSelectBuilder> by PersistentActionableComponentImpl(componentController.context, instanceRetriever),
-    IPersistentTimeoutableComponentMixin<PersistentStringSelectBuilder> by PersistentTimeoutableComponentImpl(instanceRetriever) {
+    IPersistentTimeoutableComponentMixin<PersistentStringSelectBuilder> by PersistentTimeoutableComponentImpl(componentController.context, ComponentType.SELECT_MENU, instanceRetriever) {
 
     override val componentType: ComponentType get() = ComponentType.SELECT_MENU
     override val lifetimeType: LifetimeType get() = LifetimeType.PERSISTENT

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/timeout/PersistentTimeout.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/timeout/PersistentTimeout.kt
@@ -57,10 +57,12 @@ internal class PersistentTimeout private constructor(
 
 // It ain't much but hey
 private object PersistentTimeoutComponentDataOptionCache {
-    private val cache = ConcurrentHashMap<String, List<TimeoutHandlerOption>>()
+    private val cache = ConcurrentHashMap<CacheKey, List<TimeoutHandlerOption>>()
+
+    private data class CacheKey(private val componentType: ComponentType, private val handlerName: String)
 
     fun getOrCreate(context: BContext, componentType: ComponentType, handlerName: String): List<TimeoutHandlerOption> {
-        return cache.computeIfAbsent(handlerName) {
+        return cache.computeIfAbsent(CacheKey(componentType, handlerName)) {
             val container = when (componentType) {
                 ComponentType.GROUP -> context.getService<GroupTimeoutHandlers>()
                 else -> context.getService<ComponentTimeoutHandlers>()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/timeout/PersistentTimeout.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/timeout/PersistentTimeout.kt
@@ -1,30 +1,73 @@
 package io.github.freya022.botcommands.internal.components.data.timeout
 
-import net.dv8tion.jda.api.entities.ISnowflake
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
+import io.github.freya022.botcommands.api.components.serialization.exceptions.ComponentSerializationException
+import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.service.getService
+import io.github.freya022.botcommands.api.core.utils.unmodifiableView
+import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
+import io.github.freya022.botcommands.internal.components.ComponentType
+import io.github.freya022.botcommands.internal.components.timeout.ComponentTimeoutHandlers
+import io.github.freya022.botcommands.internal.components.timeout.GroupTimeoutHandlers
+import io.github.freya022.botcommands.internal.components.timeout.options.TimeoutHandlerOption
+import io.github.freya022.botcommands.internal.utils.ReflectionUtils.function
+import io.github.freya022.botcommands.internal.utils.findDeclarationName
+import io.github.freya022.botcommands.internal.utils.shortSignature
+import io.github.freya022.botcommands.internal.utils.throwArgument
+import java.util.concurrent.ConcurrentHashMap
 
 internal class PersistentTimeout private constructor(
     val handlerName: String,
-    val userData: List<String?>
+    val userData: List<SerializedComponentData?>
 ) : ComponentTimeout {
     internal companion object {
-        internal fun create(handlerName: String, userData: List<Any?>): PersistentTimeout {
+        internal fun create(context: BContext, componentType: ComponentType, handlerName: String, userData: List<Any?>): PersistentTimeout {
             return PersistentTimeout(
                 handlerName,
-                userData.map { arg ->
-                    when (arg) {
-                        null -> null
-                        is ISnowflake -> arg.id
-                        else -> arg.toString()
-                    }
-                }
+                processArgs(context, componentType, handlerName, userData)
             )
         }
 
-        internal fun fromData(handlerName: String, userData: List<String>): PersistentTimeout {
+        internal fun fromData(handlerName: String, userData: List<ByteArray?>): PersistentTimeout {
             return PersistentTimeout(
                 handlerName,
-                userData
+                userData.map { it?.let(SerializedComponentData::fromBytes) }
             )
+        }
+
+        private fun processArgs(context: BContext, componentType: ComponentType, handlerName: String, args: List<Any?>): List<SerializedComponentData?> {
+            val allOptionsOrdered = PersistentTimeoutComponentDataOptionCache.getOrCreate(context, componentType, handlerName)
+
+            return args.mapIndexed { index, arg ->
+                if (arg == null) return@mapIndexed null
+
+                val option = allOptionsOrdered[index]
+                try {
+                    @Suppress("UNCHECKED_CAST")
+                    (option.resolver as TimeoutParameterResolver<*, Any>).serialize(arg)
+                } catch (e: ClassCastException) {
+                    throw ComponentSerializationException("Argument #$index of value '$arg' is incompatible with parameter '${option.kParameter.findDeclarationName()}' of ${option.kParameter.function.shortSignature}", e)
+                } catch (e: Exception) {
+                    throw ComponentSerializationException("Exception while serializing '$arg'", e)
+                }
+            }
+        }
+    }
+}
+
+// It ain't much but hey
+private object PersistentTimeoutComponentDataOptionCache {
+    private val cache = ConcurrentHashMap<String, List<TimeoutHandlerOption>>()
+
+    fun getOrCreate(context: BContext, componentType: ComponentType, handlerName: String): List<TimeoutHandlerOption> {
+        return cache.computeIfAbsent(handlerName) {
+            val container = when (componentType) {
+                ComponentType.GROUP -> context.getService<GroupTimeoutHandlers>()
+                else -> context.getService<ComponentTimeoutHandlers>()
+            }
+
+            val descriptor = container[handlerName] ?: throwArgument("No timeout handler named '$handlerName' exists")
+            descriptor.allOptionsOrdered.filterIsInstance<TimeoutHandlerOption>().unmodifiableView()
         }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandler.kt
@@ -1,5 +1,7 @@
 package io.github.freya022.botcommands.internal.components.handler
 
+import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
+import io.github.freya022.botcommands.api.components.annotations.JDASelectMenuListener
 import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.components.serialization.exceptions.ComponentSerializationException
 import io.github.freya022.botcommands.api.core.BContext
@@ -7,11 +9,10 @@ import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.core.utils.unmodifiableView
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
+import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.handler.options.ComponentHandlerOption
+import io.github.freya022.botcommands.internal.utils.*
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.function
-import io.github.freya022.botcommands.internal.utils.findDeclarationName
-import io.github.freya022.botcommands.internal.utils.shortSignature
-import io.github.freya022.botcommands.internal.utils.throwArgument
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
 import java.util.concurrent.ConcurrentHashMap
 
@@ -27,16 +28,16 @@ internal class PersistentHandler private constructor(val handlerName: String, va
     }
 
     internal companion object {
-        internal fun create(context: BContext, handlerName: String, userData: List<Any?>): PersistentHandler {
-            return PersistentHandler(handlerName, processArgs(context, handlerName, userData))
+        internal fun create(context: BContext, componentType: ComponentType, handlerName: String, userData: List<Any?>): PersistentHandler {
+            return PersistentHandler(handlerName, processArgs(context, componentType, handlerName, userData))
         }
 
         internal fun fromData(handlerName: String, userData: List<ByteArray?>): PersistentHandler {
             return PersistentHandler(handlerName, userData.map { it?.let(SerializedComponentData::fromBytes) })
         }
 
-        private fun processArgs(context: BContext, handlerName: String, args: List<Any?>): List<SerializedComponentData?> {
-            val allOptionsOrdered = PersistentHandlerComponentDataOptionCache.getOrCreate(context, handlerName)
+        private fun processArgs(context: BContext, componentType: ComponentType, handlerName: String, args: List<Any?>): List<SerializedComponentData?> {
+            val allOptionsOrdered = PersistentHandlerComponentDataOptionCache.getOrCreate(context, componentType, handlerName)
 
             return args.mapIndexed { index, arg ->
                 if (arg == null) return@mapIndexed null
@@ -59,10 +60,16 @@ internal class PersistentHandler private constructor(val handlerName: String, va
 private object PersistentHandlerComponentDataOptionCache {
     private val cache = ConcurrentHashMap<String, List<ComponentHandlerOption>>()
 
-    fun getOrCreate(context: BContext, handlerName: String): List<ComponentHandlerOption> {
+    fun getOrCreate(context: BContext, componentType: ComponentType, handlerName: String): List<ComponentHandlerOption> {
         return cache.computeIfAbsent(handlerName) {
-            val descriptor = context.getService<ComponentHandlerContainer>().getButtonDescriptor(handlerName)
-                ?: throwArgument("No handler named '$handlerName' exists")
+            val container = context.getService<ComponentHandlerContainer>()
+            val descriptor = when (componentType) {
+                ComponentType.GROUP -> throwInternal("Tried to retrieve an action component descriptor but the type is a group")
+                ComponentType.BUTTON -> container.getButtonDescriptor(handlerName)
+                    ?: throwArgument("No ${annotationRef<JDAButtonListener>()} named '$handlerName' exists")
+                ComponentType.SELECT_MENU -> container.getSelectMenuDescriptor(handlerName)
+                    ?: throwArgument("No ${annotationRef<JDASelectMenuListener>()} named '$handlerName' exists")
+            }
             descriptor.allOptionsOrdered.filterIsInstance<ComponentHandlerOption>().unmodifiableView()
         }
     }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandler.kt
@@ -1,8 +1,18 @@
 package io.github.freya022.botcommands.internal.components.handler
 
+import io.github.freya022.botcommands.api.components.serialization.exceptions.ComponentSerializationException
+import io.github.freya022.botcommands.api.core.BContext
+import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
-import net.dv8tion.jda.api.entities.ISnowflake
+import io.github.freya022.botcommands.api.core.utils.unmodifiableView
+import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
+import io.github.freya022.botcommands.internal.components.handler.options.ComponentHandlerOption
+import io.github.freya022.botcommands.internal.utils.ReflectionUtils.function
+import io.github.freya022.botcommands.internal.utils.findDeclarationName
+import io.github.freya022.botcommands.internal.utils.shortSignature
+import io.github.freya022.botcommands.internal.utils.throwArgument
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
+import java.util.concurrent.ConcurrentHashMap
 
 internal sealed interface ComponentHandler
 
@@ -16,20 +26,43 @@ internal class PersistentHandler private constructor(val handlerName: String, va
     }
 
     internal companion object {
-        internal fun create(handlerName: String, userData: List<Any?>): PersistentHandler {
-            return PersistentHandler(handlerName, processArgs(userData))
+        internal fun create(context: BContext, handlerName: String, userData: List<Any?>): PersistentHandler {
+            return PersistentHandler(handlerName, processArgs(context, handlerName, userData))
         }
 
         internal fun fromData(handlerName: String, userData: List<String?>): PersistentHandler {
             return PersistentHandler(handlerName, userData)
         }
 
-        private fun processArgs(args: List<Any?>): List<String?> = args.map { arg ->
-            when (arg) {
-                null -> null
-                is ISnowflake -> arg.id
-                else -> arg.toString()
+        private fun processArgs(context: BContext, handlerName: String, args: List<Any?>): List<String?> {
+            val allOptionsOrdered = PersistentHandlerComponentDataOptionCache.getOrCreate(context, handlerName)
+
+            return args.mapIndexed { index, arg ->
+                if (arg == null) return@mapIndexed null
+
+                val option = allOptionsOrdered[index]
+                try {
+                    @Suppress("UNCHECKED_CAST")
+                    (option.resolver as ComponentParameterResolver<*, Any>).serialize(arg)
+                } catch (e: ClassCastException) {
+                    throw ComponentSerializationException("Argument #$index of value '$arg' is incompatible with parameter '${option.kParameter.findDeclarationName()}' of ${option.kParameter.function.shortSignature}", e)
+                } catch (e: Exception) {
+                    throw ComponentSerializationException("Exception while serializing '$arg'", e)
+                }
             }
+        }
+    }
+}
+
+// It ain't much but hey
+private object PersistentHandlerComponentDataOptionCache {
+    private val cache = ConcurrentHashMap<String, List<ComponentHandlerOption>>()
+
+    fun getOrCreate(context: BContext, handlerName: String): List<ComponentHandlerOption> {
+        return cache.computeIfAbsent(handlerName) {
+            val descriptor = context.getService<ComponentHandlerContainer>().getButtonDescriptor(handlerName)
+                ?: throwArgument("No handler named '$handlerName' exists")
+            descriptor.allOptionsOrdered.filterIsInstance<ComponentHandlerOption>().unmodifiableView()
         }
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandler.kt
@@ -58,10 +58,12 @@ internal class PersistentHandler private constructor(val handlerName: String, va
 
 // It ain't much but hey
 private object PersistentHandlerComponentDataOptionCache {
-    private val cache = ConcurrentHashMap<String, List<ComponentHandlerOption>>()
+    private val cache = ConcurrentHashMap<CacheKey, List<ComponentHandlerOption>>()
+
+    private data class CacheKey(private val componentType: ComponentType, private val handlerName: String)
 
     fun getOrCreate(context: BContext, componentType: ComponentType, handlerName: String): List<ComponentHandlerOption> {
-        return cache.computeIfAbsent(handlerName) {
+        return cache.computeIfAbsent(CacheKey(componentType, handlerName)) {
             val container = context.getService<ComponentHandlerContainer>()
             val descriptor = when (componentType) {
                 ComponentType.GROUP -> throwInternal("Tried to retrieve an action component descriptor but the type is a group")

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandler.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandler.kt
@@ -1,5 +1,6 @@
 package io.github.freya022.botcommands.internal.components.handler
 
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.components.serialization.exceptions.ComponentSerializationException
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.service.getService
@@ -16,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 internal sealed interface ComponentHandler
 
-internal class PersistentHandler private constructor(val handlerName: String, val userData: List<String?>) : ComponentHandler {
+internal class PersistentHandler private constructor(val handlerName: String, val userData: List<SerializedComponentData?>) : ComponentHandler {
 
     operator fun component1() = handlerName
     operator fun component2() = userData
@@ -30,11 +31,11 @@ internal class PersistentHandler private constructor(val handlerName: String, va
             return PersistentHandler(handlerName, processArgs(context, handlerName, userData))
         }
 
-        internal fun fromData(handlerName: String, userData: List<String?>): PersistentHandler {
-            return PersistentHandler(handlerName, userData)
+        internal fun fromData(handlerName: String, userData: List<ByteArray?>): PersistentHandler {
+            return PersistentHandler(handlerName, userData.map { it?.let(SerializedComponentData::fromBytes) })
         }
 
-        private fun processArgs(context: BContext, handlerName: String, args: List<Any?>): List<String?> {
+        private fun processArgs(context: BContext, handlerName: String, args: List<Any?>): List<SerializedComponentData?> {
             val allOptionsOrdered = PersistentHandlerComponentDataOptionCache.getOrCreate(context, handlerName)
 
             return args.mapIndexed { index, arg ->

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerExecutor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentHandlerExecutor.kt
@@ -6,6 +6,7 @@ import io.github.freya022.botcommands.api.components.annotations.JDASelectMenuLi
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.components.event.EntitySelectEvent
 import io.github.freya022.botcommands.api.components.event.StringSelectEvent
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
 import io.github.freya022.botcommands.api.localization.DefaultMessagesFactory
@@ -78,7 +79,7 @@ internal class ComponentHandlerExecutor internal constructor(
     private suspend fun handlePersistentComponent(
         descriptor: ComponentDescriptor,
         event: GenericComponentInteractionCreateEvent, // already a BC event
-        userDataIterator: Iterator<String?>
+        userDataIterator: Iterator<SerializedComponentData?>
     ): Boolean {
         checkEventType(event, descriptor)
 
@@ -112,7 +113,7 @@ internal class ComponentHandlerExecutor internal constructor(
         event: GenericComponentInteractionCreateEvent,
         option: OptionImpl,
         optionMap: MutableMap<OptionImpl, Any?>,
-        userDataIterator: Iterator<String?>
+        userDataIterator: Iterator<SerializedComponentData?>
     ): InsertOptionResult {
         val value = when (option.optionType) {
             OptionType.OPTION -> {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentTimeoutExecutor.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/handler/ComponentTimeoutExecutor.kt
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.components.annotations.GroupTimeoutHan
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.components.data.ComponentTimeoutData
 import io.github.freya022.botcommands.api.components.data.GroupTimeoutData
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.data.ComponentData
@@ -70,7 +71,7 @@ internal class ComponentTimeoutExecutor internal constructor(
     private suspend fun handlePersistentTimeout(
         descriptor: TimeoutDescriptor<*>,
         firstArgument: Any,
-        userDataIterator: Iterator<String?>
+        userDataIterator: Iterator<SerializedComponentData?>
     ): Boolean {
         with(descriptor) {
             val optionValues = parameters.mapOptions { option ->
@@ -86,7 +87,7 @@ internal class ComponentTimeoutExecutor internal constructor(
     private suspend fun tryInsertOption(
         option: OptionImpl,
         optionMap: MutableMap<OptionImpl, Any?>,
-        userDataIterator: Iterator<String?>
+        userDataIterator: Iterator<SerializedComponentData?>
     ): InsertOptionResult {
         val value = when (option.optionType) {
             OptionType.OPTION -> {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentHandlerRepository.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentHandlerRepository.kt
@@ -30,7 +30,7 @@ internal class ComponentHandlerRepository(
     context(Transaction)
     internal suspend fun insertPersistentHandler(componentId: Int, handler: PersistentHandler) {
         preparedStatement("INSERT INTO bc_persistent_handler (component_id, handler_name, user_data) VALUES (?, ?, ?)") {
-            executeUpdate(componentId, handler.handlerName, handler.userData.toTypedArray())
+            executeUpdate(componentId, handler.handlerName, handler.userData.map { it?.asBytes() }.toTypedArray())
         }
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentHandlerRepository.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentHandlerRepository.kt
@@ -3,6 +3,7 @@ package io.github.freya022.botcommands.internal.components.repositories
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.core.db.Transaction
 import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.core.utils.mapToArray
 import io.github.freya022.botcommands.internal.components.handler.EphemeralComponentHandlers
 import io.github.freya022.botcommands.internal.components.handler.EphemeralHandler
 import io.github.freya022.botcommands.internal.components.handler.PersistentHandler
@@ -30,7 +31,7 @@ internal class ComponentHandlerRepository(
     context(Transaction)
     internal suspend fun insertPersistentHandler(componentId: Int, handler: PersistentHandler) {
         preparedStatement("INSERT INTO bc_persistent_handler (component_id, handler_name, user_data) VALUES (?, ?, ?)") {
-            executeUpdate(componentId, handler.handlerName, handler.userData.map { it?.asBytes() }.toTypedArray())
+            executeUpdate(componentId, handler.handlerName, handler.userData.mapToArray { it?.asBytes() })
         }
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentTimeoutRepository.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentTimeoutRepository.kt
@@ -3,6 +3,7 @@ package io.github.freya022.botcommands.internal.components.repositories
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.core.db.Transaction
 import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.core.utils.mapToArray
 import io.github.freya022.botcommands.internal.components.data.timeout.EphemeralTimeout
 import io.github.freya022.botcommands.internal.components.data.timeout.PersistentTimeout
 import io.github.freya022.botcommands.internal.components.timeout.EphemeralTimeoutHandlers
@@ -30,7 +31,7 @@ internal class ComponentTimeoutRepository(
     context(Transaction)
     internal suspend fun insertPersistentTimeout(componentId: Int, timeout: PersistentTimeout) {
         preparedStatement("INSERT INTO bc_persistent_timeout (component_id, handler_name, user_data) VALUES (?, ?, ?)") {
-            executeUpdate(componentId, timeout.handlerName, timeout.userData.map { it?.asBytes() }.toTypedArray())
+            executeUpdate(componentId, timeout.handlerName, timeout.userData.mapToArray { it?.asBytes() })
         }
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentTimeoutRepository.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentTimeoutRepository.kt
@@ -30,7 +30,7 @@ internal class ComponentTimeoutRepository(
     context(Transaction)
     internal suspend fun insertPersistentTimeout(componentId: Int, timeout: PersistentTimeout) {
         preparedStatement("INSERT INTO bc_persistent_timeout (component_id, handler_name, user_data) VALUES (?, ?, ?)") {
-            executeUpdate(componentId, timeout.handlerName, timeout.userData.toTypedArray())
+            executeUpdate(componentId, timeout.handlerName, timeout.userData.map { it?.asBytes() }.toTypedArray())
         }
     }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/serialization/DefaultGlobalComponentDataSerializerProvider.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/serialization/DefaultGlobalComponentDataSerializerProvider.kt
@@ -1,0 +1,62 @@
+package io.github.freya022.botcommands.internal.components.serialization
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.github.freya022.botcommands.api.components.serialization.GlobalComponentDataSerializer
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
+import io.github.freya022.botcommands.api.components.serialization.readValue
+import io.github.freya022.botcommands.api.components.serialization.writeValueAsComponentData
+import io.github.freya022.botcommands.api.core.reflect.KotlinTypeToken
+import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
+import io.github.freya022.botcommands.api.core.service.ConditionalServiceChecker
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
+import io.github.freya022.botcommands.api.core.service.annotations.BService
+import io.github.freya022.botcommands.api.core.service.annotations.ConditionalService
+import io.github.freya022.botcommands.api.core.service.getInterfacedServiceTypes
+import io.github.freya022.botcommands.api.core.utils.shortQualifiedName
+import io.github.freya022.botcommands.internal.utils.classRef
+import io.github.freya022.botcommands.internal.utils.throwInternal
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@BService
+@Configuration
+internal open class DefaultGlobalComponentDataSerializerProvider {
+
+    @Bean
+    @ConditionalOnMissingBean(GlobalComponentDataSerializer::class)
+    @BService
+    @ConditionalService(ExistingInstanceChecker::class)
+    internal open fun defaultGlobalComponentDataSerializer(): GlobalComponentDataSerializer {
+        return DefaultGlobalComponentDataSerializer
+    }
+
+    private object DefaultGlobalComponentDataSerializer : GlobalComponentDataSerializer {
+        private val mapper = jacksonObjectMapper()
+
+        override fun serialize(parameter: ParameterWrapper, obj: Any): SerializedComponentData {
+            return mapper.writeValueAsComponentData(obj)
+        }
+
+        override fun deserialize(parameter: ParameterWrapper, data: SerializedComponentData): Any {
+            //TODO use parameter.typeToken
+            @Suppress("UNCHECKED_CAST")
+            return mapper.readValue(data, KotlinTypeToken.ofType(parameter.type))
+        }
+    }
+
+    internal object ExistingInstanceChecker : ConditionalServiceChecker {
+
+        override fun checkServiceAvailability(serviceContainer: ServiceContainer, checkedClass: Class<*>): String? {
+            // Does not include default instance as it uses this checker
+            val existingType = serviceContainer.getInterfacedServiceTypes<GlobalComponentDataSerializer>()
+            if (existingType.size > 1) throwInternal("Cannot have more than 1 ${classRef<GlobalComponentDataSerializer>()}")
+
+            if (existingType.size == 1) {
+                return "Disabling default ${classRef<GlobalComponentDataSerializer>()}, using ${existingType.first().shortQualifiedName} instead"
+            }
+
+            return null
+        }
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/components/serialization/resolver/SerializableComponentDataResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/components/serialization/resolver/SerializableComponentDataResolverFactory.kt
@@ -1,0 +1,54 @@
+package io.github.freya022.botcommands.internal.components.serialization.resolver
+
+import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.GlobalComponentDataSerializer
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableComponentData
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableTimeoutData
+import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
+import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
+import io.github.freya022.botcommands.api.core.reflect.hasAnnotation
+import io.github.freya022.botcommands.api.core.service.annotations.ResolverFactory
+import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
+import io.github.freya022.botcommands.api.parameters.ParameterResolverFactory
+import io.github.freya022.botcommands.api.parameters.ResolverRequest
+import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
+import io.github.freya022.botcommands.internal.utils.annotationRef
+import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
+
+@ResolverFactory
+internal class SerializableComponentDataResolverFactory(
+    private val globalSerializer: GlobalComponentDataSerializer,
+) : ParameterResolverFactory<SerializableComponentDataResolverFactory.Resolver>(Resolver::class) {
+
+    override val supportedTypesStr: List<String> =
+        listOf("<any ${annotationRef<SerializableComponentData>()} or ${annotationRef<SerializableTimeoutData>()} parameter>")
+
+    override fun isResolvable(request: ResolverRequest): Boolean {
+        return request.parameter.hasAnnotation<SerializableComponentData>() || request.parameter.hasAnnotation<SerializableTimeoutData>()
+    }
+
+    override fun get(request: ResolverRequest): Resolver {
+        return Resolver(request.parameter, globalSerializer)
+    }
+
+    internal class Resolver(
+        private val parameter: ParameterWrapper,
+        private val globalSerializer: GlobalComponentDataSerializer,
+    ) : ClassParameterResolver<Resolver, Any>(Resolver::class),
+        ComponentParameterResolver<Resolver, Any>,
+        TimeoutParameterResolver<Resolver, Any> {
+
+        override suspend fun resolveSuspend(
+            option: ComponentOption,
+            event: GenericComponentInteractionCreateEvent,
+            data: SerializedComponentData
+        ): Any = globalSerializer.deserialize(parameter, data)
+
+        override suspend fun resolveSuspend(option: TimeoutOption, data: SerializedComponentData): Any =
+            globalSerializer.deserialize(parameter, data)
+
+        override fun serialize(obj: Any): SerializedComponentData = globalSerializer.serialize(parameter, obj)
+    }
+}

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/core/db/DatabaseImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/core/db/DatabaseImpl.kt
@@ -22,7 +22,7 @@ import java.sql.Connection
 import kotlin.time.toKotlinDuration
 
 // If the build script has 3.0.0-alpha.5_DEV, use the next release version, in this case 3.0.0-alpha.6
-private const val latestVersion = "3.0.0-alpha.19" // Change in the latest migration script too
+private const val latestVersion = "3.0.0-beta.1" // Change in the latest migration script too
 
 private val logger = KotlinLogging.logger { }
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
@@ -78,6 +78,8 @@ internal sealed class AbstractUserSnowflakeResolver<T : AbstractUserSnowflakeRes
         return entity
     }
 
+    override fun serialize(obj: R): String = obj.id
+
     final override fun resolve(option: UserContextCommandOption, event: UserContextInteractionEvent): R? =
         transformEntities(event.target, event.targetMember)
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/AbstractUserSnowflakeResolver.kt
@@ -6,6 +6,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.core.traceNull
@@ -69,8 +70,10 @@ internal sealed class AbstractUserSnowflakeResolver<T : AbstractUserSnowflakeRes
         optionMapping: OptionMapping
     ): R? = transformEntities(optionMapping.asUser, optionMapping.asMember)
 
-    final override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): R? {
-        val id = arg.toLongOrNull() ?: throwArgument("Invalid user id: $arg")
+    final override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, data: SerializedComponentData): R? {
+        val id = data.asString().let {
+            it.toLongOrNull() ?: throwArgument("Invalid user id: $it")
+        }
         val entity = retrieveOrNull(id, event.message)
         if (entity == null)
             event.reply_(defaultMessagesFactory.get(event).resolverUserNotFoundMsg, ephemeral = true).queue()
@@ -78,7 +81,7 @@ internal sealed class AbstractUserSnowflakeResolver<T : AbstractUserSnowflakeRes
         return entity
     }
 
-    override fun serialize(obj: R): String = obj.id
+    override fun serialize(obj: R) = SerializedComponentData.fromString(obj.id)
 
     final override fun resolve(option: UserContextCommandOption, event: UserContextInteractionEvent): R? =
         transformEntities(event.target, event.targetMember)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.kt
@@ -51,6 +51,8 @@ class BooleanResolver : ClassParameterResolver<BooleanResolver, Boolean>(Boolean
         arg: String
     ): Boolean? = parseBoolean(arg)
 
+    override fun serialize(obj: Boolean): String = obj.toString()
+
 
     override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Boolean? = parseBoolean(arg)
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
@@ -48,10 +49,10 @@ class BooleanResolver : ClassParameterResolver<BooleanResolver, Boolean>(Boolean
     override suspend fun resolveSuspend(
         option: ComponentOption,
         event: GenericComponentInteractionCreateEvent,
-        arg: String
-    ): Boolean? = parseBoolean(arg)
+        data: SerializedComponentData
+    ): Boolean? = parseBoolean(data.asString())
 
-    override fun serialize(obj: Boolean): String = obj.toString()
+    override fun serialize(obj: Boolean) = SerializedComponentData.fromString(obj.toString())
 
 
     override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Boolean? = parseBoolean(arg)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/BooleanResolver.kt
@@ -55,7 +55,7 @@ class BooleanResolver : ClassParameterResolver<BooleanResolver, Boolean>(Boolean
     override fun serialize(obj: Boolean) = SerializedComponentData.fromString(obj.toString())
 
 
-    override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Boolean? = parseBoolean(arg)
+    override suspend fun resolveSuspend(option: TimeoutOption, data: SerializedComponentData): Boolean? = parseBoolean(data.asString())
 
 
     private fun parseBoolean(arg: String): Boolean? {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -7,6 +7,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.exceptions.InvalidChannelTypeException
 import io.github.freya022.botcommands.api.core.reflect.ParameterWrapper
@@ -106,9 +107,9 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
         //endregion
 
         //region Component
-        override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): GuildChannel? {
+        override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, data: SerializedComponentData): GuildChannel? {
             val guild = event.guild ?: throwArgument("Cannot resolve a channel outside of a guild")
-            val channelId = arg.toLong()
+            val channelId = data.asString().toLong()
             val channel = guild.getChannelById(type, channelId)
             if (channel == null) {
                 if (ThreadChannel::class.java.isAssignableFrom(type))
@@ -121,7 +122,7 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
             return channel
         }
 
-        override fun serialize(obj: GuildChannel): String = obj.id
+        override fun serialize(obj: GuildChannel) = SerializedComponentData.fromString(obj.id)
         //endregion
 
         private suspend fun retrieveThreadChannel(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/ChannelResolverFactory.kt
@@ -120,6 +120,8 @@ internal class ChannelResolverFactory(private val context: BContext) : Parameter
 
             return channel
         }
+
+        override fun serialize(obj: GuildChannel): String = obj.id
         //endregion
 
         private suspend fun retrieveThreadChannel(

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
@@ -50,11 +51,11 @@ class DoubleResolver : ClassParameterResolver<DoubleResolver, Double>(Double::cl
     }
 
 
-    override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): Double {
-        return arg.toDouble()
+    override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, data: SerializedComponentData): Double {
+        return data.asString().toDouble()
     }
 
-    override fun serialize(obj: Double): String = obj.toString()
+    override fun serialize(obj: Double) = SerializedComponentData.fromString(obj.toString())
 
 
     override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Double {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.kt
@@ -54,6 +54,8 @@ class DoubleResolver : ClassParameterResolver<DoubleResolver, Double>(Double::cl
         return arg.toDouble()
     }
 
+    override fun serialize(obj: Double): String = obj.toString()
+
 
     override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Double {
         return arg.toDouble()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/DoubleResolver.kt
@@ -58,7 +58,7 @@ class DoubleResolver : ClassParameterResolver<DoubleResolver, Double>(Double::cl
     override fun serialize(obj: Double) = SerializedComponentData.fromString(obj.toString())
 
 
-    override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Double {
-        return arg.toDouble()
+    override suspend fun resolveSuspend(option: TimeoutOption, data: SerializedComponentData): Double {
+        return data.asString().toDouble()
     }
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
@@ -51,10 +52,10 @@ class EmojiResolver : ClassParameterResolver<EmojiResolver, Emoji>(Emoji::class)
     override suspend fun resolveSuspend(
         option: ComponentOption,
         event: GenericComponentInteractionCreateEvent,
-        arg: String
-    ): Emoji? = getEmoji(arg)
+        data: SerializedComponentData
+    ): Emoji? = getEmoji(data.asString())
 
-    override fun serialize(obj: Emoji): String = obj.formatted
+    override fun serialize(obj: Emoji) = SerializedComponentData.fromString(obj.formatted)
 
 
     override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Emoji? = getEmoji(arg)

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.kt
@@ -54,6 +54,8 @@ class EmojiResolver : ClassParameterResolver<EmojiResolver, Emoji>(Emoji::class)
         arg: String
     ): Emoji? = getEmoji(arg)
 
+    override fun serialize(obj: Emoji): String = obj.formatted
+
 
     override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Emoji? = getEmoji(arg)
 

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/EmojiResolver.kt
@@ -58,7 +58,7 @@ class EmojiResolver : ClassParameterResolver<EmojiResolver, Emoji>(Emoji::class)
     override fun serialize(obj: Emoji) = SerializedComponentData.fromString(obj.formatted)
 
 
-    override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Emoji? = getEmoji(arg)
+    override suspend fun resolveSuspend(option: TimeoutOption, data: SerializedComponentData): Emoji? = getEmoji(data.asString())
 
 
     private fun getEmoji(arg: String): Emoji? {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.kt
@@ -48,4 +48,6 @@ class GuildResolver : ClassParameterResolver<GuildResolver, Guild>(Guild::class)
         event: GenericComponentInteractionCreateEvent,
         arg: String
     ): Guild? = event.jda.getGuildById(arg)
+
+    override fun serialize(obj: Guild): String = obj.id
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/GuildResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
@@ -46,8 +47,8 @@ class GuildResolver : ClassParameterResolver<GuildResolver, Guild>(Guild::class)
     override suspend fun resolveSuspend(
         option: ComponentOption,
         event: GenericComponentInteractionCreateEvent,
-        arg: String
-    ): Guild? = event.jda.getGuildById(arg)
+        data: SerializedComponentData
+    ): Guild? = event.jda.getGuildById(data.asString())
 
-    override fun serialize(obj: Guild): String = obj.id
+    override fun serialize(obj: Guild) = SerializedComponentData.fromString(obj.id)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
@@ -53,10 +54,10 @@ class IntegerResolver : ClassParameterResolver<IntegerResolver, Int>(Int::class)
     override suspend fun resolveSuspend(
         option: ComponentOption,
         event: GenericComponentInteractionCreateEvent,
-        arg: String
-    ): Int = arg.toInt()
+        data: SerializedComponentData
+    ): Int = data.asString().toInt()
 
-    override fun serialize(obj: Int): String = obj.toString()
+    override fun serialize(obj: Int) = SerializedComponentData.fromString(obj.toString())
 
 
     override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Int = arg.toInt()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.kt
@@ -60,5 +60,5 @@ class IntegerResolver : ClassParameterResolver<IntegerResolver, Int>(Int::class)
     override fun serialize(obj: Int) = SerializedComponentData.fromString(obj.toString())
 
 
-    override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Int = arg.toInt()
+    override suspend fun resolveSuspend(option: TimeoutOption, data: SerializedComponentData): Int = data.asString().toInt()
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/IntegerResolver.kt
@@ -56,6 +56,8 @@ class IntegerResolver : ClassParameterResolver<IntegerResolver, Int>(Int::class)
         arg: String
     ): Int = arg.toInt()
 
+    override fun serialize(obj: Int): String = obj.toString()
+
 
     override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Int = arg.toInt()
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
@@ -55,10 +56,10 @@ class LongResolver : ClassParameterResolver<LongResolver, Long>(Long::class),
     override suspend fun resolveSuspend(
         option: ComponentOption,
         event: GenericComponentInteractionCreateEvent,
-        arg: String
-    ): Long = arg.toLong()
+        data: SerializedComponentData
+    ): Long = data.asString().toLong()
 
-    override fun serialize(obj: Long): String = obj.toString()
+    override fun serialize(obj: Long) = SerializedComponentData.fromString(obj.toString())
 
 
     override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Long = arg.toLong()

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.kt
@@ -62,5 +62,5 @@ class LongResolver : ClassParameterResolver<LongResolver, Long>(Long::class),
     override fun serialize(obj: Long) = SerializedComponentData.fromString(obj.toString())
 
 
-    override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Long = arg.toLong()
+    override suspend fun resolveSuspend(option: TimeoutOption, data: SerializedComponentData): Long = data.asString().toLong()
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/LongResolver.kt
@@ -58,6 +58,8 @@ class LongResolver : ClassParameterResolver<LongResolver, Long>(Long::class),
         arg: String
     ): Long = arg.toLong()
 
+    override fun serialize(obj: Long): String = obj.toString()
+
 
     override suspend fun resolveSuspend(option: TimeoutOption, arg: String): Long = arg.toLong()
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.kt
@@ -64,4 +64,6 @@ class RoleResolver : ClassParameterResolver<RoleResolver, Role>(Role::class),
 
         return guild.getRoleById(arg)
     }
+
+    override fun serialize(obj: Role): String = obj.id
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/RoleResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
@@ -57,13 +58,13 @@ class RoleResolver : ClassParameterResolver<RoleResolver, Role>(Role::class),
     override suspend fun resolveSuspend(
         option: ComponentOption,
         event: GenericComponentInteractionCreateEvent,
-        arg: String
+        data: SerializedComponentData
     ): Role? {
         val guild = event.guild
         requireNotNull(guild) { "Can't get a role from DMs" }
 
-        return guild.getRoleById(arg)
+        return guild.getRoleById(data.asString())
     }
 
-    override fun serialize(obj: Role): String = obj.id
+    override fun serialize(obj: Role) = SerializedComponentData.fromString(obj.id)
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.modals.ModalEvent
@@ -51,10 +52,10 @@ class StringResolver : ClassParameterResolver<StringResolver, String>(String::cl
     override suspend fun resolveSuspend(
         option: ComponentOption,
         event: GenericComponentInteractionCreateEvent,
-        arg: String
-    ): String = arg
+        data: SerializedComponentData
+    ): String = data.asString()
 
-    override fun serialize(obj: String): String = obj
+    override fun serialize(obj: String) = SerializedComponentData.fromString(obj)
 
 
     override suspend fun resolveSuspend(option: ModalOption, event: ModalEvent, modalMapping: ModalMapping): String =

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.kt
@@ -54,6 +54,8 @@ class StringResolver : ClassParameterResolver<StringResolver, String>(String::cl
         arg: String
     ): String = arg
 
+    override fun serialize(obj: String): String = obj
+
 
     override suspend fun resolveSuspend(option: ModalOption, event: ModalEvent, modalMapping: ModalMapping): String =
         modalMapping.asString

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/StringResolver.kt
@@ -62,5 +62,5 @@ class StringResolver : ClassParameterResolver<StringResolver, String>(String::cl
         modalMapping.asString
 
 
-    override suspend fun resolveSuspend(option: TimeoutOption, arg: String): String = arg
+    override suspend fun resolveSuspend(option: TimeoutOption, data: SerializedComponentData): String = data.asString()
 }

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.Sla
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.options.TextCommandOption
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
@@ -37,10 +38,10 @@ internal object UserSnowflakeResolver :
         return event.member.asMention
     }
 
-    override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): UserSnowflake =
-        UserSnowflake.fromId(arg)
+    override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, data: SerializedComponentData): UserSnowflake =
+        UserSnowflake.fromId(data.asString())
 
-    override fun serialize(obj: UserSnowflake): String = obj.id
+    override fun serialize(obj: UserSnowflake) = SerializedComponentData.fromString(obj.id)
 
     override suspend fun resolveSuspend(
         option: SlashCommandOption,

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/UserSnowflakeResolver.kt
@@ -40,6 +40,8 @@ internal object UserSnowflakeResolver :
     override suspend fun resolveSuspend(option: ComponentOption, event: GenericComponentInteractionCreateEvent, arg: String): UserSnowflake =
         UserSnowflake.fromId(arg)
 
+    override fun serialize(obj: UserSnowflake): String = obj.id
+
     override suspend fun resolveSuspend(
         option: SlashCommandOption,
         event: CommandInteractionPayload,

--- a/src/main/resources/bc_database_scripts/V3.0.0.2025.02.16__Component_data_serialization.sql
+++ b/src/main/resources/bc_database_scripts/V3.0.0.2025.02.16__Component_data_serialization.sql
@@ -1,0 +1,11 @@
+------------------------------------------------------ 8th migration script for BotCommands ------------------------------------------------------
+---------------------------------- Make sure to run the previous scripts (chronological order) before this one -----------------------------------
+
+SET SCHEMA 'bc';
+
+UPDATE bc_version
+SET version = '3.0.0-beta.1'
+WHERE one_row = true;
+
+ALTER TABLE bc_persistent_handler
+    ALTER COLUMN user_data SET DATA TYPE bytea array USING cast(user_data as bytea array);

--- a/src/main/resources/bc_database_scripts/V3.0.0.2025.02.16__Component_data_serialization.sql
+++ b/src/main/resources/bc_database_scripts/V3.0.0.2025.02.16__Component_data_serialization.sql
@@ -9,3 +9,6 @@ WHERE one_row = true;
 
 ALTER TABLE bc_persistent_handler
     ALTER COLUMN user_data SET DATA TYPE bytea array USING cast(user_data as bytea array);
+
+ALTER TABLE bc_persistent_timeout
+    ALTER COLUMN user_data SET DATA TYPE bytea array USING cast(user_data as bytea array);

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashComponentData.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashComponentData.kt
@@ -1,6 +1,7 @@
 package io.github.freya022.botcommands.test.commands.slash
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import dev.freya02.jda.emojis.unicode.Emojis
 import dev.minn.jda.ktx.interactions.components.row
 import dev.minn.jda.ktx.messages.reply_
@@ -14,6 +15,7 @@ import io.github.freya022.botcommands.api.components.annotations.JDAButtonListen
 import io.github.freya022.botcommands.api.components.builder.bindWith
 import io.github.freya022.botcommands.api.components.event.ButtonEvent
 import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
@@ -39,13 +41,13 @@ class MyComponentDataResolver :
     override suspend fun resolveSuspend(
         option: ComponentOption,
         event: GenericComponentInteractionCreateEvent,
-        arg: String
+        data: SerializedComponentData
     ): MyComponentData {
-        return mapper.readValue(arg, MyComponentData::class.java)
+        return mapper.readValue<MyComponentData>(data.asBytes())
     }
 
-    override fun serialize(obj: MyComponentData): String {
-        return mapper.writeValueAsString(obj)
+    override fun serialize(obj: MyComponentData): SerializedComponentData {
+        return SerializedComponentData.fromBytes(mapper.writeValueAsBytes(obj))
     }
 }
 

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashComponentData.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashComponentData.kt
@@ -11,15 +11,22 @@ import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashE
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.components.Buttons
 import io.github.freya022.botcommands.api.components.annotations.ComponentData
+import io.github.freya022.botcommands.api.components.annotations.ComponentTimeoutHandler
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
+import io.github.freya022.botcommands.api.components.annotations.TimeoutData
 import io.github.freya022.botcommands.api.components.builder.bindWith
+import io.github.freya022.botcommands.api.components.builder.timeoutWith
+import io.github.freya022.botcommands.api.components.data.ComponentTimeoutData
 import io.github.freya022.botcommands.api.components.event.ButtonEvent
 import io.github.freya022.botcommands.api.components.options.ComponentOption
 import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
+import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
 import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
 import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
+import kotlin.time.Duration.Companion.seconds
 
 data class MyComponentData(
     val userName: String,
@@ -34,7 +41,8 @@ data class MyComponentData(
 @Resolver
 class MyComponentDataResolver :
         ClassParameterResolver<MyComponentDataResolver, MyComponentData>(MyComponentData::class),
-        ComponentParameterResolver<MyComponentDataResolver, MyComponentData> {
+        ComponentParameterResolver<MyComponentDataResolver, MyComponentData>,
+        TimeoutParameterResolver<MyComponentDataResolver, MyComponentData> {
 
     private val mapper = jacksonObjectMapper()
 
@@ -43,6 +51,10 @@ class MyComponentDataResolver :
         event: GenericComponentInteractionCreateEvent,
         data: SerializedComponentData
     ): MyComponentData {
+        return mapper.readValue<MyComponentData>(data.asBytes())
+    }
+
+    override suspend fun resolveSuspend(option: TimeoutOption, data: SerializedComponentData): MyComponentData {
         return mapper.readValue<MyComponentData>(data.asBytes())
     }
 
@@ -66,6 +78,7 @@ class SlashComponentData(
         )
         val button = buttons.primary("See your data at the time of sending", Emojis.PENCIL).persistent {
             bindWith(SlashComponentData::onSeeDataClicked, data)
+            timeoutWith(15.seconds, ::onSeeDataTimeout, data)
         }
 
         event.replyComponents(row(button)).setEphemeral(true).queue()
@@ -79,5 +92,10 @@ class SlashComponentData(
             - Role names: ${data.nested.roleNames.joinToString(", ")}
         """.trimIndent()
         event.reply_(message, ephemeral = true).queue()
+    }
+
+    @ComponentTimeoutHandler
+    fun onSeeDataTimeout(event: ComponentTimeoutData, @TimeoutData data: MyComponentData) {
+        println("Component expired with $data")
     }
 }

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashComponentData.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashComponentData.kt
@@ -1,0 +1,81 @@
+package io.github.freya022.botcommands.test.commands.slash
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import dev.freya02.jda.emojis.unicode.Emojis
+import dev.minn.jda.ktx.interactions.components.row
+import dev.minn.jda.ktx.messages.reply_
+import io.github.freya022.botcommands.api.commands.annotations.Command
+import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
+import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
+import io.github.freya022.botcommands.api.components.Buttons
+import io.github.freya022.botcommands.api.components.annotations.ComponentData
+import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
+import io.github.freya022.botcommands.api.components.builder.bindWith
+import io.github.freya022.botcommands.api.components.event.ButtonEvent
+import io.github.freya022.botcommands.api.components.options.ComponentOption
+import io.github.freya022.botcommands.api.core.service.annotations.Resolver
+import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
+import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
+
+data class MyComponentData(
+    val userName: String,
+    val nested: Nested,
+) {
+
+    data class Nested(
+        val roleNames: List<String>,
+    )
+}
+
+@Resolver
+class MyComponentDataResolver :
+        ClassParameterResolver<MyComponentDataResolver, MyComponentData>(MyComponentData::class),
+        ComponentParameterResolver<MyComponentDataResolver, MyComponentData> {
+
+    private val mapper = jacksonObjectMapper()
+
+    override suspend fun resolveSuspend(
+        option: ComponentOption,
+        event: GenericComponentInteractionCreateEvent,
+        arg: String
+    ): MyComponentData {
+        return mapper.readValue(arg, MyComponentData::class.java)
+    }
+
+    override fun serialize(obj: MyComponentData): String {
+        return mapper.writeValueAsString(obj)
+    }
+}
+
+@Command
+class SlashComponentData(
+    private val buttons: Buttons,
+) : ApplicationCommand() {
+
+    @JDASlashCommand(name = "component_data")
+    suspend fun onSlashComponentData(event: GuildSlashEvent) {
+        val data = MyComponentData(
+            userName = event.member.effectiveName,
+            MyComponentData.Nested(
+                roleNames = event.member.roles.map { it.name }
+            )
+        )
+        val button = buttons.primary("See your data at the time of sending", Emojis.PENCIL).persistent {
+            bindWith(SlashComponentData::onSeeDataClicked, data)
+        }
+
+        event.replyComponents(row(button)).setEphemeral(true).queue()
+    }
+
+    @JDAButtonListener
+    fun onSeeDataClicked(event: ButtonEvent, @ComponentData data: MyComponentData) {
+        val message = """
+            You had the following attributes:
+            - User name: ${data.userName}
+            - Role names: ${data.nested.roleNames.joinToString(", ")}
+        """.trimIndent()
+        event.reply_(message, ephemeral = true).queue()
+    }
+}

--- a/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashComponentData.kt
+++ b/src/test/kotlin/io/github/freya022/botcommands/test/commands/slash/SlashComponentData.kt
@@ -1,7 +1,5 @@
 package io.github.freya022.botcommands.test.commands.slash
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import dev.freya02.jda.emojis.unicode.Emojis
 import dev.minn.jda.ktx.interactions.components.row
 import dev.minn.jda.ktx.messages.reply_
@@ -10,22 +8,14 @@ import io.github.freya022.botcommands.api.commands.application.ApplicationComman
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.components.Buttons
-import io.github.freya022.botcommands.api.components.annotations.ComponentData
 import io.github.freya022.botcommands.api.components.annotations.ComponentTimeoutHandler
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
-import io.github.freya022.botcommands.api.components.annotations.TimeoutData
 import io.github.freya022.botcommands.api.components.builder.bindWith
 import io.github.freya022.botcommands.api.components.builder.timeoutWith
 import io.github.freya022.botcommands.api.components.data.ComponentTimeoutData
 import io.github.freya022.botcommands.api.components.event.ButtonEvent
-import io.github.freya022.botcommands.api.components.options.ComponentOption
-import io.github.freya022.botcommands.api.components.serialization.SerializedComponentData
-import io.github.freya022.botcommands.api.components.timeout.options.TimeoutOption
-import io.github.freya022.botcommands.api.core.service.annotations.Resolver
-import io.github.freya022.botcommands.api.parameters.ClassParameterResolver
-import io.github.freya022.botcommands.api.parameters.resolvers.ComponentParameterResolver
-import io.github.freya022.botcommands.api.parameters.resolvers.TimeoutParameterResolver
-import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableComponentData
+import io.github.freya022.botcommands.api.components.serialization.annotations.SerializableTimeoutData
 import kotlin.time.Duration.Companion.seconds
 
 data class MyComponentData(
@@ -36,31 +26,6 @@ data class MyComponentData(
     data class Nested(
         val roleNames: List<String>,
     )
-}
-
-@Resolver
-class MyComponentDataResolver :
-        ClassParameterResolver<MyComponentDataResolver, MyComponentData>(MyComponentData::class),
-        ComponentParameterResolver<MyComponentDataResolver, MyComponentData>,
-        TimeoutParameterResolver<MyComponentDataResolver, MyComponentData> {
-
-    private val mapper = jacksonObjectMapper()
-
-    override suspend fun resolveSuspend(
-        option: ComponentOption,
-        event: GenericComponentInteractionCreateEvent,
-        data: SerializedComponentData
-    ): MyComponentData {
-        return mapper.readValue<MyComponentData>(data.asBytes())
-    }
-
-    override suspend fun resolveSuspend(option: TimeoutOption, data: SerializedComponentData): MyComponentData {
-        return mapper.readValue<MyComponentData>(data.asBytes())
-    }
-
-    override fun serialize(obj: MyComponentData): SerializedComponentData {
-        return SerializedComponentData.fromBytes(mapper.writeValueAsBytes(obj))
-    }
 }
 
 @Command
@@ -85,7 +50,7 @@ class SlashComponentData(
     }
 
     @JDAButtonListener
-    fun onSeeDataClicked(event: ButtonEvent, @ComponentData data: MyComponentData) {
+    fun onSeeDataClicked(event: ButtonEvent, @SerializableComponentData data: MyComponentData) {
         val message = """
             You had the following attributes:
             - User name: ${data.userName}
@@ -95,7 +60,7 @@ class SlashComponentData(
     }
 
     @ComponentTimeoutHandler
-    fun onSeeDataTimeout(event: ComponentTimeoutData, @TimeoutData data: MyComponentData) {
+    fun onSeeDataTimeout(event: ComponentTimeoutData, @SerializableTimeoutData data: MyComponentData) {
         println("Component expired with $data")
     }
 }


### PR DESCRIPTION
This enables you to pass any data to your component and timeout handlers, as long as they are serializable.

Any serialization library can be used, Jackson, Gson, kotlinx.serialization, Protobuf, Java's serialization (???), you name it.

These changes should be compatible with existing data, if it isn't, please report the bug.

### Breaking changes
- The `String` `arg` parameter have been replaced with a `data` argument of type `SerializedComponentData`
- A `SerializedComponentData serialize(R)` method has been added
- A new migration script has been added, if you are using a migration tool already, you do not need to do anything

### New features
- Added `@SerializableComponentData` and `@SerializableTimeoutData`
  - Can be used instead of `@ComponentData`/`@TimeoutData` to (de)serialize objects using `GlobalComponentDataSerializer`
  - `GlobalComponentDataSerializer` has a default instance, which can be overridden by creating your own instance.