### PR TITLE
Replace `kotlinx.datetime` types with standard library

### DIFF
--- a/BotCommands-core/build.gradle.kts
+++ b/BotCommands-core/build.gradle.kts
@@ -49,8 +49,6 @@ dependencies {
 
     // -------------------- GLOBAL DEPENDENCIES --------------------
 
-    api(libs.kotlinx.datetime)
-
     // Deserialization
     api(libs.jackson.databind)
     api(libs.jackson.module.kotlin)

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/db/DBResult.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/core/db/DBResult.kt
@@ -4,8 +4,6 @@ import io.github.freya022.botcommands.api.core.utils.isSubclassOf
 import io.github.freya022.botcommands.api.core.utils.toBoxed
 import io.github.freya022.botcommands.internal.utils.findErasureOfAt
 import io.github.freya022.botcommands.internal.utils.rethrow
-import kotlinx.datetime.Instant
-import kotlinx.datetime.toKotlinInstant
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.util.*
@@ -13,6 +11,8 @@ import java.util.stream.Stream
 import java.util.stream.StreamSupport
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
+import kotlin.time.Instant
+import kotlin.time.toKotlinInstant
 
 /**
  * Utility class to iterate over a [ResultSet],

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentController.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentController.kt
@@ -24,7 +24,7 @@ import io.github.freya022.botcommands.internal.utils.takeIfFinite
 import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 private const val PREFIX = "BotCommands-Components-"
 private const val PREFIX_LENGTH = PREFIX.length

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentTimeoutManager.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/controller/ComponentTimeoutManager.kt
@@ -14,8 +14,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 private val logger = KotlinLogging.logger { }
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentData.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentData.kt
@@ -3,8 +3,8 @@ package io.github.freya022.botcommands.internal.components.data
 import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.LifetimeType
 import io.github.freya022.botcommands.internal.components.data.timeout.ComponentTimeout
-import kotlinx.datetime.Instant
 import kotlin.time.Duration
+import kotlin.time.Instant
 
 internal sealed interface ComponentData {
     val internalId: Int

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentGroupData.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/ComponentGroupData.kt
@@ -3,8 +3,8 @@ package io.github.freya022.botcommands.internal.components.data
 import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.LifetimeType
 import io.github.freya022.botcommands.internal.components.data.timeout.ComponentTimeout
-import kotlinx.datetime.Instant
 import kotlin.time.Duration
+import kotlin.time.Instant
 
 internal class ComponentGroupData internal constructor(
     override val internalId: Int,

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/EphemeralComponentData.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/EphemeralComponentData.kt
@@ -7,8 +7,8 @@ import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.LifetimeType
 import io.github.freya022.botcommands.internal.components.data.timeout.EphemeralTimeout
 import io.github.freya022.botcommands.internal.components.handler.EphemeralHandler
-import kotlinx.datetime.Instant
 import kotlin.time.Duration
+import kotlin.time.Instant
 
 internal class EphemeralComponentData(
     override val internalId: Int,

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/PersistentComponentData.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/data/PersistentComponentData.kt
@@ -7,8 +7,8 @@ import io.github.freya022.botcommands.internal.components.ComponentType
 import io.github.freya022.botcommands.internal.components.LifetimeType
 import io.github.freya022.botcommands.internal.components.data.timeout.PersistentTimeout
 import io.github.freya022.botcommands.internal.components.handler.PersistentHandler
-import kotlinx.datetime.Instant
 import kotlin.time.Duration
+import kotlin.time.Instant
 
 internal class PersistentComponentData(
     override val internalId: Int,

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentRepository.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/components/repositories/ComponentRepository.kt
@@ -27,14 +27,14 @@ import io.github.freya022.botcommands.internal.utils.throwArgument
 import io.github.freya022.botcommands.internal.utils.throwInternal
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
-import kotlinx.datetime.toJavaInstant
 import net.dv8tion.jda.api.Permission
 import java.sql.DatabaseMetaData
 import java.sql.Timestamp
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
+import kotlin.time.toJavaInstant
 
 private val logger = KotlinLogging.logger { }
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/BContextImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/BContextImpl.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.events.session.ShutdownEvent
@@ -39,6 +38,7 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.jvmErasure
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.toJavaDuration

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/utils/Exceptions.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/utils/Exceptions.kt
@@ -5,8 +5,6 @@ import dev.freya02.botcommands.jda.ktx.messages.deleteDelayed
 import dev.freya02.botcommands.jda.ktx.requests.runIgnoringResponse
 import io.github.freya022.botcommands.api.core.DeclarationSite
 import io.github.freya022.botcommands.internal.core.exceptions.InternalException
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
 import net.dv8tion.jda.api.requests.ErrorResponse
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
@@ -14,7 +12,9 @@ import java.lang.reflect.InvocationTargetException
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import kotlin.reflect.KFunction
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 internal fun throwInternal(message: String): Nothing =
     throw InternalException(message)

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/utils/InternalUtils.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/utils/InternalUtils.kt
@@ -2,8 +2,6 @@ package io.github.freya022.botcommands.internal.utils
 
 import io.github.freya022.botcommands.api.commands.CommandPath
 import io.github.freya022.botcommands.api.commands.INamedCommand
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import net.dv8tion.jda.api.entities.Guild
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -11,7 +9,9 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
+import kotlin.time.Clock
 import kotlin.time.Duration
+import kotlin.time.Instant
 
 internal fun String.toDiscordString(): String {
     val sb: StringBuilder = StringBuilder()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ konsist = "0.17.3"
 kotlin = "2.3.10"
 kotlin-logging = "7.0.3"
 kotlinx-coroutines = "1.10.2"
-kotlinx-datetime = "0.6.1"
 kotlinx-serialization = "1.9.0"
 ksp = "2.2.20-2.0.4"
 logback-classic = "1.5.16"
@@ -76,7 +75,6 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-debug", version.ref = "kotlinx-coroutines" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime-jvm", version.ref = "kotlinx-datetime" }
 kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 ksp-aa = { module = "com.google.devtools.ksp:symbol-processing-aa-embeddable", version.ref = "ksp" }

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextDeleteIncluding.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/message/MessageContextDeleteIncluding.kt
@@ -13,12 +13,12 @@ import io.github.freya022.botcommands.api.commands.application.context.annotatio
 import io.github.freya022.botcommands.api.commands.application.context.message.GuildMessageEvent
 import io.github.freya022.botcommands.api.components.Buttons
 import kotlinx.coroutines.future.await
-import kotlinx.datetime.Clock
-import kotlinx.datetime.toJavaInstant
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Message
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaInstant
 
 @Command
 class MessageContextDeleteIncluding(


### PR DESCRIPTION
They have since been added to the Kotlin stdlib

## Breaking changes
- The `kotlinx-datetime` dependency is no longer included
- The `DBResult.getKotlinInstant` extension now returns `kotlin.time.Instant`