### PR TITLE
Add modal file uploads

### DIFF
--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ModalParameterResolver.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ModalParameterResolver.kt
@@ -5,6 +5,7 @@ import io.github.freya022.botcommands.api.modals.ModalEvent
 import io.github.freya022.botcommands.api.modals.annotations.ModalInput
 import io.github.freya022.botcommands.api.modals.options.ModalOption
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
+import net.dv8tion.jda.api.components.attachmentupload.AttachmentUpload
 import net.dv8tion.jda.api.components.selections.EntitySelectMenu
 import net.dv8tion.jda.api.components.selections.StringSelectMenu
 import net.dv8tion.jda.api.components.textinput.TextInput
@@ -24,6 +25,7 @@ import kotlin.reflect.KType
  * - [StringSelectMenu] : `List<String>`
  * - [EntitySelectMenu] : [Mentions], `T` and `List<T>` where `T` is one of:
  * [IMentionable], [Role], [User], [InputUser], [Member], [GuildChannel]
+ * - [AttachmentUpload] : `List` of [Message.Attachment]
  *
  * @param T Type of the implementation
  * @param R Type of the returned resolved objects

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/modals/resolvers/ModalAttachmentListResolver.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/modals/resolvers/ModalAttachmentListResolver.kt
@@ -1,0 +1,22 @@
+package io.github.freya022.botcommands.internal.modals.resolvers
+
+import io.github.freya022.botcommands.api.core.service.annotations.Resolver
+import io.github.freya022.botcommands.api.modals.ModalEvent
+import io.github.freya022.botcommands.api.modals.options.ModalOption
+import io.github.freya022.botcommands.api.parameters.TypedParameterResolver
+import io.github.freya022.botcommands.api.parameters.resolvers.ModalParameterResolver
+import net.dv8tion.jda.api.entities.Message.Attachment
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import kotlin.reflect.typeOf
+
+@Resolver
+internal object ModalAttachmentListResolver :
+        TypedParameterResolver<ModalAttachmentListResolver, List<Attachment>>(typeOf<List<Attachment>>()),
+        ModalParameterResolver<ModalAttachmentListResolver, List<Attachment>> {
+
+    override suspend fun resolveSuspend(
+        option: ModalOption,
+        event: ModalEvent,
+        modalMapping: ModalMapping,
+    ): List<Attachment> = modalMapping.asAttachmentList
+}

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/modals/utils/ModalMappings.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/modals/utils/ModalMappings.kt
@@ -12,5 +12,6 @@ internal val ModalMapping.valueAsString: String
         STRING_SELECT -> asStringList.toString()
         TEXT_INPUT -> asString
         CHANNEL_SELECT, ROLE_SELECT, USER_SELECT, MENTIONABLE_SELECT -> asLongList.toString()
+        FILE_UPLOAD -> asAttachmentList.map { "${it.fileName} (${it.contentType}, ${it.size} B)" }.toString()
         else -> toString()
     }

--- a/BotCommands-core/src/test/kotlin/io/github/freya022/botcommands/modals/ModalInputResolverTests.kt
+++ b/BotCommands-core/src/test/kotlin/io/github/freya022/botcommands/modals/ModalInputResolverTests.kt
@@ -10,10 +10,7 @@ import io.github.freya022.botcommands.api.modals.options.ModalOption
 import io.github.freya022.botcommands.api.parameters.ParameterResolver
 import io.github.freya022.botcommands.api.parameters.ResolverRequest
 import io.github.freya022.botcommands.api.parameters.resolvers.ModalParameterResolver
-import io.github.freya022.botcommands.internal.modals.resolvers.ModalIMentionableResolverFactory
-import io.github.freya022.botcommands.internal.modals.resolvers.ModalMentionsResolver
-import io.github.freya022.botcommands.internal.modals.resolvers.ModalStringListResolver
-import io.github.freya022.botcommands.internal.modals.resolvers.ModalStringResolver
+import io.github.freya022.botcommands.internal.modals.resolvers.*
 import io.github.freya022.botcommands.internal.parameters.ResolverContainer
 import io.mockk.every
 import io.mockk.mockk
@@ -53,6 +50,7 @@ object ModalInputResolverTests {
         every { channels } returns this@ModalInputResolverTests.channels
         every { getMentions() } returns this@ModalInputResolverTests.roles
     }
+    private val attachments = listOf<Message.Attachment>(mockk())
 
     @MethodSource("modalInputs")
     @ParameterizedTest
@@ -61,16 +59,19 @@ object ModalInputResolverTests {
             every { getServiceNamesForAnnotation(Resolver::class) } returns listOf(
                 "modalMentionsResolver",
                 "modalStringResolver",
-                "modalStringListResolver"
+                "modalStringListResolver",
+                "modalAttachmentListResolver",
             )
 
             every { findAnnotationOnService("modalMentionsResolver", Resolver::class) } returns Resolver(0)
             every { findAnnotationOnService("modalStringResolver", Resolver::class) } returns Resolver(0)
             every { findAnnotationOnService("modalStringListResolver", Resolver::class) } returns Resolver(0)
+            every { findAnnotationOnService("modalAttachmentListResolver", Resolver::class) } returns Resolver(0)
 
             every { getService("modalMentionsResolver", ParameterResolver::class) } returns ModalMentionsResolver
             every { getService("modalStringResolver", ParameterResolver::class) } returns ModalStringResolver
             every { getService("modalStringListResolver", ParameterResolver::class) } returns ModalStringListResolver
+            every { getService("modalAttachmentListResolver", ParameterResolver::class) } returns ModalAttachmentListResolver
         }
         val resolvers = ResolverContainer(serviceContainer, listOf(ModalIMentionableResolverFactory))
 
