### PR TITLE
Explicitly set `useComponentsV2` to `false` for messages sent without the dev's control

### DIFF
--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/messages/DefaultBotCommandsMessages.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/messages/DefaultBotCommandsMessages.kt
@@ -17,6 +17,7 @@ import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteract
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload
 import net.dv8tion.jda.api.utils.TimeFormat
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import java.time.Instant
 import java.util.*
@@ -123,5 +124,9 @@ open class DefaultBotCommandsMessages(
         return template
     }
 
-    protected fun String.toMessage(): MessageCreateData = MessageCreateData.fromContent(this)
+    protected fun String.toMessage(): MessageCreateData =
+        MessageCreateBuilder()
+            .setContent(this)
+            .useComponentsV2(false)
+            .build()
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
@@ -285,7 +285,7 @@ fun LocalizationContext.localizeOrNull(localizationPath: String, vararg entries:
  * @see MessageChannel.sendMessage
  */
 fun MessageChannel.sendLocalized(context: LocalizationContext, localizationPath: String, vararg entries: PairEntry): MessageCreateAction =
-    sendMessage(context.localize(localizationPath, *entries))
+    sendMessage(context.localize(localizationPath, *entries)).useComponentsV2(false)
 
 /**
  * Sends a localized message to the event's channel.
@@ -321,7 +321,7 @@ fun BaseCommandEvent.replyLocalized(context: LocalizationContext, localizationPa
  * @see IReplyCallback.reply
  */
 fun IReplyCallback.replyLocalized(context: LocalizationContext, localizationPath: String, vararg entries: PairEntry): ReplyCallbackAction =
-    reply(context.localize(localizationPath, *entries))
+    reply(context.localize(localizationPath, *entries)).useComponentsV2(false)
 
 /**
  * Replies a localized ephemeral message to this interaction and acknowledges it.
@@ -333,7 +333,7 @@ fun IReplyCallback.replyLocalized(context: LocalizationContext, localizationPath
  * @see IReplyCallback.reply
  */
 fun IReplyCallback.replyLocalizedEphemeral(context: LocalizationContext, localizationPath: String, vararg entries: PairEntry): ReplyCallbackAction =
-    reply(context.localize(localizationPath, *entries)).setEphemeral(true)
+    reply(context.localize(localizationPath, *entries)).useComponentsV2(false).setEphemeral(true)
 
 /**
  * Sends a localized followup message to this interaction hook.
@@ -348,7 +348,7 @@ fun IReplyCallback.replyLocalizedEphemeral(context: LocalizationContext, localiz
  * @see InteractionHook.sendMessage
  */
 fun InteractionHook.sendLocalized(context: LocalizationContext, localizationPath: String, vararg entries: PairEntry): WebhookMessageCreateAction<Message> =
-    sendMessage(context.localize(localizationPath, *entries))
+    sendMessage(context.localize(localizationPath, *entries)).useComponentsV2(false)
 
 /**
  * Sends a localized ephemeral followup message to this interaction hook.
@@ -363,7 +363,7 @@ fun InteractionHook.sendLocalized(context: LocalizationContext, localizationPath
  * @see InteractionHook.sendMessage
  */
 fun InteractionHook.sendLocalizedEphemeral(context: LocalizationContext, localizationPath: String, vararg entries: PairEntry): WebhookMessageCreateAction<Message> =
-    sendMessage(context.localize(localizationPath, *entries)).setEphemeral(true)
+    sendMessage(context.localize(localizationPath, *entries)).useComponentsV2(false).setEphemeral(true)
 //endregion
 
 //region Localized edits
@@ -377,7 +377,7 @@ fun InteractionHook.sendLocalizedEphemeral(context: LocalizationContext, localiz
  * @see IMessageEditCallback.editMessage
  */
 fun IMessageEditCallback.editLocalized(context: LocalizationContext, localizationPath: String, vararg entries: PairEntry): MessageEditCallbackAction =
-    editMessage(context.localize(localizationPath, *entries))
+    editMessage(context.localize(localizationPath, *entries)).useComponentsV2(false)
 
 /**
  * Replaces the entire original message with a localized message.
@@ -389,7 +389,7 @@ fun IMessageEditCallback.editLocalized(context: LocalizationContext, localizatio
  * @see IMessageEditCallback.editMessage
  */
 fun IMessageEditCallback.replaceLocalized(context: LocalizationContext, localizationPath: String, vararg entries: PairEntry): MessageEditCallbackAction =
-    editMessage(context.localize(localizationPath, *entries)).setReplace(true)
+    editMessage(context.localize(localizationPath, *entries)).useComponentsV2(false).setReplace(true)
 
 /**
  * Edits the text content of the original message with a localized message.
@@ -401,7 +401,7 @@ fun IMessageEditCallback.replaceLocalized(context: LocalizationContext, localiza
  * @see InteractionHook.editOriginal
  */
 fun InteractionHook.editLocalized(context: LocalizationContext, localizationPath: String, vararg entries: PairEntry): WebhookMessageEditAction<Message> =
-    editOriginal(context.localize(localizationPath, *entries))
+    editOriginal(context.localize(localizationPath, *entries)).useComponentsV2(false)
 
 /**
  * Replaces the entire original message with a localized message.
@@ -413,7 +413,7 @@ fun InteractionHook.editLocalized(context: LocalizationContext, localizationPath
  * @see InteractionHook.editOriginal
  */
 fun InteractionHook.replaceLocalized(context: LocalizationContext, localizationPath: String, vararg entries: PairEntry): WebhookMessageEditAction<Message> =
-    editOriginal(context.localize(localizationPath, *entries)).setReplace(true)
+    editOriginal(context.localize(localizationPath, *entries)).useComponentsV2(false).setReplace(true)
 
 /**
  * Edits the text content of the message with a localized message.
@@ -425,7 +425,7 @@ fun InteractionHook.replaceLocalized(context: LocalizationContext, localizationP
  * @see Message.editMessage
  */
 fun Message.editLocalized(context: LocalizationContext, localizationPath: String, vararg entries: PairEntry): MessageEditAction =
-    editMessage(context.localize(localizationPath, *entries))
+    editMessage(context.localize(localizationPath, *entries)).useComponentsV2(false)
 
 /**
  * Replaces the entire message with a localized message.
@@ -437,5 +437,5 @@ fun Message.editLocalized(context: LocalizationContext, localizationPath: String
  * @see Message.editMessage
  */
 fun Message.replaceLocalized(context: LocalizationContext, localizationPath: String, vararg entries: PairEntry): MessageEditAction =
-    editMessage(context.localize(localizationPath, *entries)).setReplace(true)
+    editMessage(context.localize(localizationPath, *entries)).useComponentsV2(false).setReplace(true)
 //endregion

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/pagination/menu/AbstractMenu.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/pagination/menu/AbstractMenu.kt
@@ -35,6 +35,7 @@ abstract class AbstractMenu<E, T : AbstractMenu<E, T>> protected constructor(
         editor?.accept(this as T, builder, embedBuilder, page)
 
         builder.setEmbeds(embedBuilder.build())
+        builder.useComponentsV2(false)
     }
 
     companion object {

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/pagination/nested/AbstractNestedPaginator.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/pagination/nested/AbstractNestedPaginator.kt
@@ -111,6 +111,7 @@ abstract class AbstractNestedPaginator<T : AbstractNestedPaginator<T>> protected
         @Suppress("UNCHECKED_CAST")
         selectedItem.pageEditor.accept(this as T, builder, embedBuilder, page)
         builder.setEmbeds(embedBuilder.build())
+        builder.useComponentsV2(false)
     }
 
     override fun putComponents(builder: MessageCreateBuilder) {

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/pagination/paginator/Paginator.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/pagination/paginator/Paginator.kt
@@ -37,6 +37,7 @@ class Paginator internal constructor(
         val embedBuilder = EmbedBuilder()
         editor.accept(this, builder, embedBuilder, page)
         builder.setEmbeds(embedBuilder.build())
+        builder.useComponentsV2(false)
     }
 
     object Defaults {

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/BaseCommandEventImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/BaseCommandEventImpl.kt
@@ -47,7 +47,7 @@ internal open class BaseCommandEventImpl(
     override fun getArgumentsStr(): String = argumentsStr
 
     override fun reportError(message: String, e: Throwable) {
-        channel.sendMessage(message).queue(null) { t: Throwable? -> logger.error(t) { "Could not send message to channel : $message" } }
+        channel.sendMessage(message).useComponentsV2(false).queue(null) { t: Throwable? -> logger.error(t) { "Could not send message to channel : $message" } }
         context.dispatchException(message, e)
     }
 
@@ -80,8 +80,8 @@ internal open class BaseCommandEventImpl(
         iconStream: InputStream?,
         embed: MessageEmbed
     ): RestAction<Message> = when {
-        iconStream != null -> channel.sendTyping().flatMap { channel.sendFiles(FileUpload.fromData(iconStream, "icon.jpg")).setEmbeds(embed) }
-        else -> channel.sendTyping().flatMap { channel.sendMessageEmbeds(embed) }
+        iconStream != null -> channel.sendTyping().flatMap { channel.sendFiles(FileUpload.fromData(iconStream, "icon.jpg")).setEmbeds(embed).useComponentsV2(false) }
+        else -> channel.sendTyping().flatMap { channel.sendMessageEmbeds(embed).useComponentsV2(false) }
     }
 
     @CheckReturnValue
@@ -90,39 +90,39 @@ internal open class BaseCommandEventImpl(
     @CheckReturnValue
     override fun reactError(): RestAction<Void> = channel.addReactionById(messageId, Emojis.X)
 
-    override fun respond(text: CharSequence): MessageCreateAction = channel.sendMessage(text)
+    override fun respond(text: CharSequence): MessageCreateAction = channel.sendMessage(text).useComponentsV2(false)
 
-    override fun respondFormat(format: String, vararg args: Any): MessageCreateAction = channel.sendMessageFormat(format, *args)
+    override fun respondFormat(format: String, vararg args: Any): MessageCreateAction = channel.sendMessageFormat(format, *args).useComponentsV2(false)
 
-    override fun respond(embed: MessageEmbed, vararg other: MessageEmbed): MessageCreateAction = channel.sendMessageEmbeds(embed, *other)
+    override fun respond(embed: MessageEmbed, vararg other: MessageEmbed): MessageCreateAction = channel.sendMessageEmbeds(embed, *other).useComponentsV2(false)
 
     override fun respondFile(vararg fileUploads: FileUpload): MessageCreateAction = channel.sendFiles(*fileUploads)
 
     @CheckReturnValue
-    override fun reply(text: CharSequence): MessageCreateAction = message.reply(text)
+    override fun reply(text: CharSequence): MessageCreateAction = message.reply(text).useComponentsV2(false)
 
     @CheckReturnValue
-    override fun replyFormat(format: String, vararg args: Any): MessageCreateAction = message.replyFormat(format, *args)
+    override fun replyFormat(format: String, vararg args: Any): MessageCreateAction = message.replyFormat(format, *args).useComponentsV2(false)
 
     @CheckReturnValue
-    override fun reply(embed: MessageEmbed, vararg other: MessageEmbed): MessageCreateAction = message.replyEmbeds(embed, *other)
+    override fun reply(embed: MessageEmbed, vararg other: MessageEmbed): MessageCreateAction = message.replyEmbeds(embed, *other).useComponentsV2(false)
 
     @CheckReturnValue
     override fun replyFile(vararg fileUploads: FileUpload): RestAction<Message> =
         channel.sendTyping().flatMap { message.replyFiles(*fileUploads) }
 
     override fun indicateError(text: CharSequence): RestAction<Message> = when {
-        guild.selfMember.hasPermission(guildChannel, MESSAGE_ADD_REACTION, MESSAGE_HISTORY) -> reactError().flatMap { channel.sendMessage(text) }
-        else -> channel.sendMessage(text)
+        guild.selfMember.hasPermission(guildChannel, MESSAGE_ADD_REACTION, MESSAGE_HISTORY) -> reactError().flatMap { channel.sendMessage(text).useComponentsV2(false) }
+        else -> channel.sendMessage(text).useComponentsV2(false)
     }
 
     override fun indicateErrorFormat(format: String, vararg args: Any): RestAction<Message> = when {
-        guild.selfMember.hasPermission(guildChannel, MESSAGE_ADD_REACTION, MESSAGE_HISTORY) -> reactError().flatMap { channel.sendMessageFormat(format, *args) }
-        else -> channel.sendMessageFormat(format, *args)
+        guild.selfMember.hasPermission(guildChannel, MESSAGE_ADD_REACTION, MESSAGE_HISTORY) -> reactError().flatMap { channel.sendMessageFormat(format, *args).useComponentsV2(false) }
+        else -> channel.sendMessageFormat(format, *args).useComponentsV2(false)
     }
 
     override fun indicateError(embed: MessageEmbed, vararg other: MessageEmbed): RestAction<Message> = when {
-        guild.selfMember.hasPermission(guildChannel, MESSAGE_ADD_REACTION, MESSAGE_HISTORY) -> reactError().flatMap { channel.sendMessageEmbeds(embed, *other) }
-        else -> channel.sendMessageEmbeds(embed, *other)
+        guild.selfMember.hasPermission(guildChannel, MESSAGE_ADD_REACTION, MESSAGE_HISTORY) -> reactError().flatMap { channel.sendMessageEmbeds(embed, *other).useComponentsV2(false) }
+        else -> channel.sendMessageEmbeds(embed, *other).useComponentsV2(false)
     }
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/BContextImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/BContextImpl.kt
@@ -62,7 +62,7 @@ internal class BContextImpl internal constructor(
                                 logger.warn { "Could not send exception DM to owner '${channel.user?.effectiveName}' ($ownerId)" }
                         }
 
-                        channel.sendMessage(content).queue(
+                        channel.sendMessage(content).useComponentsV2(false).queue(
                             null,
                             ErrorHandler().handle(ErrorResponse.CANNOT_SEND_TO_USER) {
                                 onUserNotFound()

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/messages/autoconfigure/BotCommandsMessagesDefaultMessagesAdapter.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/messages/autoconfigure/BotCommandsMessagesDefaultMessagesAdapter.kt
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteract
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload
 import net.dv8tion.jda.api.utils.TimeFormat
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import java.time.Instant
 
@@ -94,5 +95,9 @@ internal class BotCommandsMessagesDefaultMessagesAdapter internal constructor(
         return defaultMessages.modalExpiredErrorMsg.toMessage()
     }
 
-    private fun String.toMessage(): MessageCreateData = MessageCreateData.fromContent(this)
+    private fun String.toMessage(): MessageCreateData =
+        MessageCreateBuilder()
+            .setContent(this)
+            .useComponentsV2(false)
+            .build()
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/LocalizableEditCallbackImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/LocalizableEditCallbackImpl.kt
@@ -12,16 +12,16 @@ internal class LocalizableEditCallbackImpl internal constructor(
 ) : LocalizableEditCallback {
 
     override fun editUser(localizationPath: String, vararg entries: Localization.Entry): MessageEditCallbackAction =
-        editCallback.editMessage(interaction.getUserMessage(localizationPath, *entries))
+        editCallback.editMessage(interaction.getUserMessage(localizationPath, *entries)).useComponentsV2(false)
 
     override fun editGuild(localizationPath: String, vararg entries: Localization.Entry): MessageEditCallbackAction =
-        editCallback.editMessage(interaction.getGuildMessage(localizationPath, *entries))
+        editCallback.editMessage(interaction.getGuildMessage(localizationPath, *entries)).useComponentsV2(false)
 
     override fun editLocalized(
         locale: Locale,
         localizationPath: String,
         vararg entries: Localization.Entry,
     ): MessageEditCallbackAction {
-        return editCallback.editMessage(interaction.getLocalizedMessage(locale, localizationPath, *entries))
+        return editCallback.editMessage(interaction.getLocalizedMessage(locale, localizationPath, *entries)).useComponentsV2(false)
     }
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/LocalizableInteractionHookImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/LocalizableInteractionHookImpl.kt
@@ -15,30 +15,30 @@ internal class LocalizableInteractionHookImpl internal constructor(
     InteractionHook by interactionHook {
 
     override fun sendUser(localizationPath: String, vararg entries: Localization.Entry): WebhookMessageCreateAction<Message> =
-        interactionHook.sendMessage(localizableInteraction.getUserMessage(localizationPath, *entries))
+        interactionHook.sendMessage(localizableInteraction.getUserMessage(localizationPath, *entries)).useComponentsV2(false)
 
     override fun sendGuild(localizationPath: String, vararg entries: Localization.Entry): WebhookMessageCreateAction<Message> =
-        interactionHook.sendMessage(localizableInteraction.getGuildMessage(localizationPath, *entries))
+        interactionHook.sendMessage(localizableInteraction.getGuildMessage(localizationPath, *entries)).useComponentsV2(false)
 
     override fun sendLocalized(
         locale: Locale,
         localizationPath: String,
         vararg entries: Localization.Entry,
     ): WebhookMessageCreateAction<Message> {
-        return interactionHook.sendMessage(localizableInteraction.getLocalizedMessage(locale, localizationPath, *entries))
+        return interactionHook.sendMessage(localizableInteraction.getLocalizedMessage(locale, localizationPath, *entries)).useComponentsV2(false)
     }
 
     override fun editUser(localizationPath: String, vararg entries: Localization.Entry): WebhookMessageEditAction<Message> =
-        interactionHook.editOriginal(localizableInteraction.getUserMessage(localizationPath, *entries))
+        interactionHook.editOriginal(localizableInteraction.getUserMessage(localizationPath, *entries)).useComponentsV2(false)
 
     override fun editGuild(localizationPath: String, vararg entries: Localization.Entry): WebhookMessageEditAction<Message> =
-        interactionHook.editOriginal(localizableInteraction.getGuildMessage(localizationPath, *entries))
+        interactionHook.editOriginal(localizableInteraction.getGuildMessage(localizationPath, *entries)).useComponentsV2(false)
 
     override fun editLocalized(
         locale: Locale,
         localizationPath: String,
         vararg entries: Localization.Entry
     ): WebhookMessageEditAction<Message> {
-        return interactionHook.editOriginal(localizableInteraction.getLocalizedMessage(locale, localizationPath, *entries))
+        return interactionHook.editOriginal(localizableInteraction.getLocalizedMessage(locale, localizationPath, *entries)).useComponentsV2(false)
     }
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/LocalizableReplyCallbackImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/LocalizableReplyCallbackImpl.kt
@@ -12,16 +12,16 @@ internal class LocalizableReplyCallbackImpl internal constructor(
 ) : LocalizableReplyCallback {
 
     override fun replyUser(localizationPath: String, vararg entries: Localization.Entry): ReplyCallbackAction =
-        replyCallback.reply(interaction.getUserMessage(localizationPath, *entries))
+        replyCallback.reply(interaction.getUserMessage(localizationPath, *entries)).useComponentsV2(false)
 
     override fun replyGuild(localizationPath: String, vararg entries: Localization.Entry): ReplyCallbackAction =
-        replyCallback.reply(interaction.getGuildMessage(localizationPath, *entries))
+        replyCallback.reply(interaction.getGuildMessage(localizationPath, *entries)).useComponentsV2(false)
 
     override fun replyLocalized(
         locale: Locale,
         localizationPath: String,
         vararg entries: Localization.Entry,
     ): ReplyCallbackAction {
-        return replyCallback.reply(interaction.getLocalizedMessage(locale, localizationPath, *entries))
+        return replyCallback.reply(interaction.getLocalizedMessage(locale, localizationPath, *entries)).useComponentsV2(false)
     }
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/text/LocalizableTextCommandImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/text/LocalizableTextCommandImpl.kt
@@ -52,11 +52,11 @@ internal class LocalizableTextCommandImpl internal constructor(
     }
 
     override fun respondGuild(localizationPath: String, vararg entries: Localization.Entry): MessageCreateAction {
-        return event.channel.sendMessage(getGuildMessage(localizationPath, *entries))
+        return event.channel.sendMessage(getGuildMessage(localizationPath, *entries)).useComponentsV2(false)
     }
 
     override fun replyGuild(localizationPath: String, vararg entries: Localization.Entry): MessageCreateAction {
-        return event.message.reply(getGuildMessage(localizationPath, *entries))
+        return event.message.reply(getGuildMessage(localizationPath, *entries)).useComponentsV2(false)
     }
 
     override fun respondLocalized(
@@ -64,7 +64,7 @@ internal class LocalizableTextCommandImpl internal constructor(
         localizationPath: String,
         vararg entries: Localization.Entry
     ): MessageCreateAction {
-        return event.channel.sendMessage(getLocalizedMessage(locale, localizationPath, *entries))
+        return event.channel.sendMessage(getLocalizedMessage(locale, localizationPath, *entries)).useComponentsV2(false)
     }
 
     override fun replyLocalized(
@@ -72,6 +72,6 @@ internal class LocalizableTextCommandImpl internal constructor(
         localizationPath: String,
         vararg entries: Localization.Entry
     ): MessageCreateAction {
-        return event.message.reply(getLocalizedMessage(locale, localizationPath, *entries))
+        return event.message.reply(getLocalizedMessage(locale, localizationPath, *entries)).useComponentsV2(false)
     }
 }


### PR DESCRIPTION
So users enabling CV2 by default won't prevent our messages from being built