### PR TITLE
Split up and deprecated `ApplicationCommand` and `TextCommand`

### DIFF
--- a/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashBan.kt
+++ b/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashBan.kt
@@ -8,7 +8,6 @@ import io.github.freya022.bot.switches.KotlinDetailProfile
 import io.github.freya022.botcommands.api.commands.annotations.BotPermissions
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.UserPermissions
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -156,7 +155,7 @@ class SlashBanDetailedFront : GlobalApplicationCommandProvider {
 
 @Command
 @KotlinDetailProfile(KotlinDetailProfile.Profile.KOTLIN)
-class SlashBanSimplifiedFront(private val banImpl: SlashBan) : ApplicationCommand() {
+class SlashBanSimplifiedFront(private val banImpl: SlashBan) {
     @UserPermissions(Permission.BAN_MEMBERS)
     @BotPermissions(Permission.BAN_MEMBERS)
     @JDASlashCommand(name = "ban", description = "Ban any user from this guild")

--- a/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashButton.kt
+++ b/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashButton.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.components.into
 import dev.freya02.botcommands.jda.ktx.components.row
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.CommandScope
 import io.github.freya022.botcommands.api.commands.application.slash.GlobalSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
@@ -20,7 +19,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
 @Command
-class SlashButton(private val buttons: Buttons) : ApplicationCommand() {
+class SlashButton(private val buttons: Buttons) {
     @TopLevelSlashCommandData(scope = CommandScope.GLOBAL)
     @JDASlashCommand(name = "button", description = "Try out the new buttons!")
     suspend fun onSlashButton(event: GlobalSlashEvent) {

--- a/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashChoose.kt
+++ b/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashChoose.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.bot.switches.KotlinDetailProfile
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.VarArgs
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -40,7 +39,7 @@ class SlashChooseDetailedFront : GlobalApplicationCommandProvider {
 
 @Command
 @KotlinDetailProfile(KotlinDetailProfile.Profile.KOTLIN)
-class SlashChooseSimplifiedFront(private val slashChoose: SlashChoose) : ApplicationCommand() {
+class SlashChooseSimplifiedFront(private val slashChoose: SlashChoose) {
     @JDASlashCommand(name = "choose", description = "Randomly choose a value")
     fun onSlashBan(
         event: GuildSlashEvent,

--- a/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashDelayedSelectMenu.kt
+++ b/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashDelayedSelectMenu.kt
@@ -5,7 +5,6 @@ import dev.freya02.botcommands.jda.ktx.components.row
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import dev.freya02.botcommands.jda.ktx.requests.awaitCatching
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.components.Buttons
@@ -29,7 +28,7 @@ import kotlin.time.Duration.Companion.seconds
 class SlashDelayedSelectMenu(
     private val buttons: Buttons,
     private val selectMenus: SelectMenus
-) : ApplicationCommand() {
+) {
     private class Choices {
         var values: List<String> = emptyList()
             private set

--- a/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashFormat.kt
+++ b/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashFormat.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.components.StringSelectMenu
 import dev.freya02.botcommands.jda.ktx.components.TextInput
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.modals.Modals
@@ -17,7 +16,7 @@ private const val languageInputId = "SlashModal: languageInput"
 
 @Command
 @RequiresModals
-class SlashFormat(private val modals: Modals) : ApplicationCommand() {
+class SlashFormat(private val modals: Modals) {
 
     @JDASlashCommand(name = "format", description = "Formats your code")
     suspend fun onSlashFormat(event: GuildSlashEvent) {

--- a/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashSentence.kt
+++ b/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/slash/SlashSentence.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.bot.switches.KotlinDetailProfile
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.VarArgs
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -74,7 +73,7 @@ class SlashSentenceDetailedFront : GlobalApplicationCommandProvider {
 
 @Command
 @KotlinDetailProfile(KotlinDetailProfile.Profile.KOTLIN)
-class SlashSentenceSimplifiedFront(private val slashSentence: SlashSentence) : ApplicationCommand() {
+class SlashSentenceSimplifiedFront(private val slashSentence: SlashSentence) {
     @JDASlashCommand(name = "sentence", description = "Make a sentence")
     fun onSlashSentence(
         event: GuildSlashEvent,

--- a/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/text/TextExit.kt
+++ b/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/text/TextExit.kt
@@ -2,7 +2,6 @@ package io.github.freya022.bot.commands.text
 
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.annotations.Hidden
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.annotations.RequireOwner
@@ -13,7 +12,7 @@ import kotlin.system.exitProcess
 private val logger = KotlinLogging.logger { }
 
 @Command
-class TextExit : TextCommand() {
+class TextExit {
     @Hidden
     @RequireOwner
     @JDATextCommandVariation(path = ["exit"])

--- a/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/text/TextNumber.kt
+++ b/BotCommands-core/src/examples/kotlin/io/github/freya022/bot/commands/text/TextNumber.kt
@@ -2,13 +2,12 @@ package io.github.freya022.bot.commands.text
 
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.annotations.TextOption
 import kotlin.math.PI
 
 @Command
-class TextNumber : TextCommand() {
+class TextNumber {
     @JDATextCommandVariation(path = ["number"])
     fun onTextNumber(event: BaseCommandEvent, @TextOption number: Int) {
         event.reply("$number * pi = ${number * PI}").queue()

--- a/BotCommands-core/src/javaDocExamples/java/doc/java/examples/commands/slash/SlashRequestRole.java
+++ b/BotCommands-core/src/javaDocExamples/java/doc/java/examples/commands/slash/SlashRequestRole.java
@@ -1,7 +1,6 @@
 package doc.java.examples.commands.slash;
 
 import io.github.freya022.botcommands.api.commands.annotations.Command;
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand;
 import io.github.freya022.botcommands.api.modals.ModalEvent;
@@ -20,7 +19,7 @@ import net.dv8tion.jda.api.entities.Role;
 import java.util.List;
 
 @Command
-public class SlashRequestRole extends ApplicationCommand {
+public class SlashRequestRole {
 
     private static final String MODAL_NAME = "request role";
     private static final String INPUT_ROLE = "role";

--- a/BotCommands-core/src/javaDocExamples/java/doc/java/examples/commands/slash/SlashSayAgainEphemeral.java
+++ b/BotCommands-core/src/javaDocExamples/java/doc/java/examples/commands/slash/SlashSayAgainEphemeral.java
@@ -1,7 +1,6 @@
 package doc.java.examples.commands.slash;
 
 import io.github.freya022.botcommands.api.commands.annotations.Command;
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.Length;
@@ -17,7 +16,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 @Command
 @RequiresComponents
-public class SlashSayAgainEphemeral extends ApplicationCommand {
+public class SlashSayAgainEphemeral {
     @JDASlashCommand(name = "say_again", subcommand = "ephemeral", description = "Sends a button to send a message again")
     public void onSlashSayAgain(
             GuildSlashEvent event,

--- a/BotCommands-core/src/javaDocExamples/java/doc/java/examples/commands/slash/SlashSayAgainPersistent.java
+++ b/BotCommands-core/src/javaDocExamples/java/doc/java/examples/commands/slash/SlashSayAgainPersistent.java
@@ -1,7 +1,6 @@
 package doc.java.examples.commands.slash;
 
 import io.github.freya022.botcommands.api.commands.annotations.Command;
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.Length;
@@ -16,7 +15,7 @@ import net.dv8tion.jda.api.components.buttons.Button;
 
 @Command
 @RequiresComponents
-public class SlashSayAgainPersistent extends ApplicationCommand {
+public class SlashSayAgainPersistent {
     private static final String SAY_SENTENCE_HANDLER_NAME = "SlashSayAgainPersistent: saySentenceButton";
 
     @TopLevelSlashCommandData

--- a/BotCommands-core/src/javaDocExamples/java/doc/java/examples/commands/slash/SlashSelectRoleEphemeral.java
+++ b/BotCommands-core/src/javaDocExamples/java/doc/java/examples/commands/slash/SlashSelectRoleEphemeral.java
@@ -1,7 +1,6 @@
 package doc.java.examples.commands.slash;
 
 import io.github.freya022.botcommands.api.commands.annotations.Command;
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand;
 import io.github.freya022.botcommands.api.components.EntitySelectMenu;
@@ -18,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 @Command
 @RequiresComponents
-public class SlashSelectRoleEphemeral extends ApplicationCommand {
+public class SlashSelectRoleEphemeral {
     @JDASlashCommand(name = "select_role", subcommand = "ephemeral", description = "Sends a menu to choose a role from")
     public void onSlashSelectRole(
             GuildSlashEvent event,

--- a/BotCommands-core/src/javaDocExamples/java/doc/java/examples/commands/slash/SlashSelectRolePersistent.java
+++ b/BotCommands-core/src/javaDocExamples/java/doc/java/examples/commands/slash/SlashSelectRolePersistent.java
@@ -1,7 +1,6 @@
 package doc.java.examples.commands.slash;
 
 import io.github.freya022.botcommands.api.commands.annotations.Command;
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData;
@@ -18,7 +17,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 @Command
 @RequiresComponents
-public class SlashSelectRolePersistent extends ApplicationCommand {
+public class SlashSelectRolePersistent {
     private static final String ROLE_MENU_HANDLER_NAME = "SlashSelectRolePersistent: roleMenu";
 
     @TopLevelSlashCommandData

--- a/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashInMemoryRateLimit.kt
+++ b/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashInMemoryRateLimit.kt
@@ -2,7 +2,6 @@ package doc.kotlin.examples.commands.slash
 
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -13,7 +12,7 @@ import io.github.freya022.botcommands.api.commands.ratelimit.bucket.toSupplier
 import kotlin.time.Duration.Companion.seconds
 
 @Command
-class SlashInMemoryRateLimit : ApplicationCommand(), GlobalApplicationCommandProvider {
+class SlashInMemoryRateLimit : GlobalApplicationCommandProvider {
     fun onSlashInMemoryRateLimit(event: GuildSlashEvent) {
         event.reply_("Hi", ephemeral = true).queue()
     }

--- a/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashPersistentRateLimit.kt
+++ b/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashPersistentRateLimit.kt
@@ -3,7 +3,6 @@ package doc.kotlin.examples.commands.slash
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.bucket4j.distributed.proxy.ProxyManager
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -14,7 +13,7 @@ import io.github.freya022.botcommands.api.commands.ratelimit.bucket.toSupplier
 import kotlin.time.Duration.Companion.hours
 
 @Command
-class SlashPersistentRateLimit(private val proxyManager: ProxyManager<String>) : ApplicationCommand(), GlobalApplicationCommandProvider {
+class SlashPersistentRateLimit(private val proxyManager: ProxyManager<String>) : GlobalApplicationCommandProvider {
     fun onSlashPersistentRateLimit(event: GuildSlashEvent) {
         event.reply_("Hi", ephemeral = true).queue()
     }

--- a/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashSayAgainEphemeral.kt
+++ b/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashSayAgainEphemeral.kt
@@ -5,7 +5,6 @@ import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.durations.after
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.Length
@@ -18,7 +17,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @Command
 @RequiresComponents
-class SlashSayAgainEphemeral : ApplicationCommand() {
+class SlashSayAgainEphemeral {
     @JDASlashCommand(name = "say_again", subcommand = "ephemeral", description = "Sends a button to send a message again")
     suspend fun onSlashSayAgain(
         event: GuildSlashEvent,

--- a/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashSayAgainPersistent.kt
+++ b/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashSayAgainPersistent.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.components.row
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.Length
@@ -20,7 +19,7 @@ import net.dv8tion.jda.api.components.buttons.Button
 
 @Command
 @RequiresComponents
-class SlashSayAgainPersistent : ApplicationCommand() {
+class SlashSayAgainPersistent {
     @TopLevelSlashCommandData
     @JDASlashCommand(name = "say_again", subcommand = "persistent", description = "Sends a button to send a message again")
     suspend fun onSlashSayAgain(

--- a/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashSelectRoleEphemeral.kt
+++ b/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashSelectRoleEphemeral.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.components.row
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.durations.after
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.components.EntitySelectMenu
@@ -19,7 +18,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @Command
 @RequiresComponents
-class SlashSelectRoleEphemeral : ApplicationCommand() {
+class SlashSelectRoleEphemeral {
     @JDASlashCommand(name = "select_role", subcommand = "ephemeral", description = "Sends a menu to choose a role from")
     suspend fun onSlashSelectRole(event: GuildSlashEvent, selectMenus: SelectMenus) {
         val randomNumber = Random.nextLong()

--- a/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashSelectRolePersistent.kt
+++ b/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashSelectRolePersistent.kt
@@ -3,7 +3,6 @@ package doc.kotlin.examples.commands.slash
 import dev.freya02.botcommands.jda.ktx.components.row
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
@@ -19,7 +18,7 @@ import kotlin.random.Random
 
 @Command
 @RequiresComponents
-class SlashSelectRolePersistent : ApplicationCommand() {
+class SlashSelectRolePersistent {
     @TopLevelSlashCommandData
     @JDASlashCommand(name = "select_role", subcommand = "persistent", description = "Sends a menu to choose a role from")
     suspend fun onSlashSelectRole(event: GuildSlashEvent, selectMenus: SelectMenus) {

--- a/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashTypeSafeButtons.kt
+++ b/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashTypeSafeButtons.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.components.into
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
@@ -17,7 +16,7 @@ import io.github.freya022.botcommands.api.components.event.ButtonEvent
 
 @Command
 @RequiresComponents
-class SlashTypeSafeButtons(private val buttons: Buttons) : ApplicationCommand() {
+class SlashTypeSafeButtons(private val buttons: Buttons) {
     @JDASlashCommand(name = "type_safe_buttons", description = "Demo of Kotlin type-safe bindings")
     suspend fun onSlashTypeSafeButtons(event: GuildSlashEvent, @SlashOption argument: String) {
         val button = buttons.primary("Click me").persistent {

--- a/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashTypeSafeSelectMenus.kt
+++ b/BotCommands-core/src/kotlinDocExamples/kotlin/doc/kotlin/examples/commands/slash/SlashTypeSafeSelectMenus.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.components.into
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
@@ -18,7 +17,7 @@ import net.dv8tion.jda.api.components.selections.EntitySelectMenu
 
 @Command
 @RequiresComponents
-class SlashTypeSafeSelectMenus(private val selectMenus: SelectMenus) : ApplicationCommand() {
+class SlashTypeSafeSelectMenus(private val selectMenus: SelectMenus) {
     @JDASlashCommand(name = "type_safe_select_menus", description = "Demo of Kotlin type-safe bindings")
     suspend fun onSlashTypeSafeSelectMenus(event: GuildSlashEvent, @SlashOption argument: String) {
         val selectMenu = selectMenus.entitySelectMenu(EntitySelectMenu.SelectTarget.ROLE).persistent {

--- a/BotCommands-core/src/main/java/io/github/freya022/botcommands/api/commands/text/TextCommand.java
+++ b/BotCommands-core/src/main/java/io/github/freya022/botcommands/api/commands/text/TextCommand.java
@@ -17,8 +17,11 @@ import java.util.function.Consumer;
  * <p>You are not required to use this if you use {@link TextCommandProvider}
  *
  * @see JDATextCommandVariation @JDATextCommandVariation
+ *
+ * @deprecated This superclass is no longer mandatory, if you override methods from it, implement them using their respective interfaces
  */
 @NullMarked
+@Deprecated
 public abstract class TextCommand implements TextCommandHelpConsumer, TextGeneratedValueSupplierProvider {
     /**
      * <p>Returns a detailed embed of what the command is, it is used by the internal {@code help} command</p>

--- a/BotCommands-core/src/main/java/io/github/freya022/botcommands/api/commands/text/TextCommand.java
+++ b/BotCommands-core/src/main/java/io/github/freya022/botcommands/api/commands/text/TextCommand.java
@@ -1,7 +1,6 @@
 package io.github.freya022.botcommands.api.commands.text;
 
 import io.github.freya022.botcommands.api.commands.CommandPath;
-import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption;
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation;
 import io.github.freya022.botcommands.api.commands.text.builder.TextCommandBuilder;
 import io.github.freya022.botcommands.api.commands.text.provider.TextCommandProvider;
@@ -20,7 +19,7 @@ import java.util.function.Consumer;
  * @see JDATextCommandVariation @JDATextCommandVariation
  */
 @NullMarked
-public abstract class TextCommand {
+public abstract class TextCommand implements TextCommandHelpConsumer, TextGeneratedValueSupplierProvider {
     /**
      * <p>Returns a detailed embed of what the command is, it is used by the internal {@code help} command</p>
      * <p>The {@code help} command will automatically set the embed title to be {@code Command '[command_name]'} but can be overridden</p>
@@ -28,26 +27,22 @@ public abstract class TextCommand {
      *
      * @return The EmbedBuilder to use as a detailed description
      *
-     * @see TextCommandBuilder#setDetailedDescription(Consumer) DSL equivalent
+     * @see TextCommandBuilder#setDetailedDescription(kotlin.jvm.functions.Function1) DSL equivalent
      */
     @Nullable
     public Consumer<EmbedBuilder> getDetailedDescription() {
         return null;
     }
 
-    /**
-     * Returns the generated value supplier of an {@link GeneratedOption @GeneratedOption},
-     * if the method doesn't return a generated value supplier, the framework will throw.
-     * <br>This method is called only if your option is annotated with {@link GeneratedOption @GeneratedOption}
-     *
-     * <p>This method will only be called once per command option per guild
-     *
-     * @param commandPath   The path of the command, as set in {@link JDATextCommandVariation}
-     * @param optionName    The name of the <b>transformed</b> command option, might not be equal to the parameter name
-     * @param parameterType The <b>boxed</b> type of the command option
-     *
-     * @return A {@link TextGeneratedValueSupplier} to generate the option on command execution
-     */
+    @Override
+    public final void accept(EmbedBuilder builder) {
+        Consumer<EmbedBuilder> consumer = getDetailedDescription();
+        if (consumer != null) {
+            consumer.accept(builder);
+        }
+    }
+
+    @Override
     public TextGeneratedValueSupplier getGeneratedValueSupplier(CommandPath commandPath,
                                                                 String optionName,
                                                                 ParameterType parameterType) {

--- a/BotCommands-core/src/main/java/io/github/freya022/botcommands/api/commands/text/TextCommandHelpConsumer.java
+++ b/BotCommands-core/src/main/java/io/github/freya022/botcommands/api/commands/text/TextCommandHelpConsumer.java
@@ -1,0 +1,20 @@
+package io.github.freya022.botcommands.api.commands.text;
+
+import io.github.freya022.botcommands.api.commands.text.builder.TextCommandBuilder;
+import net.dv8tion.jda.api.EmbedBuilder;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Optional interface used by the built-in {@code help} command.
+ * <br>This consumer will apply to all text commands present in a given class.
+ *
+ * <p>If you use your own help command, you do not need to implement this.
+ */
+public interface TextCommandHelpConsumer {
+    /**
+     * Customizes the provided embed builder.
+     *
+     * @see TextCommandBuilder#setDetailedDescription(kotlin.jvm.functions.Function1) DSL equivalent
+     */
+    void accept(@NonNull EmbedBuilder builder);
+}

--- a/BotCommands-core/src/main/java/io/github/freya022/botcommands/api/commands/text/TextGeneratedValueSupplierProvider.java
+++ b/BotCommands-core/src/main/java/io/github/freya022/botcommands/api/commands/text/TextGeneratedValueSupplierProvider.java
@@ -1,0 +1,30 @@
+package io.github.freya022.botcommands.api.commands.text;
+
+import io.github.freya022.botcommands.api.commands.CommandPath;
+import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption;
+import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation;
+import io.github.freya022.botcommands.api.core.reflect.ParameterType;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Interface to be implemented for {@link GeneratedOption @GeneratedOption}s of <b>annotated</b> text commands.
+ *
+ * <p>This must be implemented on the same class as the command.
+ */
+public interface TextGeneratedValueSupplierProvider {
+    /**
+     * Returns the generated value supplier of an {@link GeneratedOption @GeneratedOption}.
+     *
+     * <p>This method will only be called once per command option per guild.
+     *
+     * @param commandPath   The path of the command, as set in {@link JDATextCommandVariation}
+     * @param optionName    The name of the <b>transformed</b> command option, might not be equal to the parameter name
+     * @param parameterType The <b>boxed</b> type of the command option
+     *
+     * @return A {@link TextGeneratedValueSupplier} to generate the option on command execution
+     */
+    @NonNull
+    TextGeneratedValueSupplier getGeneratedValueSupplier(@NonNull CommandPath commandPath,
+                                                         @NonNull String optionName,
+                                                         @NonNull ParameterType parameterType);
+}

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/annotations/GeneratedOption.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/annotations/GeneratedOption.kt
@@ -2,14 +2,14 @@ package io.github.freya022.botcommands.api.commands.annotations
 
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplierProvider
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSupplier
+import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSupplierProvider
 
 /**
  * Marks a parameter as being a generated option.
  *
  * ## For text commands
- * You will have to override [TextCommand.getGeneratedValueSupplier]
+ * You will have to implement [TextGeneratedValueSupplierProvider]
  * and return, on the correct command path/option name,
  * an appropriate [TextGeneratedValueSupplier] that will generate an object of the correct type.
  *

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/annotations/GeneratedOption.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/annotations/GeneratedOption.kt
@@ -1,7 +1,7 @@
 package io.github.freya022.botcommands.api.commands.annotations
 
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier
+import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplierProvider
 import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSupplier
 
@@ -14,7 +14,7 @@ import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSuppli
  * an appropriate [TextGeneratedValueSupplier] that will generate an object of the correct type.
  *
  * ## For application commands
- * You will have to override [ApplicationCommand.getGeneratedValueSupplier]
+ * You will have to implement [ApplicationGeneratedValueSupplierProvider]
  * and return, on the correct guild/command id/command path/option name,
  * an appropriate [ApplicationGeneratedValueSupplier] that will generate an object of the correct type.
  */

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommand.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommand.kt
@@ -6,10 +6,7 @@ import io.github.freya022.botcommands.api.commands.application.annotations.Comma
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAMessageCommand
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAUserCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
-import io.github.freya022.botcommands.api.commands.application.slash.options.builder.SlashCommandOptionBuilder
-import io.github.freya022.botcommands.api.core.config.BApplicationConfigBuilder
 import io.github.freya022.botcommands.api.core.reflect.ParameterType
-import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.internal.utils.throwArgument
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.interactions.commands.Command
@@ -22,26 +19,11 @@ import net.dv8tion.jda.api.interactions.commands.Command
  * @see JDASlashCommand @JDASlashCommand
  * @see JDAMessageCommand @JDAMessageCommand
  * @see JDAUserCommand @JDAUserCommand
+ *
+ * @see SlashOptionChoiceProvider
  */
-abstract class ApplicationCommand {
-    /**
-     * Returns the choices available for this command path,
-     * on the specific [optionName].
-     *
-     * The choices returned by this method will have their name localized
-     * if they are present in the [localization bundles][BApplicationConfigBuilder.addLocalizations].
-     *
-     * @param guild       The [Guild] in which the command is, might be `null` for global commands with choices
-     * @param commandPath The [CommandPath] of the command, this is composed of it's name and optionally of its group and subcommand name
-     * @param optionName  The option name, not the same as the parameter name, this is the same name that appears on Discord
-     *
-     * @return The list of choices for this slash command's options
-     *
-     * @see SlashParameterResolver.getPredefinedChoices
-     *
-     * @see SlashCommandOptionBuilder.choices DSL equivalent
-     */
-    open fun getOptionChoices(guild: Guild?, commandPath: CommandPath, optionName: String): List<Command.Choice> {
+abstract class ApplicationCommand : SlashOptionChoiceProvider {
+    override fun getOptionChoices(guild: Guild?, commandPath: CommandPath, optionName: String): List<Command.Choice> {
         return emptyList()
     }
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommand.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommand.kt
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.interactions.commands.Command
  *
  * @see SlashOptionChoiceProvider
  */
+@Deprecated(message = "This superclass is no longer mandatory, if you override methods from it, implement them using their respective interfaces")
 abstract class ApplicationCommand : SlashOptionChoiceProvider, ApplicationGeneratedValueSupplierProvider {
     override fun getOptionChoices(guild: Guild?, commandPath: CommandPath, optionName: String): List<Command.Choice> {
         return emptyList()

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommand.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationCommand.kt
@@ -1,8 +1,6 @@
 package io.github.freya022.botcommands.api.commands.application
 
 import io.github.freya022.botcommands.api.commands.CommandPath
-import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption
-import io.github.freya022.botcommands.api.commands.application.annotations.CommandId
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAMessageCommand
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAUserCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
@@ -22,25 +20,12 @@ import net.dv8tion.jda.api.interactions.commands.Command
  *
  * @see SlashOptionChoiceProvider
  */
-abstract class ApplicationCommand : SlashOptionChoiceProvider {
+abstract class ApplicationCommand : SlashOptionChoiceProvider, ApplicationGeneratedValueSupplierProvider {
     override fun getOptionChoices(guild: Guild?, commandPath: CommandPath, optionName: String): List<Command.Choice> {
         return emptyList()
     }
 
-    /**
-     * Returns the generated value supplier of a [@GeneratedOption][GeneratedOption].
-     *
-     * This function will only be called once per command option per guild.
-     *
-     * @param guild         The [Guild] in which to add the default value, `null` if the scope is **not** [CommandScope.GUILD]
-     * @param commandId     The ID of the command, as optionally set in [@CommandId][CommandId], might be `null`
-     * @param commandPath   The path of the command, as set in [@JDASlashCommand][JDASlashCommand]
-     * @param optionName    The option name, not the same as the parameter name, this is the same name that appears on Discord
-     * @param parameterType The **boxed** type of the command option
-     *
-     * @return A [ApplicationGeneratedValueSupplier] to generate the option on command execution
-     */
-    open fun getGeneratedValueSupplier(
+    override fun getGeneratedValueSupplier(
         guild: Guild?,
         commandId: String?, commandPath: CommandPath,
         optionName: String, parameterType: ParameterType

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationGeneratedValueSupplierProvider.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/ApplicationGeneratedValueSupplierProvider.kt
@@ -1,0 +1,33 @@
+package io.github.freya022.botcommands.api.commands.application
+
+import io.github.freya022.botcommands.api.commands.CommandPath
+import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption
+import io.github.freya022.botcommands.api.commands.application.annotations.CommandId
+import io.github.freya022.botcommands.api.core.reflect.ParameterType
+import net.dv8tion.jda.api.entities.Guild
+
+/**
+ * Provider of [ApplicationGeneratedValueSupplier] for [generated options][GeneratedOption] of **annotated** application commands.
+ *
+ * When using generated options, you must implement this on the same declaring class.
+ */
+interface ApplicationGeneratedValueSupplierProvider {
+    /**
+     * Returns the generated value supplier of a [@GeneratedOption][GeneratedOption].
+     *
+     * This function will only be called once per command option per guild.
+     *
+     * @param guild         The [Guild] in which to add the default value, `null` if the scope is **not** [CommandScope.GUILD]
+     * @param commandId     The ID of the command, as optionally set in [@CommandId][CommandId], might be `null`
+     * @param commandPath   The path of the application command
+     * @param optionName    The option name, not the same as the parameter name, this is the same name that appears on Discord
+     * @param parameterType The **boxed** type of the command option
+     *
+     * @return A [ApplicationGeneratedValueSupplier] to generate the option on command execution
+     */
+    fun getGeneratedValueSupplier(
+        guild: Guild?,
+        commandId: String?, commandPath: CommandPath,
+        optionName: String, parameterType: ParameterType
+    ): ApplicationGeneratedValueSupplier
+}

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/SlashOptionChoiceProvider.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/SlashOptionChoiceProvider.kt
@@ -1,0 +1,35 @@
+package io.github.freya022.botcommands.api.commands.application
+
+import io.github.freya022.botcommands.api.commands.CommandPath
+import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
+import io.github.freya022.botcommands.api.commands.application.slash.options.builder.SlashCommandOptionBuilder
+import io.github.freya022.botcommands.api.core.config.BApplicationConfigBuilder
+import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.interactions.commands.Command
+
+/**
+ * Provider of choices for [options][SlashOption] of **annotated** slash commands.
+ *
+ * If you wish to add choices to a command's option, you must implement this on the same declaring class.
+ */
+interface SlashOptionChoiceProvider {
+    /**
+     * Returns the choices available for this command path,
+     * on the specific [optionName].
+     *
+     * The choices returned by this method will have their name localized
+     * if they are present in the [localization bundles][BApplicationConfigBuilder.addLocalizations].
+     *
+     * @param guild       The [Guild] in which the command is, might be `null` for global commands with choices
+     * @param commandPath The [CommandPath] of the command, this is composed of it's name and optionally of its group and subcommand name
+     * @param optionName  The option name, not the same as the parameter name, this is the same name that appears on Discord
+     *
+     * @return The list of choices for this slash command's options
+     *
+     * @see SlashParameterResolver.getPredefinedChoices
+     *
+     * @see SlashCommandOptionBuilder.choices DSL equivalent
+     */
+    fun getOptionChoices(guild: Guild?, commandPath: CommandPath, optionName: String): List<Command.Choice>
+}

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAMessageCommand.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAMessageCommand.kt
@@ -1,7 +1,6 @@
 package io.github.freya022.botcommands.api.commands.application.context.annotations
 
 import io.github.freya022.botcommands.api.commands.annotations.*
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.CommandScope
 import io.github.freya022.botcommands.api.commands.application.builder.TopLevelApplicationCommandBuilder
 import io.github.freya022.botcommands.api.commands.application.context.message.GlobalMessageEvent
@@ -22,7 +21,7 @@ import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFuncti
  * for more details.
  *
  * ### Requirements
- * - The declaring class must be annotated with [@Command][Command] and extend [ApplicationCommand].
+ * - The declaring class must be annotated with [@Command][Command] .
  *
  * The first parameter must be:
  * - [GuildMessageEvent] if the [interaction context][contexts]

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAUserCommand.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/context/annotations/JDAUserCommand.kt
@@ -1,7 +1,6 @@
 package io.github.freya022.botcommands.api.commands.application.context.annotations
 
 import io.github.freya022.botcommands.api.commands.annotations.*
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.CommandScope
 import io.github.freya022.botcommands.api.commands.application.builder.TopLevelApplicationCommandBuilder
 import io.github.freya022.botcommands.api.commands.application.context.user.GlobalUserEvent
@@ -22,7 +21,7 @@ import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFuncti
  * for more details.
  *
  * ### Requirements
- * - The declaring class must be annotated with [@Command][Command] and extend [ApplicationCommand].
+ * - The declaring class must be annotated with [@Command][Command].
  *
  * The first parameter must be:
  * - [GuildUserEvent] if the [interaction context][contexts]

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/JDASlashCommand.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/JDASlashCommand.kt
@@ -1,7 +1,6 @@
 package io.github.freya022.botcommands.api.commands.application.slash.annotations
 
 import io.github.freya022.botcommands.api.commands.annotations.*
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.AbstractApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.provider.GuildApplicationCommandProvider
@@ -29,7 +28,7 @@ import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFuncti
  * Additional data can be set once **per subcommand group** with [@SlashCommandGroupData][SlashCommandGroupData].
  *
  * ### Requirements
- * - The declaring class must be annotated with [@Command][Command] and extend [ApplicationCommand].
+ * - The declaring class must be annotated with [@Command][Command].
  * - If you have subcommands,
  * [@TopLevelSlashCommandData][TopLevelSlashCommandData] must be used **once per top-level name**,
  * e.g., if you have `/tag create` and `/tag edit`, you can annotate at most one of them.

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/SlashOption.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/SlashOption.kt
@@ -2,7 +2,7 @@ package io.github.freya022.botcommands.api.commands.application.slash.annotation
 
 import io.github.freya022.botcommands.api.commands.annotations.Optional
 import io.github.freya022.botcommands.api.commands.annotations.VarArgs
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
+import io.github.freya022.botcommands.api.commands.application.SlashOptionChoiceProvider
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.AutocompleteTransformer
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.annotations.AutocompleteHandler
 import io.github.freya022.botcommands.api.commands.application.slash.autocomplete.declaration.AutocompleteHandlerProvider
@@ -33,7 +33,7 @@ import org.jspecify.annotations.Nullable
  *
  * ### Choices
  * Choices can be added by either [their parameter resolver][SlashParameterResolver.getPredefinedChoices],
- * or the [application command itself][ApplicationCommand.getOptionChoices].
+ * or by the application command itself from implementing [SlashOptionChoiceProvider].
  *
  * @see Optional @Optional
  * @see Nullable @Nullable
@@ -86,7 +86,7 @@ annotation class SlashOption(
     /**
      * Enables using choices from [SlashParameterResolver.getPredefinedChoices].
      *
-     * **Note:** Predefined choices can still be overridden by [ApplicationCommand.getOptionChoices].
+     * **Note:** Predefined choices can still be overridden by the [SlashOptionChoiceProvider].
      *
      * @return `true` to enable using choices from [SlashParameterResolver.getPredefinedChoices].
      *

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/builder/SlashCommandOptionBuilder.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/builder/SlashCommandOptionBuilder.kt
@@ -1,7 +1,7 @@
 package io.github.freya022.botcommands.api.commands.application.slash.options.builder
 
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.LengthRange
+import io.github.freya022.botcommands.api.commands.application.SlashOptionChoiceProvider
 import io.github.freya022.botcommands.api.commands.application.ValueRange
 import io.github.freya022.botcommands.api.commands.application.options.builder.ApplicationCommandOptionBuilder
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.DoubleRange
@@ -56,11 +56,10 @@ interface SlashCommandOptionBuilder : ApplicationCommandOptionBuilder {
      * The choices returned by this method will have their name localized
      * if they are present in the [localization bundles][BApplicationConfigBuilder.addLocalizations].
      *
-     * @see SlashParameterResolver.getPredefinedChoices
-     *
      * @throws IllegalStateException If [usePredefinedChoices] is enabled.
      *
-     * @see ApplicationCommand.getOptionChoices
+     * @see SlashParameterResolver.getPredefinedChoices
+     * @see SlashOptionChoiceProvider
      */
     var choices: List<Choice>?
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/ratelimit/RateLimiter.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/ratelimit/RateLimiter.kt
@@ -34,7 +34,7 @@ interface RateLimiter : BucketAccessor, RateLimitHandler {
          *
          * ```kt
          * @Command
-         * class SlashInMemoryRateLimit : ApplicationCommand(), GlobalApplicationCommandProvider {
+         * class SlashInMemoryRateLimit : GlobalApplicationCommandProvider {
          *     fun onSlashInMemoryRateLimit(event: GuildSlashEvent) {
          *         event.reply_("Hi", ephemeral = true).queue()
          *     }
@@ -113,7 +113,7 @@ interface RateLimiter : BucketAccessor, RateLimitHandler {
          *
          * ```kt
          * @Command
-         * class SlashPersistentRateLimit(private val proxyManager: ProxyManager<String>) : ApplicationCommand(), GlobalApplicationCommandProvider {
+         * class SlashPersistentRateLimit(private val proxyManager: ProxyManager<String>) : GlobalApplicationCommandProvider {
          *     fun onSlashPersistentRateLimit(event: GuildSlashEvent) {
          *         event.reply_("Hi", ephemeral = true).queue()
          *     }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/JDATextCommandVariation.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/annotations/JDATextCommandVariation.kt
@@ -4,7 +4,6 @@ import io.github.freya022.botcommands.api.commands.annotations.*
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.CommandEvent
 import io.github.freya022.botcommands.api.commands.text.IHelpCommand
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.builder.TextCommandVariationBuilder
 import io.github.freya022.botcommands.api.commands.text.provider.TextCommandManager
 import io.github.freya022.botcommands.api.commands.text.provider.TextCommandProvider
@@ -35,7 +34,7 @@ import net.dv8tion.jda.internal.utils.Checks
  * then the [help content][IHelpCommand.onInvalidCommand] is invoked for the command.
  *
  * ### Requirements
- * - The declaring class must be annotated with [@Command][Command] and extend [TextCommand]
+ * - The declaring class must be annotated with [@Command][Command]
  * - First parameter must be [BaseCommandEvent], or, [CommandEvent] for fallback commands/manual token consumption.
  *
  * ### Option types

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/builder/TextCommandBuilder.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/text/builder/TextCommandBuilder.kt
@@ -4,7 +4,7 @@ import io.github.freya022.botcommands.api.commands.builder.CommandBuilder
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.CommandEvent
 import io.github.freya022.botcommands.api.commands.text.IHelpCommand
-import io.github.freya022.botcommands.api.commands.text.TextCommand
+import io.github.freya022.botcommands.api.commands.text.TextCommandHelpConsumer
 import io.github.freya022.botcommands.api.commands.text.annotations.Hidden
 import io.github.freya022.botcommands.api.commands.text.annotations.NSFW
 import io.github.freya022.botcommands.api.commands.text.annotations.RequireOwner
@@ -12,7 +12,6 @@ import io.github.freya022.botcommands.api.commands.text.annotations.TextCommandD
 import io.github.freya022.botcommands.api.core.BotOwners
 import io.github.freya022.botcommands.internal.core.annotations.SkipJavaReflectionOverload
 import net.dv8tion.jda.api.EmbedBuilder
-import java.util.function.Consumer
 import kotlin.reflect.KFunction
 
 interface TextCommandBuilder : CommandBuilder {
@@ -69,9 +68,9 @@ interface TextCommandBuilder : CommandBuilder {
      *
      * @return The EmbedBuilder to use as a detailed description
      *
-     * @see TextCommand.getDetailedDescription
+     * @see TextCommandHelpConsumer
      */
-    var detailedDescription: Consumer<EmbedBuilder>?
+    var detailedDescription: ((EmbedBuilder) -> Unit)?
 
     //TODO docs
     fun subcommand(name: String, block: TextCommandBuilder.() -> Unit)

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/components/Buttons.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/components/Buttons.kt
@@ -18,7 +18,7 @@ import javax.annotation.CheckReturnValue
  * ### Persistent button (Kotlin)
  * ```kt
  * @Command
- * class SlashSayAgainPersistent : ApplicationCommand() {
+ * class SlashSayAgainPersistent {
  *     @JDASlashCommand(name = "say_again", subcommand = "persistent", description = "Sends a button to send a message again")
  *     suspend fun onSlashSayAgain(
  *         event: GuildSlashEvent,
@@ -50,7 +50,7 @@ import javax.annotation.CheckReturnValue
  * ### Ephemeral button (Kotlin)
  * ```kt
  * @Command
- * class SlashSayAgainEphemeral : ApplicationCommand() {
+ * class SlashSayAgainEphemeral {
  *     @JDASlashCommand(name = "say_again", subcommand = "ephemeral", description = "Sends a button to send a message again")
  *     suspend fun onSlashSayAgain(
  *         event: GuildSlashEvent,
@@ -84,7 +84,7 @@ import javax.annotation.CheckReturnValue
  * ### Persistent button (Java)
  * ```java
  * @Command
- * public class SlashSayAgainPersistent extends ApplicationCommand {
+ * public class SlashSayAgainPersistent {
  *     private static final String SAY_SENTENCE_HANDLER_NAME = "SlashSayAgainPersistent: saySentenceButton";
  *
  *     @JDASlashCommand(name = "say_again", subcommand = "persistent", description = "Sends a button to send a message again")
@@ -117,7 +117,7 @@ import javax.annotation.CheckReturnValue
  * ### Ephemeral button (Java)
  * ```java
  * @Command
- * public class SlashSayAgainEphemeral extends ApplicationCommand {
+ * public class SlashSayAgainEphemeral {
  *     @JDASlashCommand(name = "say_again", subcommand = "ephemeral", description = "Sends a button to send a message again")
  *     public void onSlashSayAgain(
  *             GuildSlashEvent event,

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/components/SelectMenus.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/components/SelectMenus.kt
@@ -16,7 +16,7 @@ import javax.annotation.CheckReturnValue
  * ### Persistent select menus (Kotlin)
  * ```kt
  * @Command
- * class SlashSelectRolePersistent : ApplicationCommand() {
+ * class SlashSelectRolePersistent {
  *     @JDASlashCommand(name = "select_role", subcommand = "persistent", description = "Sends a menu to choose a role from")
  *     suspend fun onSlashSelectRole(event: GuildSlashEvent, selectMenus: SelectMenus) {
  *         val randomNumber = Random.nextLong()
@@ -47,7 +47,7 @@ import javax.annotation.CheckReturnValue
  * ### Ephemeral select menus (Kotlin)
  * ```kt
  * @Command
- * class SlashSelectRoleEphemeral : ApplicationCommand() {
+ * class SlashSelectRoleEphemeral {
  *     @JDASlashCommand(name = "select_role", subcommand = "ephemeral", description = "Sends a menu to choose a role from")
  *     suspend fun onSlashSelectRole(event: GuildSlashEvent, selectMenus: SelectMenus) {
  *         val randomNumber = Random.nextLong()
@@ -83,7 +83,7 @@ import javax.annotation.CheckReturnValue
  * ### Persistent select menus (Java)
  * ```java
  * @Command
- * public class SlashSelectRolePersistent extends ApplicationCommand {
+ * public class SlashSelectRolePersistent {
  *     private static final String ROLE_MENU_HANDLER_NAME = "SlashSelectRolePersistent: roleMenu";
  *
  *     @JDASlashCommand(name = "select_role", subcommand = "persistent", description = "Sends a menu to choose a role from")
@@ -118,7 +118,7 @@ import javax.annotation.CheckReturnValue
  * ### Ephemeral select menus (Java)
  * ```java
  * @Command
- * public class SlashSelectRoleEphemeral extends ApplicationCommand {
+ * public class SlashSelectRoleEphemeral {
  *     @JDASlashCommand(name = "select_role", subcommand = "ephemeral", description = "Sends a menu to choose a role from")
  *     public void onSlashSelectRole(
  *             GuildSlashEvent event,

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDAButtonListener.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDAButtonListener.kt
@@ -35,7 +35,7 @@ import kotlin.reflect.KFunction
  * in this case you don't need to set the listener name:
  * ```kt
  * @Command
- * class SlashTypeSafeButtons(private val buttons: Buttons) : ApplicationCommand() {
+ * class SlashTypeSafeButtons(private val buttons: Buttons) {
  *     @JDASlashCommand(name = "type_safe_buttons", description = "Demo of Kotlin type-safe bindings")
  *     suspend fun onSlashTypeSafeButtons(event: GuildSlashEvent, @SlashOption argument: String) {
  *         val button = buttons.primary("Click me").persistent {

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDASelectMenuListener.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/components/annotations/JDASelectMenuListener.kt
@@ -36,7 +36,7 @@ import kotlin.reflect.KFunction
  * in this case you don't need to set the listener name:
  * ```kt
  * @Command
- * class SlashTypeSafeSelectMenus(private val selectMenus: SelectMenus) : ApplicationCommand() {
+ * class SlashTypeSafeSelectMenus(private val selectMenus: SelectMenus) {
  *     @JDASlashCommand(name = "type_safe_select_menus", description = "Demo of Kotlin type-safe bindings")
  *     suspend fun onSlashTypeSafeSelectMenus(event: GuildSlashEvent, @SlashOption argument: String) {
  *         val selectMenu = selectMenus.entitySelectMenu(EntitySelectMenu.SelectTarget.ROLE).persistent {

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/modals/Modals.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/modals/Modals.kt
@@ -79,7 +79,7 @@ import kotlin.time.toKotlinDuration
  * ### Java example
  * ```java
  * @Command
- * public class SlashRequestRole extends ApplicationCommand {
+ * public class SlashRequestRole {
  *
  *     private static final String MODAL_NAME = "request role";
  *     private static final String INPUT_ROLE = "role";

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/SlashParameterResolver.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/SlashParameterResolver.kt
@@ -1,6 +1,6 @@
 package io.github.freya022.botcommands.api.parameters.resolvers
 
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
+import io.github.freya022.botcommands.api.commands.application.SlashOptionChoiceProvider
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.ChannelTypes
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.MentionsString
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
@@ -61,7 +61,7 @@ interface SlashParameterResolver<T, R : Any> : IParameterResolver<T>
      * Returns a constant list of [choices][Choice] for this slash parameter resolver.
      *
      * This will be applied to all command parameters of this type,
-     * but can still be overridden if there are choices set in [ApplicationCommand.getOptionChoices].
+     * but can still be overridden if there are choices set by [SlashOptionChoiceProvider].
      *
      * This could be useful for, say, an enum resolver, or anything where the choices do not change between commands.
      *

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/ContextCommandAutoBuilder.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/ContextCommandAutoBuilder.kt
@@ -2,7 +2,7 @@ package io.github.freya022.botcommands.internal.commands.application.autobuilder
 
 import io.github.freya022.botcommands.api.commands.CommandPath
 import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
+import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplierProvider
 import io.github.freya022.botcommands.api.commands.application.builder.ApplicationCommandBuilder
 import io.github.freya022.botcommands.api.commands.application.context.annotations.ContextOption
 import io.github.freya022.botcommands.api.commands.application.context.message.options.builder.MessageCommandOptionRegistry
@@ -17,6 +17,8 @@ import io.github.freya022.botcommands.internal.commands.application.autobuilder.
 import io.github.freya022.botcommands.internal.commands.application.autobuilder.utils.ParameterAdapter
 import io.github.freya022.botcommands.internal.parameters.ResolverContainer
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.nonInstanceParameters
+import io.github.freya022.botcommands.internal.utils.checkAt
+import io.github.freya022.botcommands.internal.utils.classRef
 import io.github.freya022.botcommands.internal.utils.findDeclarationName
 import net.dv8tion.jda.api.entities.Guild
 import kotlin.reflect.KClass
@@ -35,7 +37,7 @@ internal sealed class ContextCommandAutoBuilder<T : RootAnnotatedApplicationComm
     protected fun ApplicationCommandBuilder<*>.processOptions(
         guild: Guild?,
         func: KFunction<*>,
-        instance: ApplicationCommand,
+        instance: Any,
         commandId: String?
     ) {
         func.nonInstanceParameters.drop(1).forEach { kParameter ->
@@ -54,7 +56,7 @@ internal sealed class ContextCommandAutoBuilder<T : RootAnnotatedApplicationComm
         registry: ApplicationOptionRegistry<*>,
         guild: Guild?,
         func: KFunction<*>,
-        instance: ApplicationCommand,
+        instance: Any,
         path: CommandPath,
         commandId: String?,
         parameter: ParameterAdapter
@@ -66,6 +68,10 @@ internal sealed class ContextCommandAutoBuilder<T : RootAnnotatedApplicationComm
                 is MessageCommandOptionRegistry -> registry.option(parameter.declaredName)
             }
         } else if (parameter.hasAnnotation<GeneratedOption>()) {
+            checkAt(instance is ApplicationGeneratedValueSupplierProvider, func) {
+                "Declaring class must extend ${classRef<ApplicationGeneratedValueSupplierProvider>()}"
+            }
+
             val valueSupplier = instance.getGeneratedValueSupplier(guild, commandId, path, parameter.discordName, parameter.actualType)
             registry.generatedOption(parameter.declaredName, valueSupplier)
         } else if (resolverContainer.hasResolverOfType<ICustomResolver<*, *>>(parameter.valueParameter.wrap())) {

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/SlashCommandAutoBuilder.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/SlashCommandAutoBuilder.kt
@@ -4,7 +4,9 @@ import io.github.freya022.botcommands.api.commands.CommandPath
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption
 import io.github.freya022.botcommands.api.commands.annotations.VarArgs
+import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplierProvider
 import io.github.freya022.botcommands.api.commands.application.LengthRange
+import io.github.freya022.botcommands.api.commands.application.SlashOptionChoiceProvider
 import io.github.freya022.botcommands.api.commands.application.ValueRange
 import io.github.freya022.botcommands.api.commands.application.annotations.CommandId
 import io.github.freya022.botcommands.api.commands.application.annotations.RequiresApplicationCommands
@@ -337,6 +339,10 @@ internal class SlashCommandAutoBuilder(
                 }
             }
         } else if (parameter.hasAnnotation<GeneratedOption>()) {
+            checkAt(instance is ApplicationGeneratedValueSupplierProvider, func) {
+                "Declaring class must extend ${classRef<ApplicationGeneratedValueSupplierProvider>()}"
+            }
+
             val valueSupplier = instance.getGeneratedValueSupplier(guild, commandId, path, parameter.discordName, parameter.actualType)
             registry.generatedOption(parameter.declaredName, valueSupplier)
         } else if (resolverContainer.hasResolverOfType<ICustomResolver<*, *>>(parameter.valueParameter.wrap())) {
@@ -348,6 +354,8 @@ internal class SlashCommandAutoBuilder(
     }
 
     private fun SlashCommandOptionBuilder.configureOption(metadata: SlashFunctionMetadata, guild: Guild?, parameter: ParameterAdapter, optionAnnotation: SlashOption) {
+        val instance = metadata.instance
+
         description = optionAnnotation.description.nullIfBlank()
 
         parameter.findAnnotation<LongRange>()?.let { range -> valueRange = ValueRange.ofLong(range.from, range.to) }
@@ -357,9 +365,11 @@ internal class SlashCommandAutoBuilder(
         processAutocomplete(optionAnnotation)
 
         usePredefinedChoices = optionAnnotation.usePredefinedChoices
-        val optionChoices = metadata.instance.getOptionChoices(guild, metadata.path, optionName)
-        if (optionChoices.isNotEmpty())
-            choices = optionChoices
+        if (instance is SlashOptionChoiceProvider) {
+            val optionChoices = instance.getOptionChoices(guild, metadata.path, optionName)
+            if (optionChoices.isNotEmpty())
+                choices = optionChoices
+        }
     }
 
     private fun SlashCommandOptionBuilder.processAutocomplete(optionAnnotation: SlashOption) {

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/metadata/ApplicationFunctionMetadata.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/metadata/ApplicationFunctionMetadata.kt
@@ -1,7 +1,6 @@
 package io.github.freya022.botcommands.internal.commands.application.autobuilder.metadata
 
 import io.github.freya022.botcommands.api.commands.CommandPath
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.internal.commands.autobuilder.metadata.CommandFunctionMetadata
 import io.github.freya022.botcommands.internal.core.ClassPathFunction
 
@@ -10,4 +9,4 @@ internal abstract class ApplicationFunctionMetadata<A : Annotation>(
     annotation: A,
     path: CommandPath,
     val commandId: String?
-) : CommandFunctionMetadata<ApplicationCommand, A>(classPathFunction, ApplicationCommand::class, annotation, path)
+) : CommandFunctionMetadata<A>(classPathFunction, annotation, path)

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/autobuilder/metadata/CommandFunctionMetadata.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/autobuilder/metadata/CommandFunctionMetadata.kt
@@ -1,26 +1,15 @@
 package io.github.freya022.botcommands.internal.commands.autobuilder.metadata
 
 import io.github.freya022.botcommands.api.commands.CommandPath
-import io.github.freya022.botcommands.api.core.utils.isSubclassOf
 import io.github.freya022.botcommands.internal.core.ClassPathFunction
-import io.github.freya022.botcommands.internal.utils.requireAt
-import kotlin.reflect.KClass
 
-internal abstract class CommandFunctionMetadata<T : Any, A : Annotation>(
+internal abstract class CommandFunctionMetadata<A : Annotation>(
     private val classPathFunction: ClassPathFunction,
-    instanceType: KClass<T>,
     val annotation: A,
     val path: CommandPath
 ) : MetadataFunctionHolder {
     final override val func get() = classPathFunction.function
 
-    init {
-        requireAt(classPathFunction.clazz.isSubclassOf(instanceType), func) {
-            "Declaring class must extend ${instanceType.simpleName}"
-        }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    val instance: T
-        get() = classPathFunction.instance as T
+    val instance: Any
+        get() = classPathFunction.instance
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandInfoImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/TextCommandInfoImpl.kt
@@ -36,7 +36,8 @@ internal sealed class TextCommandInfoImpl(
     final override val isOwnerRequired: Boolean = builder.ownerRequired
     final override val hidden: Boolean = builder.hidden
 
-    final override val detailedDescription: Consumer<EmbedBuilder>? = builder.detailedDescription
+    final override val detailedDescription: Consumer<EmbedBuilder>? =
+        builder.detailedDescription?.let { detailedDescription -> Consumer { detailedDescription(it) } }
 
     init {
         subcommands = buildMap(builder.subcommands.size + builder.subcommands.sumOf { it.aliases.size }) {

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/autobuilder/TextCommandAutoBuilder.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/autobuilder/TextCommandAutoBuilder.kt
@@ -6,6 +6,8 @@ import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption
 import io.github.freya022.botcommands.api.commands.annotations.VarArgs
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.TextCommandFilter
+import io.github.freya022.botcommands.api.commands.text.TextCommandHelpConsumer
+import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSupplierProvider
 import io.github.freya022.botcommands.api.commands.text.annotations.*
 import io.github.freya022.botcommands.api.commands.text.builder.TextCommandBuilder
 import io.github.freya022.botcommands.api.commands.text.builder.TextCommandVariationBuilder
@@ -214,7 +216,9 @@ internal class TextCommandAutoBuilder(
 
         nsfw = variationFunctions.singlePresentAnnotationOfVariants<NSFW>()
 
-        detailedDescription = instance.detailedDescription
+        if (instance is TextCommandHelpConsumer) {
+            detailedDescription = instance::accept
+        }
     }
 
     private fun TextCommandVariationBuilder.processOptions(metadata: TextFunctionMetadata) {
@@ -250,6 +254,10 @@ internal class TextCommandAutoBuilder(
                 }
             }
         } else if (parameter.hasAnnotation<GeneratedOption>()) {
+            checkAt(instance is TextGeneratedValueSupplierProvider, func) {
+                "Declaring class must extend ${classRef<TextGeneratedValueSupplierProvider>()}"
+            }
+
             val valueSupplier = instance.getGeneratedValueSupplier(path, parameter.discordName, parameter.actualType)
             registry.generatedOption(parameterName, valueSupplier)
         } else if (resolverContainer.hasResolverOfType<ICustomResolver<*, *>>(parameter.valueParameter.wrap())) {

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/autobuilder/metadata/TextFunctionMetadata.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/autobuilder/metadata/TextFunctionMetadata.kt
@@ -1,7 +1,6 @@
 package io.github.freya022.botcommands.internal.commands.text.autobuilder.metadata
 
 import io.github.freya022.botcommands.api.commands.CommandPath
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.internal.commands.autobuilder.metadata.CommandFunctionMetadata
 import io.github.freya022.botcommands.internal.core.ClassPathFunction
@@ -10,4 +9,4 @@ internal class TextFunctionMetadata(
     classPathFunction: ClassPathFunction,
     annotation: JDATextCommandVariation,
     path: CommandPath
-) : CommandFunctionMetadata<TextCommand, JDATextCommandVariation>(classPathFunction, TextCommand::class, annotation, path)
+) : CommandFunctionMetadata<JDATextCommandVariation>(classPathFunction, annotation, path)

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/builder/TextCommandBuilderImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/text/builder/TextCommandBuilderImpl.kt
@@ -8,7 +8,6 @@ import io.github.freya022.botcommands.api.core.setCallerAsDeclarationSite
 import io.github.freya022.botcommands.internal.commands.builder.CommandBuilderImpl
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.internal.utils.Checks
-import java.util.function.Consumer
 import kotlin.reflect.KFunction
 
 internal abstract class TextCommandBuilderImpl internal constructor(
@@ -36,7 +35,7 @@ internal abstract class TextCommandBuilderImpl internal constructor(
         Checks.matches(name, Checks.ALPHANUMERIC_WITH_DASH, "Text command name")
     }
 
-    final override var detailedDescription: Consumer<EmbedBuilder>? = null
+    final override var detailedDescription: ((EmbedBuilder) -> Unit)? = null
 
     final override fun subcommand(name: String, block: TextCommandBuilder.() -> Unit) {
         subcommands += TextSubcommandBuilderImpl(context, name, this)

--- a/BotCommands-core/src/test/kotlin/io/github/freya022/botcommands/commands/application/autobuilder/SlashCommandAutoBuilderTest.kt
+++ b/BotCommands-core/src/test/kotlin/io/github/freya022/botcommands/commands/application/autobuilder/SlashCommandAutoBuilderTest.kt
@@ -2,7 +2,6 @@ package io.github.freya022.botcommands.commands.application.autobuilder
 
 import io.github.freya022.botcommands.api.commands.CommandPath
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.CommandDeclarationFilter
 import io.github.freya022.botcommands.api.commands.application.CommandScope
 import io.github.freya022.botcommands.api.commands.application.annotations.DeclarationFilter
@@ -47,7 +46,7 @@ class SlashCommandAutoBuilderTest {
     }
 
     @Nested
-    inner class CommandsWithSamePath : ApplicationCommand() {
+    inner class CommandsWithSamePath {
         @JDASlashCommand(name = "test_command")
         fun command1(event: GlobalSlashEvent) { consume(event) }
 
@@ -72,7 +71,7 @@ class SlashCommandAutoBuilderTest {
     }
 
     @Nested
-    inner class CommandAnnotations : ApplicationCommand() {
+    inner class CommandAnnotations {
         @JDASlashCommand(name = "test_command", subcommand = "sub1")
         fun subcommand1(event: GlobalSlashEvent) { consume(event) }
 
@@ -140,7 +139,7 @@ class SlashCommandAutoBuilderTest {
     }
 
     @Nested
-    inner class CommandsWithMixedPathLengths : ApplicationCommand() {
+    inner class CommandsWithMixedPathLengths {
         @JDASlashCommand(name = "test_command")
         fun topLevel(event: GlobalSlashEvent) { consume(event) }
 
@@ -217,7 +216,7 @@ class SlashCommandAutoBuilderTest {
     }
 
     @Nested
-    inner class CommandsWithDeclarationFilters : ApplicationCommand() {
+    inner class CommandsWithDeclarationFilters {
         // TODO test that DeclarationFilter only works on guild commands (throw otherwise)
 
         inner class DoNotDeclare : CommandDeclarationFilter {

--- a/BotCommands-typesafe-messages/README.md
+++ b/BotCommands-typesafe-messages/README.md
@@ -79,7 +79,7 @@ and will allow you to create `CommandReplies` instances from an `Interaction`.
 
 ```kt
 @Command
-class SlashInfo : ApplicationCommand() {
+class SlashInfo {
 
     @JDASlashCommand(
         name = "info",

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ class SlashBan {
 
 ```kt
 @Command
-class TextBan : TextCommand() {
+class TextBan {
     @JDATextCommandVariation(path = ["ban"], description = "Bans the mentioned user")
     suspend fun onTextBan(
         event: BaseCommandEvent,

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ while also easily being able to use services provided by the framework.
 
 ```kt
 @Command
-class SlashBan : ApplicationCommand() {
+class SlashBan {
     @JDASlashCommand(name = "ban", description = "Bans an user")
     suspend fun onSlashBan(
         event: GuildSlashEvent,
@@ -186,7 +186,7 @@ Here is how you would create a slash command that sends a message in a specified
 @RequiresComponents // (Optional) Disables the command if components are not enabled
 class SlashSay(
     private val buttons: Buttons // Factory for buttons
-) : ApplicationCommand() {
+) {
 
     // The descriptions can also be moved to localization files, reducing noise
     @JDASlashCommand(name = "say", description = "Sends a message in a channel")
@@ -268,7 +268,7 @@ class SlashSay(
 ```java
 @Command
 @RequiresComponents // (Optional) Disables the command if components are not enabled
-public class SlashSayJava extends ApplicationCommand {
+public class SlashSayJava {
 
     private final Buttons buttons; // Factory for buttons
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ class SlashSay(
 ```java
 @Command
 @RequiresComponents // (Optional) Disables the command if components are not enabled
-public class SlashSayJava {
+public class SlashSay {
 
     private final Buttons buttons; // Factory for buttons
 
@@ -283,7 +283,7 @@ public class SlashSayJava {
             @SlashOption(description = "Channel to send the message in") TextChannel channel,
             @SlashOption(description = "What to say") String content
     ) {
-        final Button deleteButton = buttons.danger(UnicodeEmojis.WASTEBASKET).ephemeral()
+        Button deleteButton = buttons.danger(UnicodeEmojis.WASTEBASKET).ephemeral()
                 .bindTo(buttonEvent -> {
                     buttonEvent.deferEdit().queue();
                     buttonEvent.getHook().deleteOriginal().queue();

--- a/test-bot/src/test/java/dev/freya02/botcommands/bot/commands/slash/SlashDIJava.java
+++ b/test-bot/src/test/java/dev/freya02/botcommands/bot/commands/slash/SlashDIJava.java
@@ -3,7 +3,6 @@ package dev.freya02.botcommands.bot.commands.slash;
 import dev.freya02.botcommands.bot.services.INamedService;
 import dev.freya02.botcommands.bot.services.UnusedInterfacedService;
 import io.github.freya022.botcommands.api.commands.annotations.Command;
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand;
 import io.github.freya022.botcommands.api.commands.application.ApplicationCommandFilter;
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand;
@@ -18,7 +17,7 @@ import java.util.List;
 
 @Command
 @RequiresDefaultInjection
-public class SlashDIJava extends ApplicationCommand {
+public class SlashDIJava {
     public SlashDIJava(@ServiceName("modifiedNamedService") INamedService namedService,
                        @javax.annotation.Nullable UnusedInterfacedService unusedInterfacedService) {
         System.out.println("Named service: " + namedService);

--- a/test-bot/src/test/java/dev/freya02/botcommands/bot/commands/slash/SlashEmojis.java
+++ b/test-bot/src/test/java/dev/freya02/botcommands/bot/commands/slash/SlashEmojis.java
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.slash;
 
 import dev.freya02.jda.emojis.unicode.Emojis;
 import io.github.freya022.botcommands.api.commands.annotations.Command;
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
@@ -13,7 +12,7 @@ import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 
 @Command
-public class SlashEmojis extends ApplicationCommand {
+public class SlashEmojis {
 
     @JDASlashCommand(name = "emojis")
     public void onSlashEmojis(GuildSlashEvent event) {

--- a/test-bot/src/test/java/dev/freya02/botcommands/bot/commands/slash/SlashMyJavaCommand.java
+++ b/test-bot/src/test/java/dev/freya02/botcommands/bot/commands/slash/SlashMyJavaCommand.java
@@ -2,8 +2,9 @@ package dev.freya02.botcommands.bot.commands.slash;
 
 import io.github.freya022.botcommands.api.commands.CommandPath;
 import io.github.freya022.botcommands.api.commands.annotations.*;
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand;
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier;
+import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplierProvider;
+import io.github.freya022.botcommands.api.commands.application.SlashOptionChoiceProvider;
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.ChannelTypes;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand;
@@ -30,7 +31,7 @@ import static net.dv8tion.jda.api.interactions.commands.Command.Choice;
 
 @Command
 @NullMarked
-public class SlashMyJavaCommand extends ApplicationCommand {
+public class SlashMyJavaCommand implements ApplicationGeneratedValueSupplierProvider, SlashOptionChoiceProvider {
 	@RateLimit(
 			scope = RateLimitScope.USER, bandwidths = {
 			@Bandwidth(capacity = 5, refill = @Refill(type = RefillType.GREEDY, tokens = 5, period = 1, periodUnit = ChronoUnit.MINUTES)),
@@ -46,7 +47,7 @@ public class SlashMyJavaCommand extends ApplicationCommand {
 			return event -> event.getGuild().getName();
 		}
 
-		return super.getGeneratedValueSupplier(guild, commandId, commandPath, optionName, parameterType);
+		throw new IllegalArgumentException("Unsupported generated option: " + optionName);
 	}
 
 	@Override
@@ -57,7 +58,7 @@ public class SlashMyJavaCommand extends ApplicationCommand {
 			return List.of(new Choice("1", 1L), new Choice("2", 2L));
 		}
 
-		return super.getOptionChoices(guild, commandPath, optionName);
+		return List.of();
 	}
 
 	@CacheAutocomplete

--- a/test-bot/src/test/java/dev/freya02/botcommands/bot/commands/slash/SlashSayJava.java
+++ b/test-bot/src/test/java/dev/freya02/botcommands/bot/commands/slash/SlashSayJava.java
@@ -31,7 +31,7 @@ public class SlashSayJava {
             @SlashOption(description = "Channel to send the message in") TextChannel channel,
             @SlashOption(description = "What to say") String content
     ) {
-        final Button deleteButton = buttons.danger(UnicodeEmojis.WASTEBASKET).ephemeral()
+        Button deleteButton = buttons.danger(UnicodeEmojis.WASTEBASKET).ephemeral()
                 .bindTo(buttonEvent -> {
                     buttonEvent.deferEdit().queue();
                     buttonEvent.getHook().deleteOriginal().queue();

--- a/test-bot/src/test/java/dev/freya02/botcommands/bot/commands/slash/SlashSayJava.java
+++ b/test-bot/src/test/java/dev/freya02/botcommands/bot/commands/slash/SlashSayJava.java
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.slash;
 
 import dev.freya02.jda.emojis.unicode.UnicodeEmojis;
 import io.github.freya022.botcommands.api.commands.annotations.Command;
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand;
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption;
@@ -17,7 +16,7 @@ import java.time.Duration;
 
 @Command
 @RequiresComponents // (Optional) Disables the command if components are not enabled
-public class SlashSayJava extends ApplicationCommand {
+public class SlashSayJava {
 
     private final Buttons buttons; // Factory for buttons
 

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextAddReactionRole.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextAddReactionRole.kt
@@ -7,7 +7,6 @@ import dev.freya02.botcommands.jda.ktx.messages.InlineMessage
 import dev.freya02.botcommands.jda.ktx.messages.MessageCreate
 import dev.freya02.botcommands.jda.ktx.messages.MessageEdit
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.context.annotations.ContextOption
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAMessageCommand
 import io.github.freya022.botcommands.api.commands.application.context.message.GuildMessageEvent
@@ -40,7 +39,7 @@ class ReactionRoleService {
 @Disabled
 @RequiresComponents
 class MessageContextAddReactionRole(private val selectMenus: SelectMenus,
-                                    private val reactionRoleService: ReactionRoleService) : ApplicationCommand() {
+                                    private val reactionRoleService: ReactionRoleService) {
     @JDAMessageCommand(name = "Add reaction role", defaultLocked = true)
     suspend fun onMessageContextAddReactionRole(event: GuildMessageEvent,
                                                 @ContextOption message: Message) {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextDeleteIncluding.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextDeleteIncluding.kt
@@ -8,7 +8,6 @@ import dev.freya02.botcommands.jda.ktx.messages.send
 import io.github.freya022.botcommands.api.commands.annotations.BotPermissions
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.UserPermissions
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.context.annotations.ContextOption
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAMessageCommand
 import io.github.freya022.botcommands.api.commands.application.context.message.GuildMessageEvent
@@ -24,7 +23,7 @@ import kotlin.time.Duration.Companion.seconds
 @Command
 class MessageContextDeleteIncluding(
     private val buttons: Buttons,
-) : ApplicationCommand() {
+) {
 
     @BotPermissions(Permission.MESSAGE_MANAGE)
     @UserPermissions(Permission.MESSAGE_MANAGE)

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextEmbedLink.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextEmbedLink.kt
@@ -3,13 +3,12 @@ package dev.freya02.botcommands.bot.commands.message
 import dev.freya02.botcommands.bot.services.Disabled
 import dev.freya02.botcommands.jda.ktx.messages.Embed
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAMessageCommand
 import io.github.freya022.botcommands.api.commands.application.context.message.GuildMessageEvent
 
 @Command
 @Disabled
-class MessageContextEmbedLink : ApplicationCommand() {
+class MessageContextEmbedLink {
     @JDAMessageCommand(name = "Embed link to message")
     fun onMessageContextEmbedLinkToMessage(event: GuildMessageEvent) {
         Embed {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextGetJson.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextGetJson.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import dev.freya02.botcommands.jda.ktx.requests.awaitUnit
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.context.annotations.ContextOption
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAMessageCommand
 import io.github.freya022.botcommands.api.commands.application.context.message.GlobalMessageEvent
@@ -17,7 +16,7 @@ import net.dv8tion.jda.api.utils.FileUpload
 import net.dv8tion.jda.api.utils.data.DataPath
 
 @Command
-class MessageContextGetJson : ApplicationCommand() {
+class MessageContextGetJson {
 
     @JDAMessageCommand(
         name = "Get raw JSON",

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextRaw.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextRaw.kt
@@ -4,8 +4,8 @@ import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.CommandPath
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier
+import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplierProvider
 import io.github.freya022.botcommands.api.commands.application.CommandScope
 import io.github.freya022.botcommands.api.commands.application.context.annotations.ContextOption
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAMessageCommand
@@ -19,7 +19,7 @@ import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionE
 import net.dv8tion.jda.api.utils.MarkdownSanitizer
 
 @Command
-class MessageContextRaw : ApplicationCommand(), GuildApplicationCommandProvider {
+class MessageContextRaw : GuildApplicationCommandProvider, ApplicationGeneratedValueSupplierProvider {
     override fun getGeneratedValueSupplier(
         guild: Guild?,
         commandId: String?,
@@ -35,7 +35,7 @@ class MessageContextRaw : ApplicationCommand(), GuildApplicationCommandProvider 
             }
         }
 
-        return super.getGeneratedValueSupplier(guild, commandId, commandPath, optionName, parameterType)
+        error("Unsupported generated value: $optionName")
     }
 
     @JDAMessageCommand(scope = CommandScope.GUILD, name = "Raw content (annotated)")

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextTest.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextTest.kt
@@ -3,7 +3,6 @@ package dev.freya02.botcommands.bot.commands.message
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAMessageCommand
 import io.github.freya022.botcommands.api.commands.application.context.message.GlobalMessageEvent
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
@@ -16,7 +15,7 @@ import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.InteractionContextType.*
 
 @Command
-class MessageContextTest : ApplicationCommand(), GlobalApplicationCommandProvider {
+class MessageContextTest : GlobalApplicationCommandProvider {
     @JDAMessageCommand(
         name = "test message (annotated)",
         contexts = [GUILD, BOT_DM, PRIVATE_CHANNEL],

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashBanManual.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashBanManual.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.bot.services.Disabled
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.CommandScope
 import io.github.freya022.botcommands.api.commands.application.annotations.Test
 import io.github.freya022.botcommands.api.commands.application.provider.GuildApplicationCommandManager
@@ -17,7 +16,7 @@ import io.github.freya022.botcommands.api.core.entities.InputUser
 
 @Disabled
 @Command
-class SlashBanManual : ApplicationCommand(), GuildApplicationCommandProvider {
+class SlashBanManual : GuildApplicationCommandProvider {
     @Test(722891685755093072)
     @JDASlashCommand(name = "ban_annotated")
     @TopLevelSlashCommandData(defaultLocked = true, scope = CommandScope.GUILD)

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashComponentData.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashComponentData.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.components.row
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import dev.freya02.jda.emojis.unicode.Emojis
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.components.Buttons
@@ -31,7 +30,7 @@ data class MyComponentData(
 @Command
 class SlashComponentData(
     private val buttons: Buttons,
-) : ApplicationCommand() {
+) {
 
     @JDASlashCommand(name = "component_data")
     suspend fun onSlashComponentData(event: GuildSlashEvent) {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashComponentsV2.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashComponentsV2.kt
@@ -8,7 +8,6 @@ import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.hex
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
@@ -24,7 +23,7 @@ import net.dv8tion.jda.api.utils.FileUpload
 class SlashComponentsV2(
     private val buttons: Buttons,
     private val selectMenus: SelectMenus,
-) : ApplicationCommand() {
+) {
 
     private val kotlinIcon = FileUpload.fromData(readResource("/emojis/kotlin.png"), "kotlin.png")
     private val rustAnimation = FileUpload.fromData(readResource("/rust.webp"), "rust.webp")

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashCooldown.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashCooldown.kt
@@ -3,7 +3,6 @@ package dev.freya02.botcommands.bot.commands.slash
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.Cooldown
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -14,7 +13,7 @@ import java.time.temporal.ChronoUnit
 import kotlin.time.Duration.Companion.seconds
 
 @Command
-class SlashCooldown : GlobalApplicationCommandProvider, ApplicationCommand() {
+class SlashCooldown : GlobalApplicationCommandProvider {
     @JDASlashCommand(name = "cooldown_annotated")
     @Cooldown(cooldown = 5, unit = ChronoUnit.SECONDS, scope = RateLimitScope.GUILD)
     fun onSlashCooldown(event: GuildSlashEvent) {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashDI.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashDI.kt
@@ -5,7 +5,6 @@ import dev.freya02.botcommands.bot.services.NamedService1
 import dev.freya02.botcommands.bot.services.UnusedInterfacedService
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.ApplicationCommandFilter
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
@@ -22,7 +21,7 @@ class SlashDI internal constructor(
     @ServiceName("modifiedNamedService") namedService: INamedService?,
     @ServiceName("fakeDefaultEmbedSupplier") defaultService: DefaultEmbedSupplier = DefaultEmbedSupplier { EmbedBuilder() },
     unusedInterfacedService: UnusedInterfacedService?,
-) : ApplicationCommand() {
+) {
     init {
         check(namedService is NamedService1)
 

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashDeletedButton.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashDeletedButton.kt
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.slash
 
 import dev.freya02.botcommands.jda.ktx.components.into
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.components.Buttons
@@ -10,7 +9,7 @@ import io.github.freya022.botcommands.api.components.annotations.RequiresCompone
 
 @Command
 @RequiresComponents
-class SlashDeletedButton(private val buttons: Buttons) : ApplicationCommand() {
+class SlashDeletedButton(private val buttons: Buttons) {
     @JDASlashCommand(name = "deleted_button")
     suspend fun onSlashDeletedButton(event: GuildSlashEvent) {
         val buttonIds = arrayListOf<Int>()

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashEventWaiter.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashEventWaiter.kt
@@ -3,7 +3,6 @@ package dev.freya02.botcommands.bot.commands.slash
 import dev.freya02.botcommands.jda.ktx.messages.deleteDelayed
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.core.waiter.EventWaiter
@@ -17,7 +16,7 @@ import kotlin.time.Duration.Companion.seconds
 private val logger = KotlinLogging.logger { }
 
 @Command
-class SlashEventWaiter(private val eventWaiter: EventWaiter) : ApplicationCommand() {
+class SlashEventWaiter(private val eventWaiter: EventWaiter) {
     @JDASlashCommand(name = "waiter")
     suspend fun onSlashWaiter(event: GuildSlashEvent) {
         event.reply_("Send a message in 5 seconds", ephemeral = true).queue()

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashFilter.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashFilter.kt
@@ -8,7 +8,6 @@ import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.Filter
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.and
 import io.github.freya022.botcommands.api.commands.application.builder.filter
 import io.github.freya022.botcommands.api.commands.application.or
@@ -19,7 +18,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 
 @Command
 @TestService
-class SlashFilter : ApplicationCommand(), GlobalApplicationCommandProvider {
+class SlashFilter : GlobalApplicationCommandProvider {
     @Filter(InVoiceChannel::class)
     @JDASlashCommand(name = "filter_annotated")
     suspend fun onSlashFilter(event: GuildSlashEvent) {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashForumTest.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashForumTest.kt
@@ -3,7 +3,6 @@ package dev.freya02.botcommands.bot.commands.slash
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
@@ -12,7 +11,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 
 @Command
-class SlashForumTest : ApplicationCommand() {
+class SlashForumTest {
     @JDASlashCommand(name = "forum_test")
     suspend fun execute(event: GuildSlashEvent, @SlashOption forumChannel: ForumChannel) {
         event.reply_("OK", ephemeral = true).queue()

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashGenerateComponents.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashGenerateComponents.kt
@@ -1,7 +1,6 @@
 package dev.freya02.botcommands.bot.commands.slash
 
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.components.Button
@@ -17,7 +16,7 @@ private const val amount = 5000
 
 @Command
 @RequiresComponents
-class SlashGenerateComponents(private val buttons: Buttons) : ApplicationCommand() {
+class SlashGenerateComponents(private val buttons: Buttons) {
     @JDASlashCommand(name = "generate_components")
     suspend fun onSlashGenerateComponents(event: GuildSlashEvent) {
         event.deferReply(true).queue()

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashGroupTest.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashGroupTest.kt
@@ -1,14 +1,13 @@
 package dev.freya02.botcommands.bot.commands.slash
 
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashCommandGroupData
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
 
 @Command
-class SlashGroupTest : ApplicationCommand() {
+class SlashGroupTest {
     @TopLevelSlashCommandData
     @SlashCommandGroupData(description = "group desc")
     @JDASlashCommand(name = "group_test", group = "group1", subcommand = "sub")

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashInlineClassVararg.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashInlineClassVararg.kt
@@ -3,7 +3,6 @@ package dev.freya02.botcommands.bot.commands.slash
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.VarArgs
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -12,7 +11,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.commands.application.slash.options.builder.inlineClassOptionVararg
 
 @Command
-class SlashInlineClassVararg : ApplicationCommand(), GlobalApplicationCommandProvider {
+class SlashInlineClassVararg : GlobalApplicationCommandProvider {
     @JvmInline
     value class MyInlineList(val args: List<String>)
 

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashInteractionMetadata.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashInteractionMetadata.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.components.TextInput
 import dev.freya02.botcommands.jda.ktx.components.row
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAMessageCommand
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAUserCommand
 import io.github.freya022.botcommands.api.commands.application.context.message.GuildMessageEvent
@@ -22,7 +21,7 @@ import kotlin.time.Duration.Companion.minutes
 class SlashInteractionMetadata(
     private val buttons: Buttons,
     private val modals: Modals,
-) : ApplicationCommand() {
+) {
 
     @JDASlashCommand("interaction_metadata")
     suspend fun onSlashInteractionMetadata(event: GuildSlashEvent) {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashLength.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashLength.kt
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.slash
 
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.LengthRange
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
@@ -12,7 +11,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
 
 @Command
-class SlashLength : ApplicationCommand(), GlobalApplicationCommandProvider {
+class SlashLength : GlobalApplicationCommandProvider {
     @JDASlashCommand(name = "length_annotated")
     fun onSlashLength(
         event: GuildSlashEvent,

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashLocalization.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashLocalization.kt
@@ -8,7 +8,6 @@ import dev.freya02.botcommands.jda.ktx.durations.before
 import dev.freya02.botcommands.jda.ktx.messages.MessageCreate
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.components.Buttons
@@ -30,7 +29,7 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @Command
 @RequiresModals
-class SlashLocalization : ApplicationCommand() {
+class SlashLocalization {
 
     @JDASlashCommand(name = "localization")
     fun onSlashLocalization(

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashMentionsString.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashMentionsString.kt
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.slash
 
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.MentionsString
@@ -19,7 +18,7 @@ import net.dv8tion.jda.api.entities.emoji.CustomEmoji
 import net.dv8tion.jda.api.interactions.commands.SlashCommandReference
 
 @Command
-class SlashMentionsString : ApplicationCommand() {
+class SlashMentionsString {
     @TopLevelSlashCommandData
     @JDASlashCommand(name = "mentions_string", subcommand = "any")
     suspend fun onSlashMentionsStringAny(

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashModal.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashModal.kt
@@ -8,7 +8,6 @@ import dev.freya02.botcommands.jda.ktx.components.row
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import dev.freya02.botcommands.jda.ktx.messages.send
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -42,7 +41,7 @@ private const val SLASH_MODAL_ATTACHMENT_INPUT = "SlashModal: attachment"
 @Command
 @RequiresModals
 @RequiresComponents
-class SlashModal(private val buttons: Buttons) : ApplicationCommand(), GlobalApplicationCommandProvider {
+class SlashModal(private val buttons: Buttons) : GlobalApplicationCommandProvider {
     @JDASlashCommand(name = "modal_annotated")
     suspend fun onSlashModal(event: GuildSlashEvent, modals: Modals) {
         val modal = modals.create("Title") {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashMyCommand.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashMyCommand.kt
@@ -3,8 +3,9 @@ package dev.freya02.botcommands.bot.commands.slash
 import io.github.freya022.botcommands.api.commands.CommandPath
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier
+import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplierProvider
+import io.github.freya022.botcommands.api.commands.application.SlashOptionChoiceProvider
 import io.github.freya022.botcommands.api.commands.application.ValueRange.Companion.range
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
@@ -23,7 +24,7 @@ import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInterac
 import net.dv8tion.jda.api.interactions.commands.Command.Choice
 
 @Command
-class SlashMyCommand : ApplicationCommand(), GlobalApplicationCommandProvider, AutocompleteHandlerProvider {
+class SlashMyCommand : GlobalApplicationCommandProvider, SlashOptionChoiceProvider, ApplicationGeneratedValueSupplierProvider, AutocompleteHandlerProvider {
     override fun getOptionChoices(guild: Guild?, commandPath: CommandPath, optionName: String): List<Choice> {
         if (optionName == "string_option" || optionName == "string_annotated") {
             return listOf(Choice("a", "a"), Choice("b", "b"), Choice("c", "c"))
@@ -31,7 +32,7 @@ class SlashMyCommand : ApplicationCommand(), GlobalApplicationCommandProvider, A
             return listOf(Choice("1", 1L), Choice("2", 2L))
         }
 
-        return super.getOptionChoices(guild, commandPath, optionName)
+        return emptyList()
     }
 
     override fun getGeneratedValueSupplier(
@@ -47,7 +48,7 @@ class SlashMyCommand : ApplicationCommand(), GlobalApplicationCommandProvider, A
             }
         }
 
-        return super.getGeneratedValueSupplier(guild, commandId, commandPath, optionName, parameterType)
+        error("Unknown generated option: $optionName")
     }
 
     @TopLevelSlashCommandData

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashNewButtons.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashNewButtons.kt
@@ -8,7 +8,6 @@ import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import dev.freya02.botcommands.jda.ktx.messages.send
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.components.Button
@@ -33,7 +32,7 @@ import kotlin.time.Duration.Companion.seconds
 @RequiresComponents
 class SlashNewButtons(
     private val buttons: Buttons
-) : ApplicationCommand() {
+) {
     @JDASlashCommand(name = "new_buttons")
     suspend fun onSlashNewButtons(event: GuildSlashEvent) {
         val persistentButton = persistentGroupTest(event)

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashNewSelects.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashNewSelects.kt
@@ -7,7 +7,6 @@ import dev.freya02.botcommands.jda.ktx.components.row
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.components.EntitySelectMenu
@@ -32,7 +31,7 @@ import kotlin.time.Duration.Companion.seconds
 @RequiresComponents
 class SlashNewSelects(
     private val selectMenus: SelectMenus
-) : ApplicationCommand() {
+) {
     @JDASlashCommand(name = "new_selects")
     suspend fun onSlashNewSelects(event: GuildSlashEvent) {
         val persistentSelect = persistentGroupTest(event)

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashNsfw.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashNsfw.kt
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.slash
 
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -10,7 +9,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
 
 @Command
-class SlashNsfw : ApplicationCommand(), GlobalApplicationCommandProvider {
+class SlashNsfw : GlobalApplicationCommandProvider {
     @JDASlashCommand(name = "nsfw_annotated")
     @TopLevelSlashCommandData(nsfw = true)
     fun onSlashNsfw(event: GuildSlashEvent) {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashPagination.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashPagination.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.components.into
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
@@ -35,7 +34,7 @@ private val logger = KotlinLogging.logger { }
 
 @Command
 @RequiresComponents
-class SlashPagination(private val paginators: Paginators, private val buttons: Buttons) : ApplicationCommand() {
+class SlashPagination(private val paginators: Paginators, private val buttons: Buttons) {
     private val menuEntries = listOf("One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten", "Eleven", "Twelve")
 
     init {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashPermissions.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashPermissions.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.BotPermissions
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.UserPermissions
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -13,7 +12,7 @@ import io.github.freya022.botcommands.api.core.utils.enumSetOf
 import net.dv8tion.jda.api.Permission
 
 @Command
-class SlashPermissions : ApplicationCommand(), GlobalApplicationCommandProvider {
+class SlashPermissions : GlobalApplicationCommandProvider {
     @BotPermissions(Permission.MANAGE_EVENTS)
     @UserPermissions(Permission.MANAGE_SERVER, Permission.ADMINISTRATOR)
     @JDASlashCommand(name = "permissions_annotated")

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashRateLimit.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashRateLimit.kt
@@ -6,7 +6,6 @@ import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy
 import io.github.bucket4j.postgresql.Bucket4jPostgreSQL
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.RateLimitReference
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -33,7 +32,7 @@ private const val commandRateLimitGroup = "SlashRateLimit: my_rate_limit"
 class SlashRateLimit(
     private val buttons: Buttons,
     hikariSourceSupplier: HikariSourceSupplier
-) : ApplicationCommand(), GlobalApplicationCommandProvider, RateLimitProvider {
+) : GlobalApplicationCommandProvider, RateLimitProvider {
     private val proxyManager = Bucket4jPostgreSQL.selectForUpdateBasedBuilder(hikariSourceSupplier.source)
         .expirationAfterWrite(ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(1.minutes.toJavaDuration()))
         .primaryKeyMapper(PreparedStatement::setString)

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashResolveMentions.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashResolveMentions.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.components.row
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
@@ -20,7 +19,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
 
 @Command
 @RequiresComponents
-class SlashResolveMentions(private val buttons: Buttons) : ApplicationCommand() {
+class SlashResolveMentions(private val buttons: Buttons) {
     @JDASlashCommand(name = "resolve_mentions")
     suspend fun onSlashResolveMentions(
         event: GuildSlashEvent,

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashSay.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashSay.kt
@@ -6,7 +6,6 @@ import dev.freya02.botcommands.jda.ktx.messages.deleteDelayed
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import dev.freya02.jda.emojis.unicode.UnicodeEmojis
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -21,7 +20,7 @@ import kotlin.time.Duration.Companion.seconds
 @RequiresComponents // (Optional) Disables the command if components are not enabled
 class SlashSay(
     private val buttons: Buttons // Factory for buttons
-) : ApplicationCommand() {
+) {
 
     // The descriptions can also be moved to localization files, reducing noise
     @JDASlashCommand(name = "say", description = "Sends a message in a channel")

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashServiceOption.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashServiceOption.kt
@@ -5,7 +5,6 @@ import dev.freya02.botcommands.jda.ktx.components.into
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
@@ -32,7 +31,7 @@ import kotlin.time.Duration.Companion.seconds
 @Command
 @RequiresModals
 @RequiresComponents
-class SlashServiceOption : ApplicationCommand() {
+class SlashServiceOption {
     @JDASlashCommand(name = "service_option")
     suspend fun onSlashServiceOption(
         event: GuildSlashEvent,

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashSubWithGroup.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashSubWithGroup.kt
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.slash
 
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -10,7 +9,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
 
 @Command
-class SlashSubWithGroup : ApplicationCommand(), GlobalApplicationCommandProvider {
+class SlashSubWithGroup : GlobalApplicationCommandProvider {
     @TopLevelSlashCommandData
     @JDASlashCommand(name = "tag_annotated", subcommand = "send")
     fun onSlashSubWithGroup(event: GuildSlashEvent) {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashTest.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashTest.kt
@@ -4,8 +4,8 @@ import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.CommandPath
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier
+import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplierProvider
 import io.github.freya022.botcommands.api.commands.application.CommandScope
 import io.github.freya022.botcommands.api.commands.application.provider.GuildApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GuildApplicationCommandProvider
@@ -22,7 +22,7 @@ import net.dv8tion.jda.api.interactions.commands.Command.Choice
 private const val guildNicknameAutocompleteName = "NewSlashTest: guildNickname"
 
 @Command
-class SlashTest : ApplicationCommand(), GuildApplicationCommandProvider {
+class SlashTest : GuildApplicationCommandProvider, ApplicationGeneratedValueSupplierProvider {
     override fun getGeneratedValueSupplier(
         guild: Guild?, commandId: String?,
         commandPath: CommandPath, optionName: String,
@@ -32,7 +32,7 @@ class SlashTest : ApplicationCommand(), GuildApplicationCommandProvider {
             return ApplicationGeneratedValueSupplier { it.guild!!.name }
         }
 
-        return super.getGeneratedValueSupplier(guild, commandId, commandPath, optionName, parameterType)
+        error("Unsupported generated option: $optionName")
     }
 
     @JDASlashCommand(name = "test_annotated")

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashThreadById.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashThreadById.kt
@@ -3,13 +3,12 @@ package dev.freya02.botcommands.bot.commands.slash
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import dev.freya02.botcommands.jda.ktx.retrieve.retrieveThreadChannelByIdOrNull
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
 
 @Command
-class SlashThreadById : ApplicationCommand() {
+class SlashThreadById {
     @JDASlashCommand(name = "thread_by_id")
     suspend fun execute(event: GuildSlashEvent, @SlashOption id: String) {
         val threadChannel = event.guild.retrieveThreadChannelByIdOrNull(id.toLong())

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashTimeUnit.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashTimeUnit.kt
@@ -3,7 +3,6 @@ package dev.freya02.botcommands.bot.commands.slash
 import dev.freya02.botcommands.jda.ktx.components.into
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
@@ -18,7 +17,7 @@ import java.util.concurrent.TimeUnit
 
 @Command
 @RequiresComponents
-class SlashTimeUnit(private val buttons: Buttons) : ApplicationCommand() {
+class SlashTimeUnit(private val buttons: Buttons) {
     @JDASlashCommand(name = "time_unit")
     suspend fun onSlashTimeUnit(
         event: GuildSlashEvent,

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashUploadStream.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashUploadStream.kt
@@ -3,7 +3,6 @@ package dev.freya02.botcommands.bot.commands.slash
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.Embed
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import kotlinx.coroutines.Dispatchers
@@ -14,7 +13,7 @@ import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
 
 @Command
-class SlashUploadStream : ApplicationCommand() {
+class SlashUploadStream {
     @JDASlashCommand(name = "upload_stream")
     suspend fun execute(event: GuildSlashEvent) {
         event.deferReply(true).queue()

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashVararg.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashVararg.kt
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.slash
 
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.VarArgs
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GuildApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GuildApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -10,7 +9,7 @@ import io.github.freya022.botcommands.api.commands.application.slash.annotations
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
 
 @Command
-class SlashVararg : ApplicationCommand(), GuildApplicationCommandProvider {
+class SlashVararg : GuildApplicationCommandProvider {
     @JDASlashCommand(name = "vararg_annotated")
     fun onSlashVararg(
         event: GuildSlashEvent,

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashVoiceState.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashVoiceState.kt
@@ -2,12 +2,11 @@ package dev.freya02.botcommands.bot.commands.slash
 
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 
 @Command
-class SlashVoiceState : ApplicationCommand() {
+class SlashVoiceState {
 
     @JDASlashCommand(name = "voice_state")
     fun onSlashVoiceState(event: GuildSlashEvent) {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/StateExample.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/StateExample.kt
@@ -5,7 +5,6 @@ import dev.freya02.botcommands.jda.ktx.messages.MessageCreate
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import dev.freya02.botcommands.jda.ktx.messages.toEditData
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
@@ -19,7 +18,7 @@ private class Series(val name: String)
 @Command
 class StateExample(
     private val buttons: Buttons,
-) : ApplicationCommand() {
+) {
 
     private val states: MutableMap<Long, SeriesState> = hashMapOf()
 

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/userapps/SlashDetachedPermissions.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/userapps/SlashDetachedPermissions.kt
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.slash.userapps
 
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
@@ -18,7 +17,7 @@ import net.dv8tion.jda.api.interactions.IntegrationType.*
 import net.dv8tion.jda.api.interactions.InteractionContextType.GUILD
 
 @Command
-class SlashDetachedPermissions : ApplicationCommand(), GlobalApplicationCommandProvider {
+class SlashDetachedPermissions : GlobalApplicationCommandProvider {
     @JDASlashCommand("detached_permissions_annotated")
     @TopLevelSlashCommandData(
         contexts = [GUILD],

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/userapps/SlashMaxFollowupTest.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/userapps/SlashMaxFollowupTest.kt
@@ -5,7 +5,6 @@ import dev.freya02.botcommands.jda.ktx.messages.reply_
 import dev.freya02.botcommands.jda.ktx.requests.awaitCatching
 import dev.freya02.botcommands.jda.ktx.requests.onErrorResponse
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
@@ -14,7 +13,7 @@ import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.requests.ErrorResponse
 
 @Command
-class SlashMaxFollowupTest : ApplicationCommand() {
+class SlashMaxFollowupTest {
     @TopLevelSlashCommandData(contexts = [InteractionContextType.GUILD], integrationTypes = [IntegrationType.USER_INSTALL])
     @JDASlashCommand(name = "max_follow_up", description = "Follow up go brr")
     suspend fun onSlashMaxFollowUp(event: GuildSlashEvent) {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/userapps/SlashPrivateChannelInBot.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/userapps/SlashPrivateChannelInBot.kt
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.slash.userapps
 
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GlobalSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.TopLevelSlashCommandData
@@ -10,7 +9,7 @@ import net.dv8tion.jda.api.interactions.IntegrationType
 import net.dv8tion.jda.api.interactions.InteractionContextType
 
 @Command
-class SlashPrivateChannelInBot : ApplicationCommand() {
+class SlashPrivateChannelInBot {
 
     @TopLevelSlashCommandData(contexts = [InteractionContextType.PRIVATE_CHANNEL], integrationTypes = [IntegrationType.USER_INSTALL])
     @JDASlashCommand(name = "private_channel_in_bot")

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/userapps/SlashStealChannel.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/userapps/SlashStealChannel.kt
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.slash.userapps
 
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
@@ -12,7 +11,7 @@ import net.dv8tion.jda.api.interactions.IntegrationType
 import net.dv8tion.jda.api.interactions.InteractionContextType
 
 @Command
-class SlashStealChannel : ApplicationCommand() {
+class SlashStealChannel {
 
     @TopLevelSlashCommandData(integrationTypes = [IntegrationType.USER_INSTALL], contexts = [InteractionContextType.GUILD])
     @JDASlashCommand(name = "steal_channel")

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextAttachmentParameters.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextAttachmentParameters.kt
@@ -3,7 +3,6 @@ package dev.freya02.botcommands.bot.commands.text
 import dev.freya02.botcommands.bot.services.Disabled
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.core.options.Option
 import io.github.freya022.botcommands.api.core.service.annotations.Resolver
@@ -37,7 +36,7 @@ class TextAttachmentResolver :
  */
 @Command
 @Disabled
-class TextAttachmentParameters : TextCommand() {
+class TextAttachmentParameters {
 
     @JvmInline
     value class MyAttachment(val attachment: Attachment)

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextDelay.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextDelay.kt
@@ -3,7 +3,6 @@ package dev.freya02.botcommands.bot.commands.text
 import dev.freya02.botcommands.jda.ktx.components.row
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.components.Buttons
 import io.github.freya022.botcommands.api.components.annotations.JDAButtonListener
@@ -15,7 +14,7 @@ import kotlin.system.measureTimeMillis
 
 @Command
 @RequiresComponents
-class TextDelay : TextCommand() {
+class TextDelay {
     @JDATextCommandVariation(path = ["delay"])
     suspend fun runDelay(event: BaseCommandEvent, buttons: Buttons) {
         val millis = measureTimeMillis {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextException.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextException.kt
@@ -5,7 +5,6 @@ import dev.freya02.botcommands.jda.ktx.components.into
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.components.Buttons
 import io.github.freya022.botcommands.api.components.annotations.RequiresComponents
@@ -17,7 +16,7 @@ import net.dv8tion.jda.api.components.textinput.TextInputStyle
 @Command
 @RequiresModals
 @RequiresComponents
-class TextException : TextCommand() {
+class TextException {
     @JDATextCommandVariation(path = ["exception"])
     suspend fun onTextException(event: BaseCommandEvent, buttons: Buttons, modals: Modals) {
         event.context.dispatchException("test no throwable", null)

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextFilter.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextFilter.kt
@@ -8,7 +8,6 @@ import dev.freya02.botcommands.jda.ktx.coroutines.await
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.Filter
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.and
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.builder.filter
@@ -18,7 +17,7 @@ import io.github.freya022.botcommands.api.commands.text.provider.TextCommandProv
 
 @Command
 @TestService
-class TextFilter : TextCommand(), TextCommandProvider {
+class TextFilter : TextCommandProvider {
     @Filter(InVoiceChannel::class)
     @JDATextCommandVariation(path = ["filter_annotated"])
     suspend fun onTextFilter(event: BaseCommandEvent) {

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextHelpTesting.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextHelpTesting.kt
@@ -2,7 +2,6 @@ package dev.freya02.botcommands.bot.commands.text
 
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.annotations.TextOption
 import net.dv8tion.jda.api.entities.Guild
@@ -12,7 +11,7 @@ import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.emoji.Emoji
 
 @Command
-class TextHelpTesting : TextCommand() {
+class TextHelpTesting {
     @JDATextCommandVariation(path = ["help_testing"])
     fun onTextHelpTesting(event: BaseCommandEvent,
                           @TextOption boolean: Boolean,

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextLocalization.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextLocalization.kt
@@ -2,14 +2,13 @@ package dev.freya02.botcommands.bot.commands.text
 
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.localization.text.replyGuild
 import io.github.freya022.botcommands.api.localization.text.respondLocalized
 import net.dv8tion.jda.api.interactions.DiscordLocale
 
 @Command
-class TextLocalization : TextCommand() {
+class TextLocalization {
     @JDATextCommandVariation(path = ["localization"])
     fun onTextLocalization(event: BaseCommandEvent) {
         event.localizationPrefix = "commands.localization"

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextMentionable.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextMentionable.kt
@@ -3,13 +3,12 @@ package dev.freya02.botcommands.bot.commands.text
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.annotations.TextOption
 import net.dv8tion.jda.api.entities.IMentionable
 
 @Command
-class TextMentionable : TextCommand() {
+class TextMentionable {
     @JDATextCommandVariation(path = ["mentionable"])
     suspend fun onTextMentionable(event: BaseCommandEvent, @TextOption mentionable: IMentionable) {
         event.respond(mentionable.id).await()

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextTest.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextTest.kt
@@ -4,8 +4,8 @@ import io.github.freya022.botcommands.api.commands.CommandPath
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSupplier
+import io.github.freya022.botcommands.api.commands.text.TextGeneratedValueSupplierProvider
 import io.github.freya022.botcommands.api.commands.text.annotations.Hidden
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.annotations.TextCommandData
@@ -16,7 +16,7 @@ import io.github.freya022.botcommands.api.core.BContext
 import io.github.freya022.botcommands.api.core.reflect.ParameterType
 
 @Command
-class TextTest : TextCommand(), TextCommandProvider {
+class TextTest : TextCommandProvider, TextGeneratedValueSupplierProvider {
     override fun getGeneratedValueSupplier(
         commandPath: CommandPath,
         optionName: String,
@@ -28,7 +28,7 @@ class TextTest : TextCommand(), TextCommandProvider {
             }
         }
 
-        return super.getGeneratedValueSupplier(commandPath, optionName, parameterType)
+        error("Unsupported generated option: $optionName")
     }
 
     @JDATextCommandVariation(path = ["test_annotated"], description = "Fallback variation description")

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/user/UserContextInfo.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/user/UserContextInfo.kt
@@ -4,8 +4,8 @@ import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.CommandPath
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.annotations.GeneratedOption
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplier
+import io.github.freya022.botcommands.api.commands.application.ApplicationGeneratedValueSupplierProvider
 import io.github.freya022.botcommands.api.commands.application.CommandScope
 import io.github.freya022.botcommands.api.commands.application.context.annotations.ContextOption
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAUserCommand
@@ -19,7 +19,7 @@ import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEven
 import net.dv8tion.jda.api.interactions.InteractionContextType.*
 
 @Command
-class UserContextInfo : ApplicationCommand(), GlobalApplicationCommandProvider {
+class UserContextInfo : GlobalApplicationCommandProvider, ApplicationGeneratedValueSupplierProvider {
     override fun getGeneratedValueSupplier(
         guild: Guild?,
         commandId: String?,
@@ -35,7 +35,7 @@ class UserContextInfo : ApplicationCommand(), GlobalApplicationCommandProvider {
             }
         }
 
-        return super.getGeneratedValueSupplier(guild, commandId, commandPath, optionName, parameterType)
+        error("Unknown generated option: $optionName")
     }
 
     @JDAUserCommand(scope = CommandScope.GLOBAL, contexts = [GUILD, BOT_DM, PRIVATE_CHANNEL], name = "User info (annotated)")

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/user/UserContextTest.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/user/UserContextTest.kt
@@ -3,7 +3,6 @@ package dev.freya02.botcommands.bot.commands.user
 import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.context.annotations.JDAUserCommand
 import io.github.freya022.botcommands.api.commands.application.context.user.GlobalUserEvent
 import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
@@ -16,7 +15,7 @@ import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.InteractionContextType.*
 
 @Command
-class UserContextTest : ApplicationCommand(), GlobalApplicationCommandProvider {
+class UserContextTest : GlobalApplicationCommandProvider {
     @JDAUserCommand(
         name = "test user (annotated)",
         contexts = [GUILD, BOT_DM, PRIVATE_CHANNEL],

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/readme/SlashBan.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/readme/SlashBan.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.deleteDelayed
 import dev.freya02.botcommands.jda.ktx.messages.reply_
 import io.github.freya022.botcommands.api.commands.annotations.Command
-import io.github.freya022.botcommands.api.commands.application.ApplicationCommand
 import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.JDASlashCommand
 import io.github.freya022.botcommands.api.commands.application.slash.annotations.SlashOption
@@ -13,7 +12,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 
 @Command
-class SlashBan : ApplicationCommand() {
+class SlashBan {
     @JDASlashCommand(name = "ban", description = "Bans an user")
     suspend fun onSlashBan(
         event: GuildSlashEvent,

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/readme/TextBan.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/readme/TextBan.kt
@@ -4,7 +4,6 @@ import dev.freya02.botcommands.jda.ktx.coroutines.await
 import dev.freya02.botcommands.jda.ktx.messages.deleteDelayed
 import io.github.freya022.botcommands.api.commands.annotations.Command
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
-import io.github.freya022.botcommands.api.commands.text.TextCommand
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.commands.text.annotations.TextCommandData
 import io.github.freya022.botcommands.api.commands.text.annotations.TextOption
@@ -13,7 +12,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 
 @Command
-class TextBan : TextCommand() {
+class TextBan {
     // Applies to all variations with this path
     @TextCommandData(path = ["ban"], description = "Bans an user")
     // Applies to this variation


### PR DESCRIPTION
This removes the requirement of extending `ApplicationCommand`/`TextCommand` by splitting them in optional interfaces for each feature.

## Deprecations
- Deprecated `ApplicationCommand` and `TextCommand`

## Changes
- Split `ApplicationCommand` into optional interfaces
  - `SlashOptionChoiceProvider`
  - `ApplicationGeneratedValueSupplierProvider`
- Split `TextCommand` into optional interfaces
  - `TextCommandHelpConsumer`
  - `TextGeneratedValueSupplierProvider`