@@ -81,6 +82,7 @@ object ModalInputResolverTests {
             every { asString } returns STRING
             every { asStringList } returns strings
             every { asMentions } returns mentions
+            every { asAttachmentList } returns attachments
         }
 
         val value = resolver.resolveSuspend(
@@ -110,6 +112,7 @@ object ModalInputResolverTests {
             arguments("Select menu channel", 12, channel),
             arguments("Select menu channels", 13, channels),
             arguments("Select menu mentions", 14, mentions),
+            arguments("Attachments", 15, attachments),
         )
         return listOf
     }
@@ -133,5 +136,6 @@ object ModalInputResolverTests {
         @Suppress("unused") selectedChannel: GuildChannel?,
         @Suppress("unused") selectedChannels: List<GuildChannel>,
         @Suppress("unused") selectedMentions: Mentions,
+        @Suppress("unused") attachments: List<Message.Attachment>,
     ) {}
 }

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/components/AttachmentUpload.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/components/AttachmentUpload.kt
@@ -55,7 +55,7 @@ class InlineAttachmentUpload(
 }
 
 /**
- * Discord text input, see [AttachmentUpload][net.dv8tion.jda.api.components.attachmentupload.AttachmentUpload].
+ * Component accepting files from users, see [AttachmentUpload][net.dv8tion.jda.api.components.attachmentupload.AttachmentUpload].
  *
  * @param customId The custom ID of the input, see [AttachmentUpload.Builder.setCustomId]
  * @param uniqueId Unique identifier of this component, see [Component.withUniqueId]

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/components/AttachmentUpload.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/components/AttachmentUpload.kt
@@ -1,0 +1,90 @@
+package dev.freya02.botcommands.jda.ktx.components
+
+import net.dv8tion.jda.api.components.Component
+import net.dv8tion.jda.api.components.attachmentupload.AttachmentUpload
+
+class InlineAttachmentUpload(
+    val builder: AttachmentUpload.Builder,
+) : InlineComponent {
+
+    override var uniqueId: Int
+        get() = builder.uniqueId
+        set(value) {
+            builder.setUniqueId(value)
+        }
+
+    /** The custom ID, can be used to pass data, then read in an interaction, see [AttachmentUpload.Builder.setCustomId] */
+    var customId: String
+        get() = builder.customId
+        set(value) {
+            builder.setCustomId(value)
+        }
+
+    /** Whether the user must upload files, see [AttachmentUpload.Builder.setRequired] */
+    var required: Boolean
+        get() = builder.isRequired
+        set(value) {
+            builder.setRequired(value)
+        }
+
+    /** Minimum and maximum amount of files a user can send, see [AttachmentUpload.Builder.setRequiredRange] */
+    var range: IntRange
+        get() = builder.minValues..builder.maxValues
+        set(value) {
+            builder.setRequiredRange(value.first, value.last)
+        }
+
+    /** Minimum amount of attachments the user has to send, see [AttachmentUpload.Builder.setMinValues] */
+    var minValues: Int
+        get() = builder.minValues
+        set(value) {
+            builder.setMinValues(value)
+        }
+
+    /** Maximum amount of attachments the user can send, see [AttachmentUpload.Builder.setMaxValues] */
+    var maxValues: Int
+        get() = builder.maxValues
+        set(value) {
+            builder.setMaxValues(value)
+        }
+
+    /** See [AttachmentUpload.Builder.build] */
+    fun build(): AttachmentUpload {
+        return builder.build()
+    }
+}
+
+/**
+ * Discord text input, see [AttachmentUpload][net.dv8tion.jda.api.components.attachmentupload.AttachmentUpload].
+ *
+ * @param customId The custom ID of the input, see [AttachmentUpload.Builder.setCustomId]
+ * @param uniqueId Unique identifier of this component, see [Component.withUniqueId]
+ * @param required Whether the user must upload files, see [AttachmentUpload.Builder.setRequired]
+ * @param range    Minimum and maximum amount of files a user can send, see [AttachmentUpload.Builder.setRequiredRange]
+ * @param block    Lambda allowing further configuration
+ */
+inline fun AttachmentUpload(
+    customId: String,
+    uniqueId: Int = -1,
+    required: Boolean = true,
+    range: IntRange? = null,
+    block: InlineAttachmentUpload.() -> Unit = {},
+): AttachmentUpload {
+    return AttachmentUpload.create(customId)
+        .let(::InlineAttachmentUpload)
+        .apply {
+            if (uniqueId != -1)
+                this.uniqueId = uniqueId
+            if (!required)
+                this.required = false
+            if (range != null)
+                this.range = range
+            block()
+        }
+        .build()
+}
+
+/**
+ * Sets the minimum and maximum amount of files a user can send, see [AttachmentUpload.Builder.setRequiredRange].
+ */
+fun AttachmentUpload.Builder.setRequiredRange(range: IntRange) = setRequiredRange(range.first, range.last)

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashModal.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashModal.kt
@@ -1,9 +1,9 @@
 package dev.freya02.botcommands.bot.commands.slash
 
 import dev.freya02.botcommands.bot.CustomObject
+import dev.freya02.botcommands.jda.ktx.components.AttachmentUpload
 import dev.freya02.botcommands.jda.ktx.components.EntitySelectMenu
 import dev.freya02.botcommands.jda.ktx.components.StringSelectMenu
-import dev.freya02.botcommands.jda.ktx.components.TextInput
 import dev.freya02.botcommands.jda.ktx.components.row
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import dev.freya02.botcommands.jda.ktx.messages.send
@@ -25,8 +25,8 @@ import io.github.freya022.botcommands.api.modals.annotations.ModalInput
 import io.github.freya022.botcommands.api.modals.annotations.RequiresModals
 import io.github.freya022.botcommands.api.modals.create
 import net.dv8tion.jda.api.components.selections.EntitySelectMenu.SelectTarget
-import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.IMentionable
+import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
 import net.dv8tion.jda.api.interactions.IntegrationType
@@ -37,6 +37,7 @@ private const val SLASH_MODAL_TEXT_INPUT = "SlashModal: textInput"
 private const val SLASH_MODAL_STRING_SELECT_INPUT = "SlashModal: stringSelect"
 private const val SLASH_MODAL_ENTITY_SELECT_INPUT = "SlashModal: entitySelect"
 private const val SLASH_MODAL_CHANNEL_SELECT_INPUT = "SlashModal: channelSelect"
+private const val SLASH_MODAL_ATTACHMENT_INPUT = "SlashModal: attachment"
 
 @Command
 @RequiresModals
@@ -47,9 +48,9 @@ class SlashModal(private val buttons: Buttons) : ApplicationCommand(), GlobalApp
         val modal = modals.create("Title") {
             text("This is a text display")
 
-            label("Sample text") {
-                child = TextInput(SLASH_MODAL_TEXT_INPUT, TextInputStyle.SHORT)
-            }
+//            label("Sample text") {
+//                child = TextInput(SLASH_MODAL_TEXT_INPUT, TextInputStyle.SHORT)
+//            }
 
             label("String select menu") {
                 child = StringSelectMenu(SLASH_MODAL_STRING_SELECT_INPUT, required = false) {
@@ -67,6 +68,14 @@ class SlashModal(private val buttons: Buttons) : ApplicationCommand(), GlobalApp
                     SLASH_MODAL_CHANNEL_SELECT_INPUT,
                     type = SelectTarget.CHANNEL,
                     channelTypes = enumSetOf(ChannelType.CATEGORY),
+                    required = false
+                )
+            }
+
+            label("Attachment") {
+                child = AttachmentUpload(
+                    SLASH_MODAL_ATTACHMENT_INPUT,
+                    range = 1..2,
                     required = false
                 )
             }
@@ -91,10 +100,11 @@ class SlashModal(private val buttons: Buttons) : ApplicationCommand(), GlobalApp
     suspend fun onModalSubmitted(
         event: ModalEvent,
         @ModalData dataStr: String,
-        @ModalInput(customId = SLASH_MODAL_TEXT_INPUT) inputStr: String,
+//        @ModalInput(customId = SLASH_MODAL_TEXT_INPUT) inputStr: String,
         @ModalInput(customId = SLASH_MODAL_STRING_SELECT_INPUT) selectedStrings: List<String>,
         @ModalInput(customId = SLASH_MODAL_ENTITY_SELECT_INPUT) selectedEntities: List<IMentionable>,
         @ModalInput(customId = SLASH_MODAL_CHANNEL_SELECT_INPUT) selectedChannels: List<GuildChannel>,
+        @ModalInput(customId = SLASH_MODAL_ATTACHMENT_INPUT) attachments: List<Message.Attachment>,
         @ModalData dataInt: Int,
         @ModalData definitelyNull: Any?,
         customObject: CustomObject
@@ -104,10 +114,10 @@ class SlashModal(private val buttons: Buttons) : ApplicationCommand(), GlobalApp
             Submitted:
             dataStr: $dataStr
             dataInt: $dataInt
-            inputStr: $inputStr
             selectedStrings: $selectedStrings
             selectedEntities: $selectedEntities
             selectedChannels: $selectedChannels
+            attachments: $attachments
             definitelyNull: $definitelyNull
             customObject: $customObject
             """.trimIndent(),


### PR DESCRIPTION
Waiting on release of https://github.com/discord-jda/JDA/pull/2920

## New features
- jda-ktx: Added `AttachmentUpload` function factories
- Support for `List<Message.Attachment>` parameters annotated with `@ModalInput`