### PR TITLE
Prefer using `Locale` instead of `DiscordLocale`, and deprecate such usages

### DIFF
--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/LocalizableAction.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/LocalizableAction.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.localization
 
-import io.github.freya022.botcommands.api.core.config.BLocalizationConfig
 import io.github.freya022.botcommands.api.core.messages.BotCommandsMessages
 import io.github.freya022.botcommands.api.core.messages.BotCommandsMessagesFactory
 import io.github.freya022.botcommands.api.localization.context.LocalizationContext
@@ -102,6 +101,7 @@ interface LocalizableAction {
      * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
      * - If the template requires an argument that was not passed to [entries]
      */
+    @Deprecated("Pass a Locale instead")
     fun getLocalizedMessage(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): String =
         getLocalizedMessage(locale.toLocale(), localizationPath, *entries)
 }
@@ -109,5 +109,7 @@ interface LocalizableAction {
 fun LocalizableAction.getLocalizedMessage(locale: Locale, localizationPath: String, vararg entries: PairEntry): String =
     getLocalizedMessage(locale, localizationPath, *entries.mapToEntries())
 
+@Suppress("DEPRECATION")
+@Deprecated("Pass a Locale instead")
 fun LocalizableAction.getLocalizedMessage(locale: DiscordLocale, localizationPath: String, vararg entries: PairEntry): String =
     getLocalizedMessage(locale, localizationPath, *entries.mapToEntries())

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/AppLocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/AppLocalizationContext.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.github.freya022.botcommands.api.localization.context
 
 import io.github.freya022.botcommands.api.localization.Localization
@@ -6,6 +8,7 @@ import io.github.freya022.botcommands.api.localization.interaction.GuildLocalePr
 import io.github.freya022.botcommands.api.localization.interaction.UserLocaleProvider
 import net.dv8tion.jda.api.interactions.DiscordLocale
 import net.dv8tion.jda.api.interactions.Interaction
+import java.util.*
 import javax.annotation.CheckReturnValue
 
 /**
@@ -42,8 +45,12 @@ interface AppLocalizationContext : TextLocalizationContext {
     //User locale is always provided in interactions
     val userLocale: DiscordLocale
 
+    @Deprecated("Use the Locale overload")
     @CheckReturnValue
     override fun withGuildLocale(guildLocale: DiscordLocale?): AppLocalizationContext
+
+    @CheckReturnValue
+    override fun withGuildLocale(guildLocale: Locale?): AppLocalizationContext
 
     @CheckReturnValue
     override fun withBundle(localizationBundle: String): AppLocalizationContext

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/AppLocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/AppLocalizationContext.kt
@@ -43,7 +43,7 @@ interface AppLocalizationContext : TextLocalizationContext {
      * @see withUserLocale
      */
     //User locale is always provided in interactions
-    val userLocale: DiscordLocale
+    val userLocale: Locale
 
     @Deprecated("Use the Locale overload")
     @CheckReturnValue

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.github.freya022.botcommands.api.localization.context
 
 import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
@@ -26,6 +28,7 @@ import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import java.util.*
 import javax.annotation.CheckReturnValue
 
 typealias PairEntry = Pair<String, Any>
@@ -74,8 +77,26 @@ interface LocalizationContext {
      *
      * @param guildLocale The guild locale to use, or `null` to remove it
      */
+    @Deprecated("Use the Locale overload")
     @CheckReturnValue
     fun withGuildLocale(guildLocale: DiscordLocale?): TextLocalizationContext
+
+    /**
+     * Returns a new [TextLocalizationContext] with the specified guild locale.
+     *
+     * @param guildLocale The guild locale to use, or `null` to remove it
+     */
+    @CheckReturnValue
+    fun withGuildLocale(guildLocale: Locale?): TextLocalizationContext
+
+    /**
+     * Returns a new [AppLocalizationContext] with the specified user locale.
+     *
+     * @param userLocale The user locale to use, or `null` to remove it
+     */
+    @Deprecated("Use the Locale overload")
+    @CheckReturnValue
+    fun withUserLocale(userLocale: DiscordLocale?): AppLocalizationContext
 
     /**
      * Returns a new [AppLocalizationContext] with the specified user locale.
@@ -83,7 +104,7 @@ interface LocalizationContext {
      * @param userLocale The user locale to use, or `null` to remove it
      */
     @CheckReturnValue
-    fun withUserLocale(userLocale: DiscordLocale?): AppLocalizationContext
+    fun withUserLocale(userLocale: Locale?): AppLocalizationContext
 
     /**
      * Returns a new localization context with the specified localization bundle.
@@ -118,7 +139,19 @@ interface LocalizationContext {
      * prefixed with [localizationPrefix][LocalizationContext.localizationPrefix] unless starting with `/`
      * @param entries          The entries to fill the template with
      */
+    @Deprecated("Use the Locale overload")
     fun localize(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): String
+        = localize(locale.toLocale(), localizationPath, *entries)
+
+    /**
+     * Localizes the provided path, with the provided locale.
+     *
+     * @param locale           The [Locale] to use when fetching the localization bundle
+     * @param localizationPath The path of the localization template,
+     * prefixed with [localizationPrefix][LocalizationContext.localizationPrefix] unless starting with `/`
+     * @param entries          The entries to fill the template with
+     */
+    fun localize(locale: Locale, localizationPath: String, vararg entries: Localization.Entry): String
 
     /**
      * Localizes the provided path, with the provided locale, or returns `null` if the path does not exist.
@@ -128,7 +161,19 @@ interface LocalizationContext {
      * prefixed with [localizationPrefix][LocalizationContext.localizationPrefix] unless starting with `/`
      * @param entries          The entries to fill the template with
      */
+    @Deprecated("Use the Locale overload")
     fun localizeOrNull(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): String?
+        = localizeOrNull(locale.toLocale(), localizationPath, *entries)
+
+    /**
+     * Localizes the provided path, with the provided locale, or returns `null` if the path does not exist.
+     *
+     * @param locale           The [Locale] to use when fetching the localization bundle
+     * @param localizationPath The path of the localization template,
+     * prefixed with [localizationPrefix][LocalizationContext.localizationPrefix] unless starting with `/`
+     * @param entries          The entries to fill the template with
+     */
+    fun localizeOrNull(locale: Locale, localizationPath: String, vararg entries: Localization.Entry): String?
 
     /**
      * Localizes the provided path, with the [best locale][effectiveLocale] available.
@@ -153,8 +198,8 @@ interface LocalizationContext {
 
     class Builder internal constructor(private val localizationService: LocalizationService, private val bundleName: String) {
         private var prefix: String? = null
-        private var guildLocaleProvider: Lazy<DiscordLocale>? = null
-        private var userLocaleProvider: Lazy<DiscordLocale>? = null
+        private var guildLocaleProvider: Lazy<Locale>? = null
+        private var userLocaleProvider: Lazy<Locale>? = null
 
         /**
          * Sets the prefix of the context.
@@ -170,24 +215,24 @@ interface LocalizationContext {
          * Sets the guild locale to be provided by the passed [GuildLocaleProvider].
          */
         fun setGuildLocaleProvider(provider: GuildLocaleProvider, interaction: Interaction): Builder {
-            return setGuildLocaleProvider(lazy { provider.getDiscordLocale(interaction) })
+            return setGuildLocaleProvider(lazy { provider.getLocale(interaction) })
         }
 
         /**
          * Sets the guild locale to be provided by the passed [TextCommandLocaleProvider].
          */
         fun setGuildLocaleProvider(provider: TextCommandLocaleProvider, event: MessageReceivedEvent): Builder {
-            return setGuildLocaleProvider(lazy { provider.getDiscordLocale(event) })
+            return setGuildLocaleProvider(lazy { provider.getLocale(event) })
         }
 
         /**
          * Sets the guild locale to the provided one.
          */
-        fun setGuildLocale(locale: DiscordLocale): Builder {
+        fun setGuildLocale(locale: Locale): Builder {
             return setGuildLocaleProvider(lazyOf(locale))
         }
 
-        private fun setGuildLocaleProvider(provider: Lazy<DiscordLocale>): Builder {
+        private fun setGuildLocaleProvider(provider: Lazy<Locale>): Builder {
             this.guildLocaleProvider = provider
             return this
         }
@@ -196,17 +241,17 @@ interface LocalizationContext {
          * Sets the user locale to be provided by the passed [UserLocaleProvider].
          */
         fun setUserLocaleProvider(provider: UserLocaleProvider, interaction: Interaction): Builder {
-            return setUserLocaleProvider(lazy { provider.getDiscordLocale(interaction) })
+            return setUserLocaleProvider(lazy { provider.getLocale(interaction) })
         }
 
         /**
          * Sets the user locale to the provided one.
          */
-        fun setUserLocale(locale: DiscordLocale): Builder {
+        fun setUserLocale(locale: Locale): Builder {
             return setUserLocaleProvider(lazyOf(locale))
         }
 
-        private fun setUserLocaleProvider(provider: Lazy<DiscordLocale>): Builder {
+        private fun setUserLocaleProvider(provider: Lazy<Locale>): Builder {
             this.userLocaleProvider = provider
             return this
         }
@@ -273,8 +318,8 @@ interface LocalizationContext {
                 context.getService<LocalizationService>(),
                 localizationBundle,
                 localizationPrefix,
-                lazy { context.getService<GuildLocaleProvider>().getDiscordLocale(event) },
-                lazy { context.getService<UserLocaleProvider>().getDiscordLocale(event) },
+                lazy { context.getService<GuildLocaleProvider>().getLocale(event) },
+                lazy { context.getService<UserLocaleProvider>().getLocale(event) },
             )
         }
 
@@ -292,7 +337,7 @@ interface LocalizationContext {
                 context.getService<LocalizationService>(),
                 localizationBundle,
                 localizationPrefix,
-                lazy { context.getService<TextCommandLocaleProvider>().getDiscordLocale(event) },
+                lazy { context.getService<TextCommandLocaleProvider>().getLocale(event) },
                 userLocale?.toProvider(),
             )
         }
@@ -315,7 +360,7 @@ interface LocalizationContext {
             return Builder(localizationService, localizationBundle)
         }
 
-        private fun DiscordLocale.toProvider(): Lazy<DiscordLocale> = lazyOf(this)
+        private fun DiscordLocale.toProvider(): Lazy<Locale> = lazyOf(this.toLocale())
     }
 }
 
@@ -331,7 +376,19 @@ internal fun Array<out PairEntry>.mapToEntries() = Array(this.size) {
  * prefixed with [localizationPrefix][LocalizationContext.localizationPrefix] unless starting with `/`
  * @param entries          The entries to fill the template with
  */
+@Deprecated("Use the Locale overload")
 fun LocalizationContext.localize(locale: DiscordLocale, localizationPath: String, vararg entries: PairEntry): String =
+    localize(locale, localizationPath, *entries.mapToEntries())
+
+/**
+ * Localizes the provided path, with the provided locale.
+ *
+ * @param locale           The [Locale] to use when fetching the localization bundle
+ * @param localizationPath The path of the localization template,
+ * prefixed with [localizationPrefix][LocalizationContext.localizationPrefix] unless starting with `/`
+ * @param entries          The entries to fill the template with
+ */
+fun LocalizationContext.localize(locale: Locale, localizationPath: String, vararg entries: PairEntry): String =
     localize(locale, localizationPath, *entries.mapToEntries())
 
 /**
@@ -342,7 +399,19 @@ fun LocalizationContext.localize(locale: DiscordLocale, localizationPath: String
  * prefixed with [localizationPrefix][LocalizationContext.localizationPrefix] unless starting with `/`
  * @param entries          The entries to fill the template with
  */
+@Deprecated("Use the Locale overload")
 fun LocalizationContext.localizeOrNull(locale: DiscordLocale, localizationPath: String, vararg entries: PairEntry): String? =
+    localizeOrNull(locale, localizationPath, *entries.mapToEntries())
+
+/**
+ * Localizes the provided path, with the provided locale, or returns `null` if the path does not exist.
+ *
+ * @param locale           The [Locale] to use when fetching the localization bundle
+ * @param localizationPath The path of the localization template,
+ * prefixed with [localizationPrefix][LocalizationContext.localizationPrefix] unless starting with `/`
+ * @param entries          The entries to fill the template with
+ */
+fun LocalizationContext.localizeOrNull(locale: Locale, localizationPath: String, vararg entries: PairEntry): String? =
     localizeOrNull(locale, localizationPath, *entries.mapToEntries())
 
 /**

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/LocalizationContext.kt
@@ -48,9 +48,9 @@ interface LocalizationContext {
      * The locale used when no locale is specified, the best locale is picked in this order:
      * - The [user locale][Interaction.getUserLocale]
      * - The [guild locale][Guild.getLocale]
-     * - The default locale ([DiscordLocale.ENGLISH_US])
+     * - The default locale ([Locale.US])
      */
-    val effectiveLocale: DiscordLocale
+    val effectiveLocale: Locale
 
     /**
      * Returns the localization bundle of the current context.

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/TextLocalizationContext.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/context/TextLocalizationContext.kt
@@ -5,8 +5,8 @@ import io.github.freya022.botcommands.api.localization.annotations.LocalizationB
 import io.github.freya022.botcommands.api.localization.interaction.GuildLocaleProvider
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
-import net.dv8tion.jda.api.interactions.DiscordLocale
 import net.dv8tion.jda.api.interactions.Interaction
+import java.util.*
 import javax.annotation.CheckReturnValue
 
 /**
@@ -43,18 +43,18 @@ interface TextLocalizationContext : LocalizationContext {
     fun hasGuildLocale(): Boolean
 
     /**
-     * Returns the [DiscordLocale] of the guild.
+     * Returns the [Locale] of the guild.
      *
      * The locale can either come from the [GuildLocaleProvider] or from a [withGuildLocale].
      *
-     * @return the [DiscordLocale] of the guild
+     * @return the [Locale] of the guild
      *
      * @throws IllegalStateException If the event did not happen in a Guild and the guild locale was not supplied
      *
      * @see hasGuildLocale
      * @see withGuildLocale
      */
-    val guildLocale: DiscordLocale
+    val guildLocale: Locale
 
     @CheckReturnValue
     override fun withBundle(localizationBundle: String): TextLocalizationContext

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/GuildLocaleProvider.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/GuildLocaleProvider.kt
@@ -26,8 +26,10 @@ import java.util.*
  */
 @InterfacedService(acceptMultiple = false)
 interface GuildLocaleProvider {
+    @Deprecated("Use 'getLocale' instead, use 'DiscordLocale.from' / 'DiscordLocale#toLocale' if necessary")
     fun getDiscordLocale(interaction: Interaction): DiscordLocale
 
+    @Suppress("DEPRECATION")
     fun getLocale(interaction: Interaction): Locale =
         getDiscordLocale(interaction).toLocale()
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/LocalizableEditCallback.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/LocalizableEditCallback.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.localization.interaction
 
-import io.github.freya022.botcommands.api.core.config.BLocalizationConfig
 import io.github.freya022.botcommands.api.localization.Localization
 import io.github.freya022.botcommands.api.localization.context.PairEntry
 import io.github.freya022.botcommands.api.localization.context.mapToEntries
@@ -95,6 +94,7 @@ interface LocalizableEditCallback {
      * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
      * - If the template requires an argument that was not passed to [entries]
      */
+    @Deprecated("Pass a Locale instead")
     @CheckReturnValue
     fun editLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): MessageEditCallbackAction =
         editLocalized(locale.toLocale(), localizationPath, *entries)
@@ -201,6 +201,8 @@ fun LocalizableEditCallback.editGuild(localizationPath: String, vararg entries: 
  * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
  * - If the template requires an argument that was not passed to [entries]
  */
+@Suppress("DEPRECATION")
+@Deprecated("Pass a Locale instead")
 fun LocalizableEditCallback.editLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: PairEntry) =
     editLocalized(locale, localizationPath, *entries.mapToEntries())
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/LocalizableInteraction.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/LocalizableInteraction.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.localization.interaction
 
-import io.github.freya022.botcommands.api.core.config.BLocalizationConfig
 import io.github.freya022.botcommands.api.localization.LocalizableAction
 import io.github.freya022.botcommands.api.localization.Localization
 import io.github.freya022.botcommands.api.localization.context.AppLocalizationContext
@@ -33,7 +32,7 @@ interface LocalizableInteraction : LocalizableAction {
 
     /**
      * Returns a localization context for the provided bundle name and path prefix,
-     * using the locales from [UserLocaleProvider.getDiscordLocale] and [GuildLocaleProvider.getDiscordLocale].
+     * using the locales from [UserLocaleProvider] and [GuildLocaleProvider].
      */
     override fun getLocalizationContext(bundleName: String, pathPrefix: String?): AppLocalizationContext
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/LocalizableInteractionHook.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/LocalizableInteractionHook.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.localization.interaction
 
-import io.github.freya022.botcommands.api.core.config.BLocalizationConfig
 import io.github.freya022.botcommands.api.localization.Localization
 import io.github.freya022.botcommands.api.localization.context.PairEntry
 import io.github.freya022.botcommands.api.localization.context.mapToEntries
@@ -101,6 +100,7 @@ interface LocalizableInteractionHook : InteractionHook {
      * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
      * - If the template requires an argument that was not passed to [entries]
      */
+    @Deprecated("Pass a Locale instead")
     @CheckReturnValue
     fun sendLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): WebhookMessageCreateAction<Message> =
         sendLocalized(locale.toLocale(), localizationPath, *entries)
@@ -202,6 +202,7 @@ interface LocalizableInteractionHook : InteractionHook {
      * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
      * - If the template requires an argument that was not passed to [entries]
      */
+    @Deprecated("Pass a Locale instead")
     @CheckReturnValue
     fun editLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): WebhookMessageEditAction<Message> =
         editLocalized(locale.toLocale(), localizationPath, *entries)
@@ -304,6 +305,8 @@ fun LocalizableInteractionHook.sendGuild(localizationPath: String, vararg entrie
  * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
  * - If the template requires an argument that was not passed to [entries]
  */
+@Suppress("DEPRECATION")
+@Deprecated("Pass a Locale instead")
 fun LocalizableInteractionHook.sendLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: PairEntry) =
     sendLocalized(locale, localizationPath, *entries.mapToEntries())
 
@@ -404,6 +407,8 @@ fun LocalizableInteractionHook.editGuild(localizationPath: String, vararg entrie
  * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
  * - If the template requires an argument that was not passed to [entries]
  */
+@Suppress("DEPRECATION")
+@Deprecated("Pass a Locale instead")
 fun LocalizableInteractionHook.editLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: PairEntry) =
     editLocalized(locale, localizationPath, *entries.mapToEntries())
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/LocalizableReplyCallback.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/LocalizableReplyCallback.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.localization.interaction
 
-import io.github.freya022.botcommands.api.core.config.BLocalizationConfig
 import io.github.freya022.botcommands.api.localization.Localization
 import io.github.freya022.botcommands.api.localization.context.PairEntry
 import io.github.freya022.botcommands.api.localization.context.mapToEntries
@@ -95,6 +94,7 @@ interface LocalizableReplyCallback {
      * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
      * - If the template requires an argument that was not passed to [entries]
      */
+    @Deprecated("Pass a Locale instead")
     @CheckReturnValue
     fun replyLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): ReplyCallbackAction =
         replyLocalized(locale.toLocale(), localizationPath, *entries)
@@ -201,6 +201,8 @@ fun LocalizableReplyCallback.replyGuild(localizationPath: String, vararg entries
  * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
  * - If the template requires an argument that was not passed to [entries]
  */
+@Suppress("DEPRECATION")
+@Deprecated("Pass a Locale instead")
 fun LocalizableReplyCallback.replyLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: PairEntry) =
     replyLocalized(locale, localizationPath, *entries.mapToEntries())
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/UserLocaleProvider.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/interaction/UserLocaleProvider.kt
@@ -24,8 +24,10 @@ import java.util.*
  */
 @InterfacedService(acceptMultiple = false)
 interface UserLocaleProvider {
+    @Deprecated("Use 'getLocale' instead, use 'DiscordLocale.from' / 'DiscordLocale#toLocale' if necessary")
     fun getDiscordLocale(interaction: Interaction): DiscordLocale
 
+    @Suppress("DEPRECATION")
     fun getLocale(interaction: Interaction): Locale =
         getDiscordLocale(interaction).toLocale()
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/text/LocalizableTextCommand.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/text/LocalizableTextCommand.kt
@@ -136,6 +136,7 @@ interface LocalizableTextCommand : LocalizableAction {
      * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
      * - If the template requires an argument that was not passed to [entries]
      */
+    @Deprecated("Pass a Locale instead")
     @CheckReturnValue
     fun respondLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): MessageCreateAction =
         respondLocalized(locale.toLocale(), localizationPath, *entries)
@@ -161,6 +162,7 @@ interface LocalizableTextCommand : LocalizableAction {
      * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
      * - If the template requires an argument that was not passed to [entries]
      */
+    @Deprecated("Pass a Locale instead")
     @CheckReturnValue
     fun replyLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): MessageCreateAction =
         replyLocalized(locale.toLocale(), localizationPath, *entries)
@@ -319,6 +321,8 @@ fun LocalizableTextCommand.replyGuild(localizationPath: String, vararg entries: 
  * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
  * - If the template requires an argument that was not passed to [entries]
  */
+@Suppress("DEPRECATION")
+@Deprecated("Pass a Locale instead")
 fun LocalizableTextCommand.respondLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: PairEntry) =
     respondLocalized(locale, localizationPath, *entries.mapToEntries())
 
@@ -343,6 +347,8 @@ fun LocalizableTextCommand.respondLocalized(locale: DiscordLocale, localizationP
  * - No [registered bundle][BLocalizationConfig.responseBundles] containing the path could be found
  * - If the template requires an argument that was not passed to [entries]
  */
+@Suppress("DEPRECATION")
+@Deprecated("Pass a Locale instead")
 fun LocalizableTextCommand.replyLocalized(locale: DiscordLocale, localizationPath: String, vararg entries: PairEntry) =
     replyLocalized(locale, localizationPath, *entries.mapToEntries())
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/text/LocalizableTextCommand.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/text/LocalizableTextCommand.kt
@@ -1,6 +1,5 @@
 package io.github.freya022.botcommands.api.localization.text
 
-import io.github.freya022.botcommands.api.core.config.BLocalizationConfig
 import io.github.freya022.botcommands.api.localization.LocalizableAction
 import io.github.freya022.botcommands.api.localization.Localization
 import io.github.freya022.botcommands.api.localization.context.PairEntry
@@ -29,7 +28,7 @@ import javax.annotation.CheckReturnValue
 interface LocalizableTextCommand : LocalizableAction {
     /**
      * Returns a localization context for the provided bundle name and path prefix,
-     * using the locale from [TextCommandLocaleProvider.getDiscordLocale].
+     * using the locale from [TextCommandLocaleProvider].
      */
     override fun getLocalizationContext(bundleName: String, pathPrefix: String?): TextLocalizationContext
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/text/TextCommandLocaleProvider.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/localization/text/TextCommandLocaleProvider.kt
@@ -24,8 +24,10 @@ import java.util.*
  */
 @InterfacedService(acceptMultiple = false)
 interface TextCommandLocaleProvider {
+    @Deprecated("Use 'getLocale' instead, use 'DiscordLocale.from' / 'DiscordLocale#toLocale' if necessary")
     fun getDiscordLocale(event: MessageReceivedEvent): DiscordLocale
 
+    @Suppress("DEPRECATION")
     fun getLocale(event: MessageReceivedEvent): Locale =
         getDiscordLocale(event).toLocale()
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/LocalizationContextImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/LocalizationContextImpl.kt
@@ -23,23 +23,17 @@ internal class LocalizationContextImpl(
     private val userLocaleProvider: Lazy<Locale>
         get() = _userLocaleProvider ?: throwArgument("Cannot user localize on an event which doesn't provide user localization")
 
-    private val userJavaLocale: Locale
+    override val userLocale: Locale
         get() = userLocaleProvider.value
 
-    private val guildJavaLocale: Locale
+    override val guildLocale: Locale
         get() = guildLocaleProvider.value
 
-    override val userLocale: DiscordLocale
-        get() = DiscordLocale.from(userJavaLocale)
-
-    override val guildLocale: DiscordLocale
-        get() = DiscordLocale.from(guildJavaLocale)
-
-    override val effectiveLocale: DiscordLocale
+    override val effectiveLocale: Locale
         get() = when {
             _userLocaleProvider != null -> userLocale
             _guildLocaleProvider != null -> guildLocale
-            else -> DiscordLocale.ENGLISH_US
+            else -> Locale.US
         }
 
     init {

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/LocalizationContextImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/LocalizationContextImpl.kt
@@ -14,20 +14,26 @@ internal class LocalizationContextImpl(
     private val localizationService: LocalizationService,
     override val localizationBundle: String,
     override val localizationPrefix: String?,
-    private val _guildLocaleProvider: Lazy<DiscordLocale>?,
-    private val _userLocaleProvider: Lazy<DiscordLocale>?,
+    private val _guildLocaleProvider: Lazy<Locale>?,
+    private val _userLocaleProvider: Lazy<Locale>?,
 ) : TextLocalizationContext, AppLocalizationContext {
-    private val guildLocaleProvider: Lazy<DiscordLocale>
+    private val guildLocaleProvider: Lazy<Locale>
         get() = _guildLocaleProvider ?: throwArgument("Cannot guild localize on an event which doesn't provide guild localization")
 
-    private val userLocaleProvider: Lazy<DiscordLocale>
+    private val userLocaleProvider: Lazy<Locale>
         get() = _userLocaleProvider ?: throwArgument("Cannot user localize on an event which doesn't provide user localization")
 
-    override val userLocale: DiscordLocale
+    private val userJavaLocale: Locale
+        get() = userLocaleProvider.value
+
+    private val guildJavaLocale: Locale
         get() = guildLocaleProvider.value
 
+    override val userLocale: DiscordLocale
+        get() = DiscordLocale.from(userJavaLocale)
+
     override val guildLocale: DiscordLocale
-        get() = userLocaleProvider.value
+        get() = DiscordLocale.from(guildJavaLocale)
 
     override val effectiveLocale: DiscordLocale
         get() = when {
@@ -43,11 +49,19 @@ internal class LocalizationContextImpl(
         }
     }
 
-    override fun withGuildLocale(guildLocale: DiscordLocale?): LocalizationContextImpl {
+    @Deprecated("Use the Locale overload")
+    override fun withGuildLocale(guildLocale: DiscordLocale?): LocalizationContextImpl =
+        withGuildLocale(guildLocale?.toLocale())
+
+    override fun withGuildLocale(guildLocale: Locale?): LocalizationContextImpl {
         return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, guildLocale?.toProvider(), _userLocaleProvider)
     }
 
-    override fun withUserLocale(userLocale: DiscordLocale?): LocalizationContextImpl {
+    @Deprecated("Use the Locale overload")
+    override fun withUserLocale(userLocale: DiscordLocale?): LocalizationContextImpl =
+        withUserLocale(userLocale?.toLocale())
+
+    override fun withUserLocale(userLocale: Locale?): LocalizationContextImpl {
         return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, _guildLocaleProvider, userLocale?.toProvider())
     }
 
@@ -63,11 +77,11 @@ internal class LocalizationContextImpl(
         return LocalizationContextImpl(localizationService, localizationBundle, null, _guildLocaleProvider, _userLocaleProvider)
     }
 
-    fun withLocales(guildLocale: DiscordLocale, userLocale: DiscordLocale): LocalizationContextImpl {
+    internal fun withLocales(guildLocale: Locale, userLocale: Locale): LocalizationContextImpl {
         return LocalizationContextImpl(localizationService, localizationBundle, localizationPrefix, lazyOf(guildLocale), lazyOf(userLocale))
     }
 
-    override fun localize(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): String {
+    override fun localize(locale: Locale, localizationPath: String, vararg entries: Localization.Entry): String {
         val localization = getLocalization(locale)
         val effectivePath = LocalizationUtils.getEffectivePath(localizationPrefix, localizationPath)
         val template = localization[effectivePath]
@@ -76,7 +90,7 @@ internal class LocalizationContextImpl(
         return template.localize(*entries)
     }
 
-    override fun localizeOrNull(locale: DiscordLocale, localizationPath: String, vararg entries: Localization.Entry): String? {
+    override fun localizeOrNull(locale: Locale, localizationPath: String, vararg entries: Localization.Entry): String? {
         val localization = getLocalization(locale)
         val effectivePath = LocalizationUtils.getEffectivePath(localizationPrefix, localizationPath)
         val template = localization[effectivePath] ?: return null
@@ -84,13 +98,13 @@ internal class LocalizationContextImpl(
         return template.localize(*entries)
     }
 
-    private fun getLocalization(discordLocale: DiscordLocale) =
-        localizationService.getInstance(localizationBundle, discordLocale.toLocale())
+    private fun getLocalization(discordLocale: Locale) =
+        localizationService.getInstance(localizationBundle, discordLocale)
             ?: throwInternal("Found no localization instance for bundle '$localizationBundle' and locale '$discordLocale', the root bundle should have been checked")
 
     override fun hasGuildLocale(): Boolean {
         return _guildLocaleProvider != null
     }
 
-    private fun DiscordLocale.toProvider(): Lazy<DiscordLocale> = lazyOf(this)
+    private fun Locale.toProvider(): Lazy<Locale> = lazyOf(this)
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/autoconfigure/DefaultGuildLocaleProvider.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/autoconfigure/DefaultGuildLocaleProvider.kt
@@ -3,8 +3,12 @@ package io.github.freya022.botcommands.internal.localization.interaction.autocon
 import io.github.freya022.botcommands.api.localization.interaction.GuildLocaleProvider
 import net.dv8tion.jda.api.interactions.DiscordLocale
 import net.dv8tion.jda.api.interactions.Interaction
+import java.util.*
 
 internal object DefaultGuildLocaleProvider : GuildLocaleProvider {
 
+    @Deprecated("Use 'getLocale' instead, use 'DiscordLocale.from' / 'DiscordLocale#toLocale' if necessary")
     override fun getDiscordLocale(interaction: Interaction): DiscordLocale = interaction.guildLocale
+
+    override fun getLocale(interaction: Interaction): Locale = interaction.guildLocale.toLocale()
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/autoconfigure/DefaultUserLocaleProvider.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/interaction/autoconfigure/DefaultUserLocaleProvider.kt
@@ -3,8 +3,12 @@ package io.github.freya022.botcommands.internal.localization.interaction.autocon
 import io.github.freya022.botcommands.api.localization.interaction.UserLocaleProvider
 import net.dv8tion.jda.api.interactions.DiscordLocale
 import net.dv8tion.jda.api.interactions.Interaction
+import java.util.*
 
 internal object DefaultUserLocaleProvider : UserLocaleProvider {
 
+    @Deprecated("Use 'getLocale' instead, use 'DiscordLocale.from' / 'DiscordLocale#toLocale' if necessary")
     override fun getDiscordLocale(interaction: Interaction): DiscordLocale = interaction.userLocale
+
+    override fun getLocale(interaction: Interaction): Locale = interaction.userLocale.toLocale()
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/text/autoconfigure/DefaultTextCommandLocaleProvider.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/localization/text/autoconfigure/DefaultTextCommandLocaleProvider.kt
@@ -3,8 +3,12 @@ package io.github.freya022.botcommands.internal.localization.text.autoconfigure
 import io.github.freya022.botcommands.api.localization.text.TextCommandLocaleProvider
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.interactions.DiscordLocale
+import java.util.*
 
 internal object DefaultTextCommandLocaleProvider : TextCommandLocaleProvider {
 
+    @Deprecated("Use 'getLocale' instead, use 'DiscordLocale.from' / 'DiscordLocale#toLocale' if necessary")
     override fun getDiscordLocale(event: MessageReceivedEvent): DiscordLocale = event.guild.locale
+
+    override fun getLocale(event: MessageReceivedEvent): Locale = event.guild.locale.toLocale()
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/localization/LocalizationContextResolvers.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/parameters/resolvers/localization/LocalizationContextResolvers.kt
@@ -24,7 +24,7 @@ internal class AppLocalizationContextResolver(
 
     override suspend fun resolveSuspend(option: Option, event: Event): AppLocalizationContext {
         return when (event) {
-            is Interaction -> baseContext.withLocales(guildLocaleProvider.getDiscordLocale(event), userLocaleProvider.getDiscordLocale(event))
+            is Interaction -> baseContext.withLocales(guildLocaleProvider.getLocale(event), userLocaleProvider.getLocale(event))
             //MessageReceivedEvent does not provide user locale
             else -> throwInternal("Unsupported event type for ${classRef<AppLocalizationContext>()}: ${event.javaClass.name}")
         }
@@ -41,9 +41,9 @@ internal class TextLocalizationContextResolver(
 
     override suspend fun resolveSuspend(option: Option, event: Event): TextLocalizationContext {
         return when (event) {
-            is Interaction -> baseContext.withLocales(guildLocaleProvider.getDiscordLocale(event), userLocaleProvider.getDiscordLocale(event))
+            is Interaction -> baseContext.withLocales(guildLocaleProvider.getLocale(event), userLocaleProvider.getLocale(event))
             is MessageReceivedEvent -> when {
-                event.isFromGuild -> baseContext.withGuildLocale(textCommandLocaleProvider.getDiscordLocale(event))
+                event.isFromGuild -> baseContext.withGuildLocale(textCommandLocaleProvider.getLocale(event))
                 else -> baseContext
             }
             else -> throwInternal("Unsupported event type for ${classRef<TextLocalizationContext>()}: ${event.javaClass.name}")

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashLocalization.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashLocalization.kt
@@ -22,9 +22,9 @@ import io.github.freya022.botcommands.api.modals.Modals
 import io.github.freya022.botcommands.api.modals.annotations.RequiresModals
 import io.github.freya022.botcommands.api.modals.create
 import net.dv8tion.jda.api.components.textinput.TextInputStyle
-import net.dv8tion.jda.api.interactions.DiscordLocale
 import net.dv8tion.jda.api.utils.TimeFormat
 import java.lang.management.ManagementFactory
+import java.util.*
 import kotlin.time.Duration.Companion.milliseconds
 
 @Command
@@ -52,7 +52,7 @@ class SlashLocalization {
                 "uptime" to 3.141519
             ),
             ctx.localize(
-                DiscordLocale.GERMAN,
+                Locale.GERMAN,
                 localizationPath = "response",
                 "guild_users" to event.guild.memberCount,
                 "uptime" to 3.141519
@@ -95,7 +95,7 @@ class SlashLocalization {
             }
             val customLocaleButton = buttons.primary("Custom locale").ephemeral {
                 bindTo { buttonEvent ->
-                    buttonEvent.replyLocalized(DiscordLocale.GERMAN, "commands.localization.response", *customData)
+                    buttonEvent.replyLocalized(Locale.GERMAN, "commands.localization.response", *customData)
                         .setEphemeral(true)
                         .queue()
                 }
@@ -117,7 +117,7 @@ class SlashLocalization {
                     modalEvent.replyUser("response", *userData).setEphemeral(true).queue()
                     modalEvent.hook.editUser("response", *userData).queue()
                     modalEvent.hook.editGuild("response", *guildData).queue()
-                    modalEvent.hook.editLocalized(DiscordLocale.GERMAN, "response", *customData).queue()
+                    modalEvent.hook.editLocalized(Locale.GERMAN, "response", *customData).queue()
                 }
             }
 
@@ -127,7 +127,7 @@ class SlashLocalization {
                     when (selectEvent.values.single()) {
                         "user" -> selectEvent.replyUser("response", *userData)
                         "guild" -> selectEvent.replyGuild("response", *guildData)
-                        "custom" -> selectEvent.replyLocalized(DiscordLocale.GERMAN, "response", *customData)
+                        "custom" -> selectEvent.replyLocalized(Locale.GERMAN, "response", *customData)
                         else -> throw AssertionError()
                     }.setEphemeral(true).queue()
                 }
@@ -149,10 +149,10 @@ class SlashLocalization {
             .queue()
         event.hook.editGuild("response", *guildData).queue()
 
-        event.hook.sendLocalized(DiscordLocale.GERMAN, "response", *customData)
+        event.hook.sendLocalized(Locale.GERMAN, "response", *customData)
             .setEphemeral(true)
             .queue()
-        event.hook.editLocalized(DiscordLocale.GERMAN, "response", *customData).queue()
+        event.hook.editLocalized(Locale.GERMAN, "response", *customData).queue()
     }
 
     private val userData get() = arrayOf("guild_users" to 20, "uptime" to uptime)

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextLocalization.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/text/TextLocalization.kt
@@ -5,7 +5,7 @@ import io.github.freya022.botcommands.api.commands.text.BaseCommandEvent
 import io.github.freya022.botcommands.api.commands.text.annotations.JDATextCommandVariation
 import io.github.freya022.botcommands.api.localization.text.replyGuild
 import io.github.freya022.botcommands.api.localization.text.respondLocalized
-import net.dv8tion.jda.api.interactions.DiscordLocale
+import java.util.*
 
 @Command
 class TextLocalization {
@@ -14,6 +14,6 @@ class TextLocalization {
         event.localizationPrefix = "commands.localization"
 
         event.replyGuild("response", "guild_users" to event.guild.memberCount, "uptime" to 3.141519).queue()
-        event.respondLocalized(DiscordLocale.GERMAN, "response", "guild_users" to event.guild.memberCount, "uptime" to 3.141519).queue()
+        event.respondLocalized(Locale.GERMAN, "response", "guild_users" to event.guild.memberCount, "uptime" to 3.141519).queue()
     }
 }


### PR DESCRIPTION
As mapping `Locale` between `DiscordLocale` is not perfect, and the underlying localization is using `Locale`, getting messages should be using `Locale`. Implicit convertions should be avoided, so methods using `DiscordLocale` are deprecated.

If you wish to continue using `DiscordLocale`, you will have to use `toLocale()`.

Commands are still localized using `DiscordLocale`, any feature that is limited to the locales Discord supports, should use `DiscordLocale`.

## Breaking changes
- `AppLocalizationContext.userLocale` now returns `Locale`
- `TextLocalizationContext.guildLocale` now returns `Locale`
- `LocalizationContext.effectiveLocale` now returns `Locale`

## Deprecations
- `getDiscordLocale` was deprecated in all locale providers (`UserLocaleProvider`, `GuildLocaleProvider`, `TextCommandLocaleProvider`)
- Deprecated all reply/edit methods accepting `DiscordLocale`

## Additions
- Added new overloads accepting `Locale`