### PR TITLE
Publish empty Javadoc JARs for snapshots

### DIFF
--- a/buildSrc/src/main/kotlin/dev/freya02/botcommands/plugins/PublishedProjectEnvironmentConfig.kt
+++ b/buildSrc/src/main/kotlin/dev/freya02/botcommands/plugins/PublishedProjectEnvironmentConfig.kt
@@ -87,8 +87,10 @@ abstract class PublishedProjectEnvironmentConfig(
         }
 
         project.extensions.configure<MavenPublishBaseExtension>("mavenPublishing") {
-            // Publish empty JAR if the project has no API, and thus no docs
-            if (dokkaExtension == null) {
+            // Publish empty JAR
+            // if the project has no API, and thus no docs,
+            // or, we are publishing a snapshot (wasted disk space and CI time imo)
+            if (dokkaExtension == null || canPublishSnapshot) {
                 configure(KotlinJvm(javadocJar = JavadocJar.Empty()))
             }
 


### PR DESCRIPTION
Publishing them for snapshots is a waste of disk and CI time