### PR TITLE
Set an empty list for vararg arguments with no values available

### DIFF
--- a/src/main/kotlin/io/github/freya022/botcommands/api/commands/annotations/VarArgs.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/api/commands/annotations/VarArgs.kt
@@ -7,6 +7,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.options.bui
 import io.github.freya022.botcommands.api.commands.text.annotations.TextOption
 import io.github.freya022.botcommands.api.commands.text.builder.TextCommandVariationBuilder
 import io.github.freya022.botcommands.api.commands.text.options.builder.inlineClassOptionVararg
+import net.dv8tion.jda.api.interactions.commands.build.CommandData
 
 /**
  * Generates N command options from the specified [@SlashOption][SlashOption] or [@TextOption][TextOption].
@@ -32,12 +33,16 @@ import io.github.freya022.botcommands.api.commands.text.options.builder.inlineCl
 @Retention(AnnotationRetention.RUNTIME)
 annotation class VarArgs(
     /**
-     * The number of times this option needs to appear, which must be between 1 and {@value CommandData#MAX_OPTIONS}.
+     * The number of times this option needs to appear, must be positive.
      */
     val value: Int,
 
     /**
      * The number of required options for this vararg.
+     *
+     * For slash commands, this must can be 0, positive, or how many remaining options there are until [MAX_OPTIONS][CommandData.MAX_OPTIONS].
+     *
+     * For text commands, this must be at least 1.
      */
     val numRequired: Int = 1
 )

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/builder/SlashCommandBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/builder/SlashCommandBuilderImpl.kt
@@ -44,6 +44,9 @@ internal abstract class SlashCommandBuilderImpl internal constructor(
     }
 
     final override fun optionVararg(declaredName: String, amount: Int, requiredAmount: Int, optionNameSupplier: (Int) -> String, block: SlashCommandOptionBuilder.(Int) -> Unit) {
+        require(amount > 0) { "Amount must be positive" }
+        require(requiredAmount >= 0) { "Required amount must be zero or positive" }
+
         //Same as in TextCommandVariationBuilder#optionVararg
         varargAggregate(declaredName) {
             for (i in 0..<amount) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/builder/SlashCommandOptionAggregateBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/builder/SlashCommandOptionAggregateBuilderImpl.kt
@@ -39,6 +39,9 @@ internal class SlashCommandOptionAggregateBuilderImpl internal constructor(
     }
 
     override fun optionVararg(declaredName: String, amount: Int, requiredAmount: Int, optionNameSupplier: (Int) -> String, block: SlashCommandOptionBuilder.(Int) -> Unit) {
+        require(amount > 0) { "Amount must be positive" }
+        require(requiredAmount >= 0) { "Required amount must be zero or positive" }
+
         //Same as in TextCommandVariationBuilder#optionVararg
         varargAggregate(declaredName) {
             for (i in 0..<amount) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/builder/TextCommandVariationBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/builder/TextCommandVariationBuilderImpl.kt
@@ -53,8 +53,10 @@ internal class TextCommandVariationBuilderImpl internal constructor(
     }
 
     override fun optionVararg(declaredName: String, amount: Int, requiredAmount: Int, optionNameSupplier: (Int) -> String, block: TextCommandOptionBuilder.(Int) -> Unit) {
-        if (aggregateContainer.hasVararg())
+        if (hasVararg())
             throwArgument("Cannot have more than 1 vararg in text commands")
+        require(amount > 0) { "Amount must be positive" }
+        require(requiredAmount > 0) { "Required amount must be positive" }
 
         //Same as in SlashCommandBuilder#optionVararg
         aggregateContainer.varargAggregate(declaredName) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/builder/TextCommandOptionAggregateBuilderImpl.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/options/builder/TextCommandOptionAggregateBuilderImpl.kt
@@ -35,6 +35,8 @@ internal class TextCommandOptionAggregateBuilderImpl internal constructor(
     override fun optionVararg(declaredName: String, amount: Int, requiredAmount: Int, optionNameSupplier: (Int) -> String, block: TextCommandOptionBuilder.(Int) -> Unit) {
         if (hasVararg())
             throwArgument("Cannot have more than 1 vararg in text commands")
+        require(amount > 0) { "Amount must be positive" }
+        require(requiredAmount > 0) { "Required amount must be positive" }
 
         //Same as in TextCommandVariationBuilder#optionVararg
         varargAggregate(declaredName) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ExecutionUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ExecutionUtils.kt
@@ -7,6 +7,7 @@ import io.github.freya022.botcommands.internal.parameters.AggregatedParameterMix
 import io.github.freya022.botcommands.internal.parameters.MethodParameterMixin
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.function
 import kotlin.reflect.KParameter
+import kotlin.reflect.full.valueParameters
 
 internal enum class InsertOptionResult {
     OK,
@@ -68,11 +69,20 @@ private suspend fun insertAggregate(firstParam: Any, aggregatedObjects: MutableM
         }
     } else {
         val aggregatorArguments: MutableMap<KParameter, Any?> = HashMap(aggregator.parametersSize)
+        var addedOption = false
         for (option in parameter.options) {
             //This is necessary to distinguish between null mappings and default mappings
             if (option in optionValues) {
                 aggregatorArguments[option] = optionValues[option]
+                addedOption = true
             }
+        }
+        // If this is not a vararg, it should throw later when calling the aggregator
+        if (!addedOption && parameter.isVararg) {
+            // TODO: this may cause issues with text commands
+            //  for example when a variation has no argument
+            //  and another variation has a 0-N vararg
+            aggregatorArguments[parameter.aggregator.kFunction.valueParameters.last()] = emptyList<Any?>()
         }
 
         for (nestedAggregatedParameter in parameter.nestedAggregatedParameters) {

--- a/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ExecutionUtils.kt
+++ b/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ExecutionUtils.kt
@@ -79,9 +79,6 @@ private suspend fun insertAggregate(firstParam: Any, aggregatedObjects: MutableM
         }
         // If this is not a vararg, it should throw later when calling the aggregator
         if (!addedOption && parameter.isVararg) {
-            // TODO: this may cause issues with text commands
-            //  for example when a variation has no argument
-            //  and another variation has a 0-N vararg
             aggregatorArguments[parameter.aggregator.kFunction.valueParameters.last()] = emptyList<Any?>()
         }
 


### PR DESCRIPTION
Fixes 0-length vararg for slash commands.

Restricted text commands to at least 1 required argument, to avoid confusion between variants