### PR TITLE
Log debug instead of error about external component/modal interactions

### DIFF
--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentsListener.kt
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.internal.components.controller
 
 import io.github.freya022.botcommands.api.commands.ratelimit.CancellableRateLimit
 import io.github.freya022.botcommands.api.components.ComponentInteractionFilter
-import io.github.freya022.botcommands.api.components.Components
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
 import io.github.freya022.botcommands.api.components.event.ButtonEvent
 import io.github.freya022.botcommands.api.components.event.EntitySelectEvent
@@ -11,7 +10,6 @@ import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.Filter
 import io.github.freya022.botcommands.api.core.annotations.BEventListener
 import io.github.freya022.botcommands.api.core.checkFilters
-import io.github.freya022.botcommands.api.core.config.BComponentsConfigBuilder
 import io.github.freya022.botcommands.api.core.messages.BotCommandsMessagesFactory
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.core.utils.simpleNestedName
@@ -21,7 +19,10 @@ import io.github.freya022.botcommands.internal.components.data.PersistentCompone
 import io.github.freya022.botcommands.internal.components.handler.ComponentHandlerExecutor
 import io.github.freya022.botcommands.internal.core.ExceptionHandler
 import io.github.freya022.botcommands.internal.localization.interaction.LocalizableInteractionFactory
-import io.github.freya022.botcommands.internal.utils.*
+import io.github.freya022.botcommands.internal.utils.launchCatching
+import io.github.freya022.botcommands.internal.utils.reference
+import io.github.freya022.botcommands.internal.utils.replyExceptionMessage
+import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.EntitySelectInteractionEvent
@@ -54,9 +55,9 @@ internal class ComponentsListener(
 
         scope.launchCatching({ handleException(event, it) }) launch@{
             val componentId = event.componentId.let { id ->
-                if (!ComponentController.isCompatibleComponent(id))
-                    return@launch logger.error { "Received an interaction for an external component format: '${event.componentId}', " +
-                            "please only use ${classRef<Components>()} to make components or disable ${BComponentsConfigBuilder::enable.reference}" }
+                if (!ComponentController.isCompatibleComponent(id)) {
+                    return@launch logger.debug { "Ignoring an interaction for an external component format: '${event.componentId}'" }
+                }
                 ComponentController.parseComponentId(id)
             }
             val component = componentController.getActiveComponent(componentId)

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalListener.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/modals/ModalListener.kt
@@ -1,18 +1,19 @@
 package io.github.freya022.botcommands.internal.modals
 
 import io.github.freya022.botcommands.api.core.annotations.BEventListener
-import io.github.freya022.botcommands.api.core.config.BModalsConfig
 import io.github.freya022.botcommands.api.core.messages.BotCommandsMessagesFactory
 import io.github.freya022.botcommands.api.core.service.annotations.BService
 import io.github.freya022.botcommands.api.modals.ModalEvent
-import io.github.freya022.botcommands.api.modals.Modals
 import io.github.freya022.botcommands.api.modals.annotations.ModalHandler
 import io.github.freya022.botcommands.api.modals.annotations.RequiresModals
 import io.github.freya022.botcommands.internal.core.BContextImpl
 import io.github.freya022.botcommands.internal.core.ExceptionHandler
 import io.github.freya022.botcommands.internal.localization.interaction.LocalizableInteractionFactory
 import io.github.freya022.botcommands.internal.modals.utils.allValuesAsString
-import io.github.freya022.botcommands.internal.utils.*
+import io.github.freya022.botcommands.internal.utils.annotationRef
+import io.github.freya022.botcommands.internal.utils.launchCatching
+import io.github.freya022.botcommands.internal.utils.replyExceptionMessage
+import io.github.freya022.botcommands.internal.utils.throwArgument
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException
@@ -39,8 +40,7 @@ internal class ModalListener(
 
         scope.launchCatching({ handleException(it, jdaEvent) }) launch@{
             if (!ModalMaps.isCompatibleModal(jdaEvent.modalId)) {
-                return@launch logger.error { "Received an interaction for an external modal format: '${jdaEvent.modalId}', " +
-                        "please use ${classRef<Modals>()} to make modals or disable them with ${BModalsConfig::enable.reference}" }
+                return@launch logger.debug { "Ignoring an interaction for an external modal format: '${jdaEvent.modalId}'" }
             }
 
             val modalData = modalMaps.consumeModal(ModalMaps.parseModalId(jdaEvent.modalId))


### PR DESCRIPTION
It's unlikely that a user will use JDA's components then complain about specialized listeners not working. Moving to debug logs also allows for other libraries (using vanilla components) to be used, such as pagination libraries.