### PR TITLE
Add file type filtering in slash command attachment options and modal attachment uploads

### DIFF
--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/FileTypes.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/FileTypes.kt
@@ -1,0 +1,27 @@
+package io.github.freya022.botcommands.api.commands.application.slash.annotations
+
+/**
+ * Sets the desired file types accepted by an [Attachment][net.dv8tion.jda.api.entities.Message.Attachment] [@SlashOption][SlashOption].
+ *
+ * @see net.dv8tion.jda.api.interactions.FileType FileType
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FileTypes(
+    /**
+     * Extensions to filter for.
+     */
+    vararg val extensions: String,
+    /**
+     * Accepts any kind of image file supported by the Discord client.
+     */
+    val image: Boolean = false,
+    /**
+     * Accepts any kind of video file supported by the Discord client.
+     */
+    val video: Boolean = false,
+    /**
+     * Accepts any kind of audio file supported by the Discord client.
+     */
+    val audio: Boolean = false,
+)

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/FileTypes.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/annotations/FileTypes.kt
@@ -9,7 +9,9 @@ package io.github.freya022.botcommands.api.commands.application.slash.annotation
 @Retention(AnnotationRetention.RUNTIME)
 annotation class FileTypes(
     /**
-     * Extensions to filter for.
+     * Extensions to filter for. Must match `[\w\-.]+`.
+     *
+     * Examples: `zip`, `tar.zst`
      */
     vararg val extensions: String,
     /**

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/SlashCommandOption.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/SlashCommandOption.kt
@@ -58,6 +58,8 @@ interface SlashCommandOption : ApplicationCommandOption {
 
     /**
      * The file types this [Attachment][net.dv8tion.jda.api.entities.Message.Attachment] option is accepting, if it is one.
+     *
+     * If empty, all file types are accepted.
      */
     val fileTypes: List<FileType>
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/SlashCommandOption.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/SlashCommandOption.kt
@@ -4,6 +4,7 @@ import io.github.freya022.botcommands.api.commands.application.LengthRange
 import io.github.freya022.botcommands.api.commands.application.ValueRange
 import io.github.freya022.botcommands.api.commands.application.options.ApplicationCommandOption
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
+import net.dv8tion.jda.api.interactions.FileType
 import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.interactions.commands.OptionType
 
@@ -54,6 +55,11 @@ interface SlashCommandOption : ApplicationCommandOption {
      * as their resolver's [option type][SlashParameterResolver.optionType].
      */
     val length: LengthRange?
+
+    /**
+     * The file types this [Attachment][net.dv8tion.jda.api.entities.Message.Attachment] option is accepting, if it is one.
+     */
+    val fileTypes: List<FileType>
 
     /**
      * Whether this option uses autocomplete

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/builder/SlashCommandOptionBuilder.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/builder/SlashCommandOptionBuilder.kt
@@ -91,12 +91,16 @@ interface SlashCommandOptionBuilder : ApplicationCommandOptionBuilder {
      * The file types this [Attachment][net.dv8tion.jda.api.entities.Message.Attachment] option is accepting, if it is one;
      * up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES].
      *
+     * The extensions must match `[\w\-.]+`. For example: `zip`, `tar.zst`.
+     *
      * @see FileType
      */
     val fileTypes: FileTypeAccumulator
 
     /**
      * Adds up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     *
+     * The extensions must match `[\w\-.]+`. For example: `zip`, `tar.zst`.
      *
      * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
      *
@@ -111,6 +115,8 @@ interface SlashCommandOptionBuilder : ApplicationCommandOptionBuilder {
 
     /**
      * Adds up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     *
+     * The extensions must match `[\w\-.]+`. For example: `zip`, `tar.zst`.
      *
      * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
      *
@@ -127,6 +133,8 @@ interface SlashCommandOptionBuilder : ApplicationCommandOptionBuilder {
      * Sets up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
      * Leave the arguments empty to remove file type filtering.
      *
+     * The extensions must match `[\w\-.]+`. For example: `zip`, `tar.zst`.
+     *
      * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
      *
      * @throws IllegalArgumentException There are more than [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] extensions,
@@ -142,6 +150,8 @@ interface SlashCommandOptionBuilder : ApplicationCommandOptionBuilder {
     /**
      * Sets up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
      * Leave the arguments empty to remove file type filtering.
+     *
+     * The extensions must match `[\w\-.]+`. For example: `zip`, `tar.zst`.
      *
      * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
      *

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/builder/SlashCommandOptionBuilder.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/commands/application/slash/options/builder/SlashCommandOptionBuilder.kt
@@ -13,6 +13,8 @@ import io.github.freya022.botcommands.api.commands.application.slash.autocomplet
 import io.github.freya022.botcommands.api.core.config.BApplicationConfigBuilder
 import io.github.freya022.botcommands.api.parameters.resolvers.SlashParameterResolver
 import io.github.freya022.botcommands.internal.core.annotations.SkipJavaReflectionOverload
+import net.dv8tion.jda.api.interactions.FileType
+import net.dv8tion.jda.api.interactions.IFilterableFileTypes
 import net.dv8tion.jda.api.interactions.commands.Command.Choice
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFunction
@@ -86,6 +88,74 @@ interface SlashCommandOptionBuilder : ApplicationCommandOptionBuilder {
     var lengthRange: LengthRange?
 
     /**
+     * The file types this [Attachment][net.dv8tion.jda.api.entities.Message.Attachment] option is accepting, if it is one;
+     * up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES].
+     *
+     * @see FileType
+     */
+    val fileTypes: FileTypeAccumulator
+
+    /**
+     * Adds up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     *
+     * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
+     *
+     * @throws IllegalArgumentException There are more than [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] extensions,
+     *                                  or, an extension is empty or isn't alphanumeric
+     *
+     * @see FileType
+     */
+    fun addFileTypeExtensions(extensions: List<String>) {
+        fileTypes += extensions
+    }
+
+    /**
+     * Adds up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     *
+     * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
+     *
+     * @throws IllegalArgumentException There are more than [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] extensions,
+     *                                  or, an extension is empty or isn't alphanumeric
+     *
+     * @see FileType
+     */
+    fun addFileTypeExtensions(vararg extensions: String) {
+        fileTypes += extensions.asList()
+    }
+
+    /**
+     * Sets up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     * Leave the arguments empty to remove file type filtering.
+     *
+     * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
+     *
+     * @throws IllegalArgumentException There are more than [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] extensions,
+     *                                  or, an extension is empty or isn't alphanumeric
+     *
+     * @see FileType
+     */
+    fun setFileTypeExtensions(extensions: List<String>) {
+        fileTypes.clear()
+        fileTypes += extensions
+    }
+
+    /**
+     * Sets up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     * Leave the arguments empty to remove file type filtering.
+     *
+     * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
+     *
+     * @throws IllegalArgumentException There are more than [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] extensions,
+     *                                  or, an extension is empty or isn't alphanumeric
+     *
+     * @see FileType
+     */
+    fun setFileTypeExtensions(vararg extensions: String) {
+        fileTypes.clear()
+        fileTypes += extensions.asList()
+    }
+
+    /**
      * Uses an existing autocomplete handler with the specified [name][AutocompleteHandler.name].
      *
      * Must match an autocomplete handler created from a named [@AutocompleteHandler][AutocompleteHandler]
@@ -103,4 +173,37 @@ interface SlashCommandOptionBuilder : ApplicationCommandOptionBuilder {
      */
     @SkipJavaReflectionOverload
     fun autocompleteByFunction(function: KFunction<Collection<Any>>)
+
+    class FileTypeAccumulator internal constructor() {
+        internal val list: List<FileType>
+            field = arrayListOf<FileType>()
+
+        @JvmName("plusAssignExtensions")
+        operator fun plusAssign(extensions: Collection<String>) {
+            require(list.size + extensions.size <= OptionData.MAX_FILE_TYPES) {
+                "Cannot filter with more than ${OptionData.MAX_FILE_TYPES} file types"
+            }
+            list += extensions.map(FileType::ofExtension)
+        }
+
+        operator fun plusAssign(extension: String) {
+            this += listOf(extension)
+        }
+
+        @JvmName("plusAssignFileTypes")
+        operator fun plusAssign(extensions: Collection<FileType>) {
+            require(list.size + extensions.size <= OptionData.MAX_FILE_TYPES) {
+                "Cannot filter with more than ${OptionData.MAX_FILE_TYPES} file types"
+            }
+            list += extensions
+        }
+
+        operator fun plusAssign(extension: FileType) {
+            this += listOf(extension)
+        }
+
+        fun clear() {
+            list.clear()
+        }
+    }
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/SlashCommandAutoBuilder.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/autobuilder/SlashCommandAutoBuilder.kt
@@ -41,6 +41,7 @@ import io.github.freya022.botcommands.internal.parameters.ResolverContainer
 import io.github.freya022.botcommands.internal.utils.*
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.nonInstanceParameters
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.interactions.FileType
 import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.commands.Command as JDACommand
 import kotlin.reflect.KClass
@@ -361,6 +362,16 @@ internal class SlashCommandAutoBuilder(
         parameter.findAnnotation<LongRange>()?.let { range -> valueRange = ValueRange.ofLong(range.from, range.to) }
         parameter.findAnnotation<DoubleRange>()?.let { range -> valueRange = ValueRange.ofDouble(range.from, range.to) }
         parameter.findAnnotation<Length>()?.let { length -> lengthRange = LengthRange.of(length.min, length.max) }
+
+        parameter.findAnnotation<FileTypes>()?.let { fileTypes ->
+            if (fileTypes.image)
+                this.fileTypes += FileType.IMAGE
+            if (fileTypes.video)
+                this.fileTypes += FileType.VIDEO
+            if (fileTypes.audio)
+                this.fileTypes += FileType.AUDIO
+            this.fileTypes += fileTypes.extensions.asList()
+        }
 
         processAutocomplete(optionAnnotation)
 

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashUtils.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/SlashUtils.kt
@@ -138,6 +138,8 @@ internal object SlashUtils {
             }
         }
 
+        data.setFileTypes(option.fileTypes)
+
         data.isRequired = option.isRequired
     }
 }

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandOptionImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/SlashCommandOptionImpl.kt
@@ -9,6 +9,7 @@ import io.github.freya022.botcommands.internal.commands.application.slash.autoco
 import io.github.freya022.botcommands.internal.commands.application.slash.options.builder.SlashCommandOptionBuilderImpl
 import io.github.freya022.botcommands.internal.utils.LocalizationUtils
 import io.github.freya022.botcommands.internal.utils.classRef
+import net.dv8tion.jda.api.interactions.FileType
 import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.interactions.commands.OptionType
 
@@ -35,6 +36,7 @@ internal class SlashCommandOptionImpl internal constructor(
     override val choices: List<Command.Choice>? = optionBuilder.choices
     override val range: ValueRange? = optionBuilder.valueRange
     override val length: LengthRange? = optionBuilder.lengthRange
+    override val fileTypes: List<FileType> = optionBuilder.fileTypes.list
 
     init {
         choices?.forEach {

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/builder/SlashCommandOptionBuilderImpl.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/commands/application/slash/options/builder/SlashCommandOptionBuilderImpl.kt
@@ -13,7 +13,9 @@ import io.github.freya022.botcommands.internal.commands.application.slash.builde
 import io.github.freya022.botcommands.internal.parameters.OptionParameter
 import io.github.freya022.botcommands.internal.utils.shortSignatureNoSrc
 import io.github.freya022.botcommands.internal.utils.throwArgument
+import net.dv8tion.jda.api.interactions.FileType
 import net.dv8tion.jda.api.interactions.commands.Command
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import kotlin.reflect.KFunction
 
 internal class SlashCommandOptionBuilderImpl internal constructor(
@@ -52,6 +54,8 @@ internal class SlashCommandOptionBuilderImpl internal constructor(
     override var valueRange: ValueRange? = null
 
     override var lengthRange: LengthRange? = null
+
+    override val fileTypes = SlashCommandOptionBuilder.FileTypeAccumulator()
 
     internal var autocompleteInfo: AutocompleteInfoImpl? = null
         private set

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/components/AttachmentUpload.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/components/AttachmentUpload.kt
@@ -53,12 +53,16 @@ class InlineAttachmentUpload(
     /**
      * The file types this attachment upload is accepting, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES].
      *
+     * The extensions must match `[\w\-.]+`. For example: `zip`, `tar.zst`.
+     *
      * @see FileType
      */
     val fileTypes = FileTypeAccumulator()
 
     /**
      * Adds up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     *
+     * The extensions must match `[\w\-.]+`. For example: `zip`, `tar.zst`.
      *
      * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
      *
@@ -73,6 +77,8 @@ class InlineAttachmentUpload(
 
     /**
      * Adds up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     *
+     * The extensions must match `[\w\-.]+`. For example: `zip`, `tar.zst`.
      *
      * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
      *
@@ -89,6 +95,8 @@ class InlineAttachmentUpload(
      * Sets up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
      * Leave the arguments empty to remove file type filtering.
      *
+     * The extensions must match `[\w\-.]+`. For example: `zip`, `tar.zst`.
+     *
      * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
      *
      * @throws IllegalArgumentException There are more than [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] extensions,
@@ -104,6 +112,8 @@ class InlineAttachmentUpload(
     /**
      * Sets up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
      * Leave the arguments empty to remove file type filtering.
+     *
+     * The extensions must match `[\w\-.]+`. For example: `zip`, `tar.zst`.
      *
      * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
      *

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/components/AttachmentUpload.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/components/AttachmentUpload.kt
@@ -2,6 +2,8 @@ package dev.freya02.botcommands.jda.ktx.components
 
 import net.dv8tion.jda.api.components.Component
 import net.dv8tion.jda.api.components.attachmentupload.AttachmentUpload
+import net.dv8tion.jda.api.interactions.FileType
+import net.dv8tion.jda.api.interactions.IFilterableFileTypes
 
 class InlineAttachmentUpload(
     val builder: AttachmentUpload.Builder,
@@ -48,26 +50,119 @@ class InlineAttachmentUpload(
             builder.setMaxValues(value)
         }
 
+    /**
+     * The file types this attachment upload is accepting, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES].
+     *
+     * @see FileType
+     */
+    val fileTypes = FileTypeAccumulator()
+
+    /**
+     * Adds up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     *
+     * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
+     *
+     * @throws IllegalArgumentException There are more than [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] extensions,
+     *                                  or, an extension is empty or isn't alphanumeric
+     *
+     * @see FileType
+     */
+    fun addFileTypeExtensions(extensions: List<String>) {
+        fileTypes += extensions
+    }
+
+    /**
+     * Adds up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     *
+     * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
+     *
+     * @throws IllegalArgumentException There are more than [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] extensions,
+     *                                  or, an extension is empty or isn't alphanumeric
+     *
+     * @see FileType
+     */
+    fun addFileTypeExtensions(vararg extensions: String) {
+        fileTypes += extensions.asList()
+    }
+
+    /**
+     * Sets up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     * Leave the arguments empty to remove file type filtering.
+     *
+     * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
+     *
+     * @throws IllegalArgumentException There are more than [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] extensions,
+     *                                  or, an extension is empty or isn't alphanumeric
+     *
+     * @see FileType
+     */
+    fun setFileTypeExtensions(extensions: List<String>) {
+        fileTypes.clear()
+        fileTypes += extensions
+    }
+
+    /**
+     * Sets up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] file extensions to filter for.
+     * Leave the arguments empty to remove file type filtering.
+     *
+     * @param  extensions The extensions, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
+     *
+     * @throws IllegalArgumentException There are more than [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES] extensions,
+     *                                  or, an extension is empty or isn't alphanumeric
+     *
+     * @see FileType
+     */
+    fun setFileTypeExtensions(vararg extensions: String) {
+        fileTypes.clear()
+        fileTypes += extensions.asList()
+    }
+
     /** See [AttachmentUpload.Builder.build] */
     fun build(): AttachmentUpload {
         return builder.build()
+    }
+
+    inner class FileTypeAccumulator {
+        @JvmName("plusAssignExtensions")
+        operator fun plusAssign(extensions: Collection<String>) {
+            builder.addFileTypeExtensions(extensions)
+        }
+
+        operator fun plusAssign(extension: String) {
+            builder.addFileTypeExtensions(extension)
+        }
+
+        @JvmName("plusAssignFileTypes")
+        operator fun plusAssign(extensions: Collection<FileType>) {
+            builder.addFileTypes(extensions)
+        }
+
+        operator fun plusAssign(extension: FileType) {
+            builder.addFileTypes(extension)
+        }
+
+        fun clear() {
+            builder.setFileTypes()
+        }
     }
 }
 
 /**
  * Component accepting files from users, see [AttachmentUpload][net.dv8tion.jda.api.components.attachmentupload.AttachmentUpload].
  *
- * @param customId The custom ID of the input, see [AttachmentUpload.Builder.setCustomId]
- * @param uniqueId Unique identifier of this component, see [Component.withUniqueId]
- * @param required Whether the user must upload files, see [AttachmentUpload.Builder.setRequired]
- * @param range    Minimum and maximum amount of files a user can send, see [AttachmentUpload.Builder.setRequiredRange]
- * @param block    Lambda allowing further configuration
+ * @param customId  The custom ID of the input, see [AttachmentUpload.Builder.setCustomId]
+ * @param uniqueId  Unique identifier of this component, see [Component.withUniqueId]
+ * @param required  Whether the user must upload files, see [AttachmentUpload.Builder.setRequired]
+ * @param range     Minimum and maximum amount of files a user can send, see [AttachmentUpload.Builder.setRequiredRange]
+ * @param fileTypes The file types to accept, up to [MAX_FILE_TYPES][IFilterableFileTypes.MAX_FILE_TYPES]
+ * @param block     Lambda allowing further configuration
  */
 inline fun AttachmentUpload(
     customId: String,
     uniqueId: Int = -1,
     required: Boolean = true,
     range: IntRange? = null,
+    fileTypes: Collection<FileType> = emptyList(),
     block: InlineAttachmentUpload.() -> Unit = {},
 ): AttachmentUpload {
     return AttachmentUpload.create(customId)
@@ -79,6 +174,7 @@ inline fun AttachmentUpload(
                 this.required = false
             if (range != null)
                 this.range = range
+            this.fileTypes += fileTypes
             block()
         }
         .build()

--- a/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashFileTypes.kt
+++ b/test-bot/src/test/kotlin/dev/freya02/botcommands/bot/commands/slash/SlashFileTypes.kt
@@ -1,0 +1,55 @@
+package dev.freya02.botcommands.bot.commands.slash
+
+import dev.freya02.botcommands.jda.ktx.components.AttachmentUpload
+import dev.freya02.botcommands.jda.ktx.messages.reply_
+import io.github.freya022.botcommands.api.commands.annotations.Command
+import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandManager
+import io.github.freya022.botcommands.api.commands.application.provider.GlobalApplicationCommandProvider
+import io.github.freya022.botcommands.api.commands.application.slash.GuildSlashEvent
+import io.github.freya022.botcommands.api.core.utils.enumSetOf
+import io.github.freya022.botcommands.api.modals.Modals
+import io.github.freya022.botcommands.api.modals.create
+import net.dv8tion.jda.api.entities.Message.Attachment
+import net.dv8tion.jda.api.interactions.FileType
+import net.dv8tion.jda.api.interactions.IntegrationType
+import net.dv8tion.jda.api.interactions.InteractionContextType
+
+@Command
+class SlashFileTypes(
+    private val modals: Modals
+) : GlobalApplicationCommandProvider {
+
+    fun onSlashFileTypesModal(event: GuildSlashEvent) {
+        event.replyModal(modals.create("File types") {
+            label("JSON") {
+                child = AttachmentUpload("json") {
+                    fileTypes += "json"
+                }
+            }
+
+            bindTo { modalEvent ->
+                val jsonAttachment = modalEvent.getValue("json")!!.asAttachmentList.first()
+                modalEvent.reply_("File size: ${jsonAttachment.size}", ephemeral = true).queue()
+            }
+        }).queue()
+    }
+
+    fun onSlashFileTypesJson(event: GuildSlashEvent, jsonAttachment: Attachment) {
+        event.reply_("File size: ${jsonAttachment.size}", ephemeral = true).queue()
+    }
+
+    override fun declareGlobalApplicationCommands(manager: GlobalApplicationCommandManager) {
+        manager.slashCommand("file_types", function = null) {
+            integrationTypes = enumSetOf(IntegrationType.USER_INSTALL)
+            contexts = enumSetOf(InteractionContextType.GUILD)
+
+            subcommand("modal", ::onSlashFileTypesModal)
+
+            subcommand("json", ::onSlashFileTypesJson) {
+                option("jsonAttachment", optionName = "json") {
+                    fileTypes += "json"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR enables slash commands options to accept attachments with specific extensions or media type (image, video, audio ; the list of extensions implied by these is not documented on purpose). A property on the jda-ktx `AttachmentUpload` builder has also been added.

Depends on https://github.com/discord-jda/JDA/pull/3113.

## New features
- Added `@FileTypes`, accepts extensions and/or switches for certain media types
- Added a `fileTypes` property to declarative slash command option builders, example:
  - `fileTypes += "json"`
  - `fileTypes += FileType.IMAGE`
- Added a `fileTypes` property to the `AttachmentUpload` DSL, it is used the same as with slash commands