### PR TITLE
Replace `LocalizationContext` factories with a builder

### DIFF
--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/AppLocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/AppLocalizationContext.kt
@@ -21,13 +21,13 @@ import javax.annotation.CheckReturnValue
  *
  * ### Manual usage
  * While instances of this interface are primarily injected with [@LocalizationBundle][LocalizationBundle],
- * you can also construct instances of this interface with [LocalizationContext.create].
+ * you can also construct instances of this interface with [LocalizationContext.builder].
  *
  * Instances are only injectable if the event is a subclass of [Interaction].
  *
  * @see userLocale
  * @see guildLocale
- * @see LocalizationContext.create
+ * @see LocalizationContext.builder
  */
 interface AppLocalizationContext : TextLocalizationContext {
     /**

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
@@ -6,7 +6,7 @@ import io.github.freya022.botcommands.api.core.service.getService
 import io.github.freya022.botcommands.api.localization.Localization
 import io.github.freya022.botcommands.api.localization.LocalizationService
 import io.github.freya022.botcommands.api.localization.annotations.LocalizationBundle
-import io.github.freya022.botcommands.api.localization.context.LocalizationContext.Companion.create
+import io.github.freya022.botcommands.api.localization.context.LocalizationContext.Companion.builder
 import io.github.freya022.botcommands.api.localization.interaction.GuildLocaleProvider
 import io.github.freya022.botcommands.api.localization.interaction.UserLocaleProvider
 import io.github.freya022.botcommands.api.localization.text.TextCommandLocaleProvider
@@ -38,7 +38,7 @@ typealias PairEntry = Pair<String, Any>
  *
  * @see TextLocalizationContext
  * @see AppLocalizationContext
- * @see create
+ * @see builder
  */
 interface LocalizationContext {
     /**

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
@@ -61,11 +61,9 @@ interface LocalizationContext {
     val localizationBundle: String
 
     /**
-     * Returns the localization prefix of the current context.
+     * The prefix to add to every localization request.
      *
-     * The localization prefix can either come from [LocalizationBundle.prefix] or [withPrefix].
-     *
-     * @return The localization prefix for this context, or `null` if none has been set
+     * This will be ignored if the request's path starts with a `/`.
      *
      * @see withPrefix
      */
@@ -158,19 +156,33 @@ interface LocalizationContext {
         private var guildLocaleProvider: Lazy<DiscordLocale>? = null
         private var userLocaleProvider: Lazy<DiscordLocale>? = null
 
+        /**
+         * Sets the prefix of the context.
+         *
+         * @see LocalizationContext.localizationPrefix
+         */
         fun setPrefix(prefix: String?): Builder {
             this.prefix = prefix
             return this
         }
 
+        /**
+         * Sets the guild locale to be provided by the passed [GuildLocaleProvider].
+         */
         fun setGuildLocaleProvider(provider: GuildLocaleProvider, interaction: Interaction): Builder {
             return setGuildLocaleProvider(lazy { provider.getDiscordLocale(interaction) })
         }
 
+        /**
+         * Sets the guild locale to be provided by the passed [TextCommandLocaleProvider].
+         */
         fun setGuildLocaleProvider(provider: TextCommandLocaleProvider, event: MessageReceivedEvent): Builder {
             return setGuildLocaleProvider(lazy { provider.getDiscordLocale(event) })
         }
 
+        /**
+         * Sets the guild locale to the provided one.
+         */
         fun setGuildLocale(locale: DiscordLocale): Builder {
             return setGuildLocaleProvider(lazyOf(locale))
         }
@@ -180,10 +192,16 @@ interface LocalizationContext {
             return this
         }
 
+        /**
+         * Sets the user locale to be provided by the passed [UserLocaleProvider].
+         */
         fun setUserLocaleProvider(provider: UserLocaleProvider, interaction: Interaction): Builder {
             return setUserLocaleProvider(lazy { provider.getDiscordLocale(interaction) })
         }
 
+        /**
+         * Sets the user locale to the provided one.
+         */
         fun setUserLocale(locale: DiscordLocale): Builder {
             return setUserLocaleProvider(lazyOf(locale))
         }
@@ -193,6 +211,11 @@ interface LocalizationContext {
             return this
         }
 
+        /**
+         * Builds an instance with the current configuration.
+         *
+         * **Note:** This returns an [AppLocalizationContext] (instead of a [LocalizationContext]) to give you full capabilities.
+         */
         fun build(): AppLocalizationContext {
             return LocalizationContextImpl(localizationService, bundleName, prefix, guildLocaleProvider, userLocaleProvider)
         }
@@ -274,10 +297,19 @@ interface LocalizationContext {
             )
         }
 
+        /**
+         * Creates a new builder, using a [LocalizationService] retrieved from the provided context,
+         * and the specified bundle name, from which the strings will be retrieved from.
+         */
+        @JvmStatic
         fun builder(context: BContext, localizationBundle: String): Builder {
             return Builder(localizationService = context.getService(), localizationBundle)
         }
 
+        /**
+         * Creates a new builder, using a [LocalizationService] and the specified bundle name,
+         * from which the strings will be retrieved from.
+         */
         fun builder(localizationService: LocalizationService, localizationBundle: String): Builder {
             return Builder(localizationService, localizationBundle)
         }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
@@ -310,6 +310,7 @@ interface LocalizationContext {
          * Creates a new builder, using a [LocalizationService] and the specified bundle name,
          * from which the strings will be retrieved from.
          */
+        @JvmStatic
         fun builder(localizationService: LocalizationService, localizationBundle: String): Builder {
             return Builder(localizationService, localizationBundle)
         }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
@@ -153,6 +153,51 @@ interface LocalizationContext {
     fun localizeOrNull(localizationPath: String, vararg entries: Localization.Entry): String? =
         localizeOrNull(effectiveLocale, localizationPath, *entries)
 
+    class Builder internal constructor(private val localizationService: LocalizationService, private val bundleName: String) {
+        private var prefix: String? = null
+        private var guildLocaleProvider: Lazy<DiscordLocale>? = null
+        private var userLocaleProvider: Lazy<DiscordLocale>? = null
+
+        fun setPrefix(prefix: String?): Builder {
+            this.prefix = prefix
+            return this
+        }
+
+        fun setGuildLocaleProvider(provider: GuildLocaleProvider, interaction: Interaction): Builder {
+            return setGuildLocaleProvider(lazy { provider.getDiscordLocale(interaction) })
+        }
+
+        fun setGuildLocaleProvider(provider: TextCommandLocaleProvider, event: MessageReceivedEvent): Builder {
+            return setGuildLocaleProvider(lazy { provider.getDiscordLocale(event) })
+        }
+
+        fun setGuildLocale(locale: DiscordLocale): Builder {
+            return setGuildLocaleProvider(lazyOf(locale))
+        }
+
+        private fun setGuildLocaleProvider(provider: Lazy<DiscordLocale>): Builder {
+            this.guildLocaleProvider = provider
+            return this
+        }
+
+        fun setUserLocaleProvider(provider: UserLocaleProvider, interaction: Interaction): Builder {
+            return setUserLocaleProvider(lazy { provider.getDiscordLocale(interaction) })
+        }
+
+        fun setUserLocale(locale: DiscordLocale): Builder {
+            return setUserLocaleProvider(lazyOf(locale))
+        }
+
+        private fun setUserLocaleProvider(provider: Lazy<DiscordLocale>): Builder {
+            this.userLocaleProvider = provider
+            return this
+        }
+
+        fun build(): AppLocalizationContext {
+            return LocalizationContextImpl(localizationService, bundleName, prefix, guildLocaleProvider, userLocaleProvider)
+        }
+    }
+
     companion object {
         @JvmStatic
         @JvmOverloads
@@ -167,8 +212,8 @@ interface LocalizationContext {
                 context.getService<LocalizationService>(),
                 localizationBundle,
                 localizationPrefix,
-                guildLocale,
-                userLocale
+                guildLocale?.toProvider(),
+                userLocale?.toProvider()
             )
         }
 
@@ -185,8 +230,8 @@ interface LocalizationContext {
                 localizationService,
                 localizationBundle,
                 localizationPrefix,
-                guildLocale,
-                userLocale
+                guildLocale?.toProvider(),
+                userLocale?.toProvider()
             )
         }
 
@@ -202,8 +247,8 @@ interface LocalizationContext {
                 context.getService<LocalizationService>(),
                 localizationBundle,
                 localizationPrefix,
-                context.getService<GuildLocaleProvider>().getDiscordLocale(event),
-                context.getService<UserLocaleProvider>().getDiscordLocale(event),
+                lazy { context.getService<GuildLocaleProvider>().getDiscordLocale(event) },
+                lazy { context.getService<UserLocaleProvider>().getDiscordLocale(event) },
             )
         }
 
@@ -220,10 +265,20 @@ interface LocalizationContext {
                 context.getService<LocalizationService>(),
                 localizationBundle,
                 localizationPrefix,
-                context.getService<TextCommandLocaleProvider>().getDiscordLocale(event),
-                userLocale,
+                lazy { context.getService<TextCommandLocaleProvider>().getDiscordLocale(event) },
+                userLocale?.toProvider(),
             )
         }
+
+        fun builder(context: BContext, localizationBundle: String): Builder {
+            return Builder(localizationService = context.getService(), localizationBundle)
+        }
+
+        fun builder(localizationService: LocalizationService, localizationBundle: String): Builder {
+            return Builder(localizationService, localizationBundle)
+        }
+
+        private fun DiscordLocale.toProvider(): Lazy<DiscordLocale> = lazyOf(this)
     }
 }
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
@@ -201,6 +201,7 @@ interface LocalizationContext {
     companion object {
         @JvmStatic
         @JvmOverloads
+        @Deprecated("Replaced by builder")
         fun create(
             context: BContext,
             localizationBundle: String,
@@ -219,6 +220,7 @@ interface LocalizationContext {
 
         @JvmStatic
         @JvmOverloads
+        @Deprecated("Replaced by builder")
         fun create(
             localizationService: LocalizationService,
             localizationBundle: String,
@@ -237,6 +239,7 @@ interface LocalizationContext {
 
         @JvmStatic
         @JvmOverloads
+        @Deprecated("Replaced by builder")
         fun fromLocaleProviders(
             context: BContext,
             event: Interaction,
@@ -254,6 +257,7 @@ interface LocalizationContext {
 
         @JvmStatic
         @JvmOverloads
+        @Deprecated("Replaced by builder")
         fun fromLocaleProviders(
             context: BContext,
             event: MessageReceivedEvent,

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/TextLocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/TextLocalizationContext.kt
@@ -20,14 +20,14 @@ import javax.annotation.CheckReturnValue
  *
  * ### Manual usage
  * While instances of this interface are primarily injected with [@LocalizationBundle][LocalizationBundle],
- * you can also construct instances of this interface with [LocalizationContext.create].
+ * you can also construct instances of this interface with [LocalizationContext.builder].
  *
  * Instances are only injectable if the event is a subclass of either [Interaction] or [MessageReceivedEvent].
  *
  * @see guildLocale
  * @see AppLocalizationContext
  *
- * @see LocalizationContext.create
+ * @see LocalizationContext.builder
  */
 interface TextLocalizationContext : LocalizationContext {
     /**

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/LocalizationContextImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/LocalizationContextImpl.kt
@@ -14,19 +14,25 @@ internal class LocalizationContextImpl(
     private val localizationService: LocalizationService,
     override val localizationBundle: String,
     override val localizationPrefix: String?,
-    private val _guildLocale: DiscordLocale?,
-    private val _userLocale: DiscordLocale?
+    private val _guildLocaleProvider: Lazy<DiscordLocale>?,
+    private val _userLocaleProvider: Lazy<DiscordLocale>?,
 ) : TextLocalizationContext, AppLocalizationContext {
+    private val guildLocaleProvider: Lazy<DiscordLocale>
+        get() = _guildLocaleProvider ?: throwArgument("Cannot guild localize on an event which doesn't provide guild localization")
+
+    private val userLocaleProvider: Lazy<DiscordLocale>
+        get() = _userLocaleProvider ?: throwArgument("Cannot user localize on an event which doesn't provide user localization")
+
     override val userLocale: DiscordLocale
-        get() = _userLocale ?: throwArgument("Cannot user localize on an event which doesn't provide user localization")
+        get() = guildLocaleProvider.value
 
     override val guildLocale: DiscordLocale
-        get() = _guildLocale ?: throwArgument("Cannot guild localize on an event which doesn't provide guild localization")
+        get() = userLocaleProvider.value
 
     override val effectiveLocale: DiscordLocale
         get() = when {
-            _userLocale != null -> _userLocale
-            hasGuildLocale() -> guildLocale
+            _userLocaleProvider != null -> userLocale
+            _guildLocaleProvider != null -> guildLocale
             else -> DiscordLocale.ENGLISH_US
         }
 
@@ -38,27 +44,27 @@ internal class LocalizationContextImpl(
     }
 
     override fun withGuildLocale(guildLocale: DiscordLocale?): LocalizationContextImpl {
-        return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, guildLocale, _userLocale)
+        return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, guildLocale?.toProvider(), _userLocaleProvider)
     }
 
     override fun withUserLocale(userLocale: DiscordLocale?): LocalizationContextImpl {
-        return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, _guildLocale, userLocale)
+        return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, _guildLocaleProvider, userLocale?.toProvider())
     }
 
     override fun withBundle(localizationBundle: String): LocalizationContextImpl {
-        return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, _guildLocale, _userLocale)
+        return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, _guildLocaleProvider, _userLocaleProvider)
     }
 
     override fun withPrefix(localizationPrefix: String?): LocalizationContextImpl {
-        return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, _guildLocale, _userLocale)
+        return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, _guildLocaleProvider, _userLocaleProvider)
     }
 
     override fun switchBundle(localizationBundle: String): LocalizationContextImpl {
-        return LocalizationContextImpl(localizationService, localizationBundle, null, _guildLocale, _userLocale)
+        return LocalizationContextImpl(localizationService, localizationBundle, null, _guildLocaleProvider, _userLocaleProvider)
     }
 
     fun withLocales(guildLocale: DiscordLocale, userLocale: DiscordLocale): LocalizationContextImpl {
-        return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, guildLocale, userLocale)
+        return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, lazyOf(guildLocale), lazyOf(userLocale))
     }
 
     override fun localize(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): String {
@@ -83,6 +89,8 @@ internal class LocalizationContextImpl(
             ?: throwInternal("Found no localization instance for bundle '$localizationBundle' and locale '$discordLocale', the root bundle should have been checked")
 
     override fun hasGuildLocale(): Boolean {
-        return _guildLocale != null
+        return _guildLocaleProvider != null
     }
+
+    private fun DiscordLocale.toProvider(): Lazy<DiscordLocale> = lazyOf(this)
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/LocalizableInteractionImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/LocalizableInteractionImpl.kt
@@ -34,13 +34,11 @@ internal class LocalizableInteractionImpl internal constructor(
     private val guildLocale: Locale by lazy { guildLocaleProvider.getLocale(deferrableCallback) }
 
     override fun getLocalizationContext(bundleName: String, pathPrefix: String?): AppLocalizationContext {
-        return LocalizationContext.create(
-            localizationService,
-            bundleName,
-            pathPrefix,
-            guildLocale = guildLocaleProvider.getDiscordLocale(deferrableCallback),
-            userLocale = userLocaleProvider.getDiscordLocale(deferrableCallback)
-        )
+        return LocalizationContext.builder(localizationService, bundleName)
+            .setPrefix(pathPrefix)
+            .setGuildLocaleProvider(guildLocaleProvider, deferrableCallback)
+            .setUserLocaleProvider(userLocaleProvider, deferrableCallback)
+            .build()
     }
 
     @Suppress("DEPRECATION", "removal")

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/text/LocalizableTextCommandImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/text/LocalizableTextCommandImpl.kt
@@ -29,12 +29,10 @@ internal class LocalizableTextCommandImpl internal constructor(
     private val locale: Locale by lazy { localeProvider.getLocale(event) }
 
     override fun getLocalizationContext(bundleName: String, pathPrefix: String?): TextLocalizationContext {
-        return LocalizationContext.create(
-            localizationService,
-            bundleName,
-            pathPrefix,
-            guildLocale = localeProvider.getDiscordLocale(event)
-        )
+        return LocalizationContext.builder(localizationService, bundleName)
+            .setPrefix(pathPrefix)
+            .setGuildLocaleProvider(localeProvider, event)
+            .build()
     }
 
     @Suppress("DEPRECATION", "removal")

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/localization/LocalizationContextResolverFactories.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/localization/LocalizationContextResolverFactories.kt
@@ -74,8 +74,8 @@ internal object LocalizationContextResolverFactories {
             localizationService,
             localizationBundle = annotation.value,
             localizationPrefix = annotation.prefix.nullIfBlank(),
-            _guildLocale = null,
-            _userLocale = null
+            _guildLocaleProvider = null,
+            _userLocaleProvider = null,
         )
     }
 }


### PR DESCRIPTION
## Deprecations
- Deprecated `LocalizationContext.create`, `fromLocaleProviders`

## Additions
- Added `LocalizationContext.builder`

## Changes
- Locales are lazily evaluated