### PR TITLE
Prepare for module configurations

### DIFF
--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BAppEmojisConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BAppEmojisConfig.kt
@@ -6,7 +6,11 @@ import io.github.freya022.botcommands.internal.core.config.ConfigDSL
 import io.github.freya022.botcommands.internal.core.config.ConfigurationValue
 
 @InjectedService
-interface BAppEmojisConfig {
+interface BAppEmojisConfig : IConfig, BAppEmojisConfigProps {
+    override val configType get() = BAppEmojisConfig::class.java
+}
+
+interface BAppEmojisConfigProps {
     /**
      * Allows uploading application emojis at startup, and retrieving them from [AppEmojisRegistry].
      *
@@ -32,7 +36,7 @@ interface BAppEmojisConfig {
 }
 
 @ConfigDSL
-class BAppEmojisConfigBuilder internal constructor() : BAppEmojisConfig {
+class BAppEmojisConfigBuilder internal constructor() : BAppEmojisConfigProps {
     @set:JvmName("enable")
     override var enable: Boolean = false
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BApplicationConfig.kt
@@ -30,7 +30,11 @@ import java.nio.file.Path
 import kotlin.io.path.Path
 
 @InjectedService
-interface BApplicationConfig {
+interface BApplicationConfig : IConfig, BApplicationConfigProps {
+    override val configType get() = BApplicationConfig::class.java
+}
+
+interface BApplicationConfigProps {
     /**
      * Whether application commands should be listened for.
      *
@@ -157,7 +161,7 @@ interface BApplicationConfig {
 }
 
 @ConfigDSL
-class BApplicationConfigBuilder internal constructor() : BApplicationConfig {
+class BApplicationConfigBuilder internal constructor() : BApplicationConfigProps {
     @set:JvmName("enable")
     override var enable: Boolean = true
     @Deprecated("Replaced by 'guildsToUpdate'", replaceWith = ReplaceWith("guildToUpdate"))

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BComponentsConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BComponentsConfig.kt
@@ -9,7 +9,11 @@ import io.github.freya022.botcommands.internal.core.config.ConfigDSL
 import io.github.freya022.botcommands.internal.core.config.ConfigurationValue
 
 @InjectedService
-interface BComponentsConfig {
+interface BComponentsConfig : IConfig, BComponentsConfigProps {
+    override val configType get() = BComponentsConfig::class.java
+}
+
+interface BComponentsConfigProps {
     /**
      * Allows loading component services,
      * such as [Components], [Buttons] and [SelectMenus].
@@ -27,7 +31,7 @@ interface BComponentsConfig {
 }
 
 @ConfigDSL
-class BComponentsConfigBuilder internal constructor() : BComponentsConfig {
+class BComponentsConfigBuilder internal constructor() : BComponentsConfigProps {
     @set:JvmName("enable")
     override var enable: Boolean = false
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BConfig.kt
@@ -7,22 +7,49 @@ import io.github.freya022.botcommands.api.core.annotations.BEventListener
 import io.github.freya022.botcommands.api.core.requests.PriorityGlobalRestRateLimiter
 import io.github.freya022.botcommands.api.core.service.ClassGraphProcessor
 import io.github.freya022.botcommands.api.core.service.annotations.InjectedService
-import io.github.freya022.botcommands.api.core.utils.enumSetOf
-import io.github.freya022.botcommands.api.core.utils.loggerOf
-import io.github.freya022.botcommands.api.core.utils.toImmutableList
-import io.github.freya022.botcommands.api.core.utils.toImmutableSet
+import io.github.freya022.botcommands.api.core.utils.*
 import io.github.freya022.botcommands.api.core.waiter.EventWaiter
 import io.github.freya022.botcommands.internal.core.config.ConfigDSL
 import io.github.freya022.botcommands.internal.core.config.ConfigurationValue
+import io.github.freya022.botcommands.internal.utils.putIfAbsentOrThrow
+import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.events.Event
 import net.dv8tion.jda.api.requests.GatewayIntent
 import net.dv8tion.jda.api.requests.RestRateLimiter
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import org.intellij.lang.annotations.Language
+import kotlin.reflect.KClass
 
 @InjectedService
-interface BConfig {
+interface BConfig : IConfig, BConfigProps {
+    override val configType get() = BConfig::class.java
+
+    val eventManagerConfig: BEventManagerConfig
+    val serviceConfig: BServiceConfig
+    val databaseConfig: BDatabaseConfig
+    val localizationConfig: BLocalizationConfig
+    val appEmojisConfig: BAppEmojisConfig
+    val textConfig: BTextConfig
+    val applicationConfig: BApplicationConfig
+    val modalsConfig: BModalsConfig
+    val componentsConfig: BComponentsConfig
+    val coroutineScopesConfig: BCoroutineScopesConfig
+
+    /**
+     * An immutable collection of all [registered][BConfigBuilder.withConfig] configuration objects.
+     */
+    val configs: Collection<IConfig>
+
+    /**
+     * Gets a configuration of the provided type, or `null` if none were [registered][BConfigBuilder.withConfig].
+     *
+     * @param type The type of configuration to get, based on [configType].
+     */
+    fun <T : IConfig> getConfigOrNull(type: Class<T>): T?
+}
+
+interface BConfigProps {
     /**
      * Predefined user IDs of the bot owners, allowing bypassing cooldowns, user permission checks,
      * and having [hidden commands][Hidden] shown.
@@ -106,21 +133,24 @@ interface BConfig {
     val ignoreRestRateLimiter: Boolean
 
     val classGraphProcessors: List<ClassGraphProcessor>
-
-    val eventManagerConfig: BEventManagerConfig
-    val serviceConfig: BServiceConfig
-    val databaseConfig: BDatabaseConfig
-    val localizationConfig: BLocalizationConfig
-    val appEmojisConfig: BAppEmojisConfig
-    val textConfig: BTextConfig
-    val applicationConfig: BApplicationConfig
-    val modalsConfig: BModalsConfig
-    val componentsConfig: BComponentsConfig
-    val coroutineScopesConfig: BCoroutineScopesConfig
 }
 
+/**
+ * Gets a configuration of the provided type, or `null` if none were [registered][BConfigBuilder.withConfig].
+ *
+ * @param type The type of configuration to get, based on [configType][BConfig.configType].
+ */
+fun <T : IConfig> BConfig.getConfigOrNull(type: KClass<T>): T? = getConfigOrNull(type.java)
+
+/**
+ * Gets a configuration of the provided type, or `null` if none were [registered][BConfigBuilder.withConfig].
+ *
+ * @param T The type of configuration to get, based on [configType][BConfig.configType].
+ */
+inline fun <reified T : IConfig> BConfig.getConfigOrNull(): T? = getConfigOrNull(T::class.java)
+
 @ConfigDSL
-class BConfigBuilder : BConfig {
+class BConfigBuilder : BConfigProps {
     override val packages: MutableSet<String> = HashSet()
     override val classes: MutableSet<Class<*>> = HashSet()
 
@@ -139,16 +169,18 @@ class BConfigBuilder : BConfig {
 
     override val classGraphProcessors: MutableList<ClassGraphProcessor> = arrayListOf()
 
-    override val eventManagerConfig = BEventManagerConfigBuilder()
-    override val serviceConfig = BServiceConfigBuilder()
-    override val databaseConfig = BDatabaseConfigBuilder()
-    override val localizationConfig = BLocalizationConfigBuilder()
-    override val appEmojisConfig = BAppEmojisConfigBuilder()
-    override val textConfig = BTextConfigBuilder()
-    override val applicationConfig = BApplicationConfigBuilder()
-    override val modalsConfig = BModalsConfigBuilder()
-    override val componentsConfig = BComponentsConfigBuilder()
-    override val coroutineScopesConfig = BCoroutineScopesConfigBuilder()
+    private val _configs: MutableMap<Class<out IConfig>, IConfig> = hashMapOf()
+
+    val eventManagerConfig = BEventManagerConfigBuilder()
+    val serviceConfig = BServiceConfigBuilder()
+    val databaseConfig = BDatabaseConfigBuilder()
+    val localizationConfig = BLocalizationConfigBuilder()
+    val appEmojisConfig = BAppEmojisConfigBuilder()
+    val textConfig = BTextConfigBuilder()
+    val applicationConfig = BApplicationConfigBuilder()
+    val modalsConfig = BModalsConfigBuilder()
+    val componentsConfig = BComponentsConfigBuilder()
+    val coroutineScopesConfig = BCoroutineScopesConfigBuilder()
 
     /**
      * Predefined user IDs of the bot owners, allowing bypassing cooldowns, user permission checks,
@@ -278,6 +310,19 @@ class BConfigBuilder : BConfig {
         componentsConfig.apply(block)
     }
 
+    /**
+     * Registers the provided configuration, once configured, it cannot be modified or overwritten.
+     *
+     * @param newConfig The new configuration
+     *
+     * @throws IllegalStateException If a config of the same type was already registered
+     */
+    fun withConfig(newConfig: IConfig) {
+        _configs.putIfAbsentOrThrow(newConfig.configType, newConfig) { _ ->
+            "Cannot reassign configuration of ${newConfig.configType.simpleNestedName}, please configure it entirely then assign once"
+        }
+    }
+
     fun build(): BConfig {
         val logger = KotlinLogging.loggerOf<BConfig>()
         if (disableExceptionsInDMs)
@@ -303,6 +348,29 @@ class BConfigBuilder : BConfig {
             override val modalsConfig = this@BConfigBuilder.modalsConfig.build()
             override val componentsConfig = this@BConfigBuilder.componentsConfig.build()
             override val coroutineScopesConfig = this@BConfigBuilder.coroutineScopesConfig.build()
+            private val _configs = (this@BConfigBuilder._configs + mapOf(
+                this.configType to this,
+                eventManagerConfig.configType to eventManagerConfig,
+                serviceConfig.configType to serviceConfig,
+                databaseConfig.configType to databaseConfig,
+                localizationConfig.configType to localizationConfig,
+                appEmojisConfig.configType to appEmojisConfig,
+                textConfig.configType to textConfig,
+                applicationConfig.configType to applicationConfig,
+                modalsConfig.configType to modalsConfig,
+                componentsConfig.configType to componentsConfig,
+                coroutineScopesConfig.configType to coroutineScopesConfig,
+            )).unmodifiableView()
+            override val configs get() = _configs.values
+
+            override fun <T : IConfig> getConfigOrNull(type: Class<T>): T? {
+                val config = _configs[type] ?: return null
+                if (!type.isInstance(config)) {
+                    throwInternal("$config (${config.javaClass.name}) is not an instance of ${type.name}")
+                }
+
+                return type.cast(config)
+            }
         }
     }
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BCoroutineScopesConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BCoroutineScopesConfig.kt
@@ -5,12 +5,15 @@ import io.github.freya022.botcommands.api.core.hooks.EventDispatcher
 import io.github.freya022.botcommands.api.core.service.annotations.InjectedService
 import io.github.freya022.botcommands.api.core.utils.namedDefaultScope
 import io.github.freya022.botcommands.internal.core.config.ConfigDSL
-import io.github.freya022.botcommands.internal.utils.throwState
 import kotlinx.coroutines.CoroutineScope
 import java.util.concurrent.Executor
 
 @InjectedService
-interface BCoroutineScopesConfig {
+interface BCoroutineScopesConfig : IConfig, BCoroutineScopesConfigProps {
+    override val configType get() = BCoroutineScopesConfig::class.java
+}
+
+interface BCoroutineScopesConfigProps {
     val eventManagerScope: CoroutineScope           //Used by [[CoroutineEventManagerImpl]]
     val commandUpdateScope: CoroutineScope          //Not used much
     /**
@@ -32,18 +35,7 @@ fun interface CoroutineScopeFactory {
 }
 
 @ConfigDSL
-class BCoroutineScopesConfigBuilder internal constructor() : BCoroutineScopesConfig {
-    override val eventManagerScope: Nothing get() = throwState("Cannot get a coroutine scope from the builder")
-    override val commandUpdateScope: Nothing get() = throwState("Cannot get a coroutine scope from the builder")
-    override val eventDispatcherScope: Nothing get() = throwState("Cannot get a coroutine scope from the builder")
-    override val textCommandsScope: Nothing get() = throwState("Cannot get a coroutine scope from the builder")
-    override val applicationCommandsScope: Nothing get() = throwState("Cannot get a coroutine scope from the builder")
-    override val componentScope: Nothing get() = throwState("Cannot get a coroutine scope from the builder")
-    override val componentTimeoutScope: Nothing get() = throwState("Cannot get a coroutine scope from the builder")
-    override val modalScope: Nothing get() = throwState("Cannot get a coroutine scope from the builder")
-    override val modalTimeoutScope: Nothing get() = throwState("Cannot get a coroutine scope from the builder")
-    override val paginationTimeoutScope: Nothing get() = throwState("Cannot get a coroutine scope from the builder")
-
+class BCoroutineScopesConfigBuilder internal constructor() {
     var eventManagerScopeFactory: CoroutineScopeFactory = defaultFactory("Event manager", 4)
     var commandUpdateScopeFactory: CoroutineScopeFactory = defaultFactory("Command updater", 1)
     var eventDispatcherScopeFactory: CoroutineScopeFactory = defaultFactory("Event dispatcher", 4)

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BDatabaseConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BDatabaseConfig.kt
@@ -11,7 +11,11 @@ import kotlin.time.toJavaDuration
 import kotlin.time.toKotlinDuration
 
 @InjectedService
-interface BDatabaseConfig {
+interface BDatabaseConfig : IConfig, BDatabaseConfigProps {
+    override val configType get() = BDatabaseConfig::class.java
+}
+
+interface BDatabaseConfigProps {
     /**
      * Whether transactions should trigger a coroutine dump & thread dump
      * when running longer than the [max transaction duration][ConnectionSupplier.maxTransactionDuration]
@@ -67,7 +71,7 @@ interface BDatabaseConfig {
 }
 
 @ConfigDSL
-class BDatabaseConfigBuilder internal constructor() : BDatabaseConfig {
+class BDatabaseConfigBuilder internal constructor() : BDatabaseConfigProps {
     @set:DevConfig
     @set:JvmName("dumpLongTransactions")
     override var dumpLongTransactions: Boolean = false

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BEventManagerConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BEventManagerConfig.kt
@@ -10,8 +10,11 @@ import kotlin.time.toJavaDuration
 import kotlin.time.toKotlinDuration
 
 @InjectedService
-interface BEventManagerConfig {
+interface BEventManagerConfig : IConfig, BEventManagerConfigProps {
+    override val configType get() = BEventManagerConfig::class.java
+}
 
+interface BEventManagerConfigProps {
     /**
      * The time applied to all event listeners by default before their coroutine is cancelled.
      *
@@ -42,8 +45,7 @@ interface BEventManagerConfig {
 }
 
 @ConfigDSL
-class BEventManagerConfigBuilder internal constructor() : BEventManagerConfig {
-
+class BEventManagerConfigBuilder internal constructor() : BEventManagerConfigProps {
     @set:JvmSynthetic
     override var defaultTimeout: Duration? = null
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BLocalizationConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BLocalizationConfig.kt
@@ -9,7 +9,11 @@ import io.github.freya022.botcommands.internal.core.config.ConfigDSL
 import io.github.freya022.botcommands.internal.core.config.ConfigurationValue
 
 @InjectedService
-interface BLocalizationConfig {
+interface BLocalizationConfig : IConfig, BLocalizationConfigProps {
+    override val configType get() = BLocalizationConfig::class.java
+}
+
+interface BLocalizationConfigProps {
     /**
      * Localization bundles available for localizing interaction responses, with [LocalizableInteraction],
      * not to be confused with those used to [localize commands][BApplicationConfigBuilder.addLocalizations].
@@ -30,7 +34,7 @@ interface BLocalizationConfig {
 }
 
 @ConfigDSL
-class BLocalizationConfigBuilder internal constructor() : BLocalizationConfig {
+class BLocalizationConfigBuilder internal constructor() : BLocalizationConfigProps {
     override val responseBundles: MutableSet<String> = hashSetOf()
 
     /**

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BModalsConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BModalsConfig.kt
@@ -6,7 +6,11 @@ import io.github.freya022.botcommands.internal.core.config.ConfigDSL
 import io.github.freya022.botcommands.internal.core.config.ConfigurationValue
 
 @InjectedService
-interface BModalsConfig {
+interface BModalsConfig : IConfig, BModalsConfigProps {
+    override val configType get() = BModalsConfig::class.java
+}
+
+interface BModalsConfigProps {
     /**
      * Whether modal interactions should be listened for.
      *
@@ -21,7 +25,7 @@ interface BModalsConfig {
 }
 
 @ConfigDSL
-class BModalsConfigBuilder internal constructor() : BModalsConfig {
+class BModalsConfigBuilder internal constructor() : BModalsConfigProps {
     @set:JvmName("enable")
     override var enable: Boolean = true
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BServiceConfig.kt
@@ -13,7 +13,11 @@ import io.github.freya022.botcommands.internal.utils.putIfAbsentOrThrow
 import kotlin.reflect.KClass
 
 @InjectedService
-interface BServiceConfig {
+interface BServiceConfig : IConfig, BServiceConfigProps {
+    override val configType get() = BServiceConfig::class.java
+}
+
+interface BServiceConfigProps {
     /**
      * Enables debugging of service loading.
      *
@@ -25,7 +29,7 @@ interface BServiceConfig {
 }
 
 @ConfigDSL
-class BServiceConfigBuilder internal constructor() : BServiceConfig {
+class BServiceConfigBuilder internal constructor() : BServiceConfigProps {
     override var debug: Boolean = false
 
     private val _serviceSuppliers: MutableMap<KClass<*>, ServiceSupplier<*>> = hashMapOf()

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BTextConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/BTextConfig.kt
@@ -12,7 +12,11 @@ import io.github.freya022.botcommands.internal.core.config.ConfigurationValue
 import net.dv8tion.jda.api.entities.emoji.Emoji
 
 @InjectedService
-interface BTextConfig {
+interface BTextConfig : IConfig, BTextConfigProps {
+    override val configType get() = BTextConfig::class.java
+}
+
+interface BTextConfigProps {
     /**
      * Whether text commands should be listened for.
      *
@@ -89,7 +93,7 @@ interface BTextConfig {
 }
 
 @ConfigDSL
-class BTextConfigBuilder internal constructor() : BTextConfig {
+class BTextConfigBuilder internal constructor() : BTextConfigProps {
     @set:JvmName("enable")
     override var enable: Boolean = true
     @set:JvmName("usePingAsPrefix")

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/IConfig.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/config/IConfig.kt
@@ -1,0 +1,5 @@
+package io.github.freya022.botcommands.api.core.config
+
+interface IConfig {
+    val configType: Class<out IConfig>
+}

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/ConfigDSL.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/ConfigDSL.kt
@@ -1,4 +1,4 @@
 package io.github.freya022.botcommands.internal.core.config
 
 @DslMarker
-internal annotation class ConfigDSL
+annotation class ConfigDSL

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/BCBotCommandsBootstrap.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/BCBotCommandsBootstrap.kt
@@ -3,8 +3,12 @@ package io.github.freya022.botcommands.internal.core.service
 import io.github.classgraph.ClassInfo
 import io.github.classgraph.MethodInfo
 import io.github.freya022.botcommands.api.BCInfo
-import io.github.freya022.botcommands.api.core.config.*
-import io.github.freya022.botcommands.api.core.service.*
+import io.github.freya022.botcommands.api.core.config.BConfig
+import io.github.freya022.botcommands.api.core.config.BServiceConfig
+import io.github.freya022.botcommands.api.core.service.BCServiceContainer
+import io.github.freya022.botcommands.api.core.service.ClassGraphProcessor
+import io.github.freya022.botcommands.api.core.service.ServiceContainer
+import io.github.freya022.botcommands.api.core.service.putServiceWithTypeAlias
 import io.github.freya022.botcommands.internal.core.Version
 import io.github.freya022.botcommands.internal.core.service.provider.ServiceProviders
 import net.dv8tion.jda.api.JDAInfo
@@ -34,17 +38,7 @@ internal class BCBotCommandsBootstrap internal constructor(
         serviceContainer.putService(serviceContainer, serviceContainer::class, typeAliases = setOf(BCServiceContainer::class, ServiceContainer::class))
         serviceContainer.putService(serviceProviders)
 
-        serviceContainer.putServiceAs<BConfig>(config)
-        serviceContainer.putServiceAs<BEventManagerConfig>(config.eventManagerConfig)
-        serviceContainer.putServiceAs<BServiceConfig>(config.serviceConfig)
-        serviceContainer.putServiceAs<BDatabaseConfig>(config.databaseConfig)
-        serviceContainer.putServiceAs<BLocalizationConfig>(config.localizationConfig)
-        serviceContainer.putServiceAs<BAppEmojisConfig>(config.appEmojisConfig)
-        serviceContainer.putServiceAs<BApplicationConfig>(config.applicationConfig)
-        serviceContainer.putServiceAs<BModalsConfig>(config.modalsConfig)
-        serviceContainer.putServiceAs<BComponentsConfig>(config.componentsConfig)
-        serviceContainer.putServiceAs<BCoroutineScopesConfig>(config.coroutineScopesConfig)
-        serviceContainer.putServiceAs<BTextConfig>(config.textConfig)
+        config.configs.forEach { serviceContainer.putServiceAs(it, it.configType) }
 
         serviceContainer.loadServices()
     }

--- a/BotCommands-spring/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
+++ b/BotCommands-spring/src/main/kotlin/io/github/freya022/botcommands/internal/core/config/BotCommandsConfigurations.kt
@@ -25,18 +25,8 @@ internal class BotCommandsCoreConfiguration(
     override val ignoredIntents: Set<GatewayIntent> = emptySet(),
     override val ignoredEventIntents: Set<Class<out Event>> = emptySet(),
     override val ignoreRestRateLimiter: Boolean = false,
-) : BConfig {
+) : BConfigProps {
     override val classGraphProcessors: Nothing get() = unusable()
-    override val eventManagerConfig: Nothing get() = unusable()
-    override val serviceConfig: Nothing get() = unusable()
-    override val databaseConfig: Nothing get() = unusable()
-    override val localizationConfig: Nothing get() = unusable()
-    override val appEmojisConfig: Nothing get() = unusable()
-    override val textConfig: Nothing get() = unusable()
-    override val applicationConfig: Nothing get() = unusable()
-    override val modalsConfig: Nothing get() = unusable()
-    override val componentsConfig: Nothing get() = unusable()
-    override val coroutineScopesConfig: Nothing get() = unusable()
 }
 
 internal fun BConfigBuilder.applyConfig(configuration: BotCommandsCoreConfiguration) = apply {
@@ -53,7 +43,7 @@ internal fun BConfigBuilder.applyConfig(configuration: BotCommandsCoreConfigurat
 @ConfigurationProperties(prefix = "botcommands.event.manager", ignoreUnknownFields = false)
 internal class BotCommandsEventManagerConfiguration(
     defaultTimeout: JavaDuration? = null,
-) : BEventManagerConfig {
+) : BEventManagerConfigProps {
 
     override val defaultTimeout = defaultTimeout?.toKotlinDuration()
 }
@@ -69,7 +59,7 @@ internal class BotCommandsDatabaseConfiguration(
     override val logQueries: Boolean = false,
     override val logQueryParameters: Boolean = true,
     queryLogThreshold: JavaDuration? = null
-) : BDatabaseConfig {
+) : BDatabaseConfigProps {
     override val queryLogThreshold: Duration = queryLogThreshold?.toKotlinDuration() ?: Duration.INFINITE
 }
 
@@ -85,7 +75,7 @@ internal fun BDatabaseConfigBuilder.applyConfig(configuration: BotCommandsDataba
 internal class BotCommandsAppEmojisConfiguration(
     override val enable: Boolean = false,
     override val deleteOnOutOfSlots: Boolean = false,
-) : BAppEmojisConfig {
+) : BAppEmojisConfigProps {
 
 }
 
@@ -103,7 +93,7 @@ internal class BotCommandsTextConfiguration(
     override val showSuggestions: Boolean = true,
     @param:Name("dmClosedEmoji")
     internal val dmClosedEmojiString: String? = null
-) : BTextConfig {
+) : BTextConfigProps {
     override val dmClosedEmoji: Nothing get() = unusable()
 }
 
@@ -119,7 +109,7 @@ internal fun BTextConfigBuilder.applyConfig(configuration: BotCommandsTextConfig
 @ConfigurationProperties(prefix = "botcommands.localization", ignoreUnknownFields = false)
 internal class BotCommandsLocalizationConfiguration(
     override val responseBundles: Set<String> = emptySet(),
-) : BLocalizationConfig
+) : BLocalizationConfigProps
 
 internal fun BLocalizationConfigBuilder.applyConfig(configuration: BotCommandsLocalizationConfiguration) = apply {
     responseBundles += configuration.responseBundles
@@ -137,7 +127,7 @@ internal class BotCommandsApplicationConfiguration(
     override val logMissingLocalizationKeys: Boolean = false,
     @param:Name("cache")
     internal val springCache: Cache = Cache(),
-) : BApplicationConfig {
+) : BApplicationConfigProps {
     override val cache: Nothing get() = unusable()
 
     override val guildsToUpdate: List<Long> = when {
@@ -223,7 +213,7 @@ private fun BApplicationConfigBuilder.configureCache(configuration: BotCommandsA
 @ConfigurationProperties(prefix = "botcommands.modals", ignoreUnknownFields = true)
 internal class BotCommandsModalsConfiguration(
     override val enable: Boolean = true,
-) : BModalsConfig {
+) : BModalsConfigProps {
 
 }
 
@@ -234,7 +224,7 @@ internal fun BModalsConfigBuilder.applyConfig(configuration: BotCommandsModalsCo
 @ConfigurationProperties(prefix = "botcommands.components", ignoreUnknownFields = false)
 internal class BotCommandsComponentsConfiguration(
     override val enable: Boolean = false
-) : BComponentsConfig
+) : BComponentsConfigProps
 
 internal fun BComponentsConfigBuilder.applyConfig(configuration: BotCommandsComponentsConfiguration) = apply {
     enable = configuration.enable


### PR DESCRIPTION
In newer 3.X modules, and for all features in 4.X, each module added by the user will contain their own configuration, which are then added by the user (or for Kotlin users, using a more convenient extension). Adding a configuration also implies enabling the feature being configured.

## Changes
- Moved config properties to a separate interface
  - So builders are no longer configurations while still sharing properties
- Added methods to get/set configurations