### PR TITLE
Check guild when retrieving a thread from a guild, add function to retrieve a thread from any guild

### DIFF
--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/Guild.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/Guild.kt
@@ -106,11 +106,12 @@ suspend fun Guild.retrieveVanityInviteOrNull(): VanityInvite? {
 }
 
 /**
- * Retrieves a thread by ID.
+ * Retrieves a thread belonging to this guild, by ID.
  *
  * The cached threads are checked first, and then a request is made.
  *
  * The [RestAction] may throw [InvalidChannelTypeException] if a channel with the ID was found, but isn't a thread.
+ * It may also throw [ParentGuildMismatchException] if the channel isn't from the same guild.
  *
  * @see Guild.retrieveThreadChannelByIdOrNull
  */
@@ -124,6 +125,10 @@ fun Guild.retrieveThreadChannelById(id: Long): CacheRestAction<ThreadChannel> {
                 if (!channelType.isThread)
                     throw InvalidChannelTypeException("Invalid channel type, expected a thread, got $channelType")
 
+                if (dataObject.getUnsignedLong("guild_id", 0) != this.idLong) {
+                    throw ParentGuildMismatchException("Thread $id is not from the same guild (expected ${this.id})")
+                }
+
                 (jda as JDAImpl).entityBuilder.createThreadChannel(this as GuildImpl, dataObject, this.idLong, false)
             }
         }
@@ -131,11 +136,12 @@ fun Guild.retrieveThreadChannelById(id: Long): CacheRestAction<ThreadChannel> {
 }
 
 /**
- * Retrieves a thread by ID.
+ * Retrieves a thread belonging to this guild, by ID.
  *
  * The cached threads are checked first, and then a request is made.
  *
  * The [RestAction] may throw [InvalidChannelTypeException] if a channel with the ID was found, but isn't a thread.
+ * It may also throw [ParentGuildMismatchException] if the channel isn't from the same guild.
  *
  * @see Guild.retrieveThreadChannelByIdOrNull
  */
@@ -144,14 +150,15 @@ fun Guild.retrieveThreadChannelById(id: String): CacheRestAction<ThreadChannel> 
 }
 
 /**
- * Retrieves a thread by ID.
+ * Retrieves a thread belonging to this guild, by ID.
  *
  * The cached threads are checked first, and then a request is made.
  *
- * The returned thread may be null if:
+ * The returned thread may be `null` if:
  * - It doesn't exist
  * - The bot doesn't have access to it
  * - The channel isn't a thread
+ * - The channel isn't from the correct guild
  *
  * @see Guild.retrieveThreadChannelById
  */
@@ -161,19 +168,22 @@ suspend fun Guild.retrieveThreadChannelByIdOrNull(id: Long): ThreadChannel? {
             retrieveThreadChannelById(id).await()
         } catch (_: InvalidChannelTypeException) {
             return null
+        } catch (_: ParentGuildMismatchException) {
+            return null
         }
     }
 }
 
 /**
- * Retrieves a thread by ID.
+ * Retrieves a thread belonging to this guild, by ID.
  *
  * The cached threads are checked first, and then a request is made.
  *
- * The returned thread may be null if:
+ * The returned thread may be `null` if:
  * - It doesn't exist
  * - The bot doesn't have access to it
  * - The channel isn't a thread
+ * - The channel isn't from the correct guild
  *
  * @see Guild.retrieveThreadChannelById
  */

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/Guild.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/Guild.kt
@@ -112,7 +112,7 @@ suspend fun Guild.retrieveVanityInviteOrNull(): VanityInvite? {
  *
  * The [RestAction] may throw [InvalidChannelTypeException] if a channel with the ID was found, but isn't a thread.
  *
- * @see retrieveThreadChannelByIdOrNull
+ * @see Guild.retrieveThreadChannelByIdOrNull
  */
 fun Guild.retrieveThreadChannelById(id: Long): CacheRestAction<ThreadChannel> {
     return jda.deferredRestAction(
@@ -137,7 +137,7 @@ fun Guild.retrieveThreadChannelById(id: Long): CacheRestAction<ThreadChannel> {
  *
  * The [RestAction] may throw [InvalidChannelTypeException] if a channel with the ID was found, but isn't a thread.
  *
- * @see retrieveThreadChannelByIdOrNull
+ * @see Guild.retrieveThreadChannelByIdOrNull
  */
 fun Guild.retrieveThreadChannelById(id: String): CacheRestAction<ThreadChannel> {
     return retrieveThreadChannelById(MiscUtil.parseSnowflake(id))
@@ -153,7 +153,7 @@ fun Guild.retrieveThreadChannelById(id: String): CacheRestAction<ThreadChannel> 
  * - The bot doesn't have access to it
  * - The channel isn't a thread
  *
- * @see retrieveThreadChannelById
+ * @see Guild.retrieveThreadChannelById
  */
 suspend fun Guild.retrieveThreadChannelByIdOrNull(id: Long): ThreadChannel? {
     return runIgnoringResponseOrNull(ErrorResponse.UNKNOWN_CHANNEL, ErrorResponse.MISSING_ACCESS) {
@@ -175,7 +175,7 @@ suspend fun Guild.retrieveThreadChannelByIdOrNull(id: Long): ThreadChannel? {
  * - The bot doesn't have access to it
  * - The channel isn't a thread
  *
- * @see retrieveThreadChannelById
+ * @see Guild.retrieveThreadChannelById
  */
 suspend fun Guild.retrieveThreadChannelByIdOrNull(id: String): ThreadChannel? {
     return retrieveThreadChannelByIdOrNull(MiscUtil.parseSnowflake(id))

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/Guild.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/Guild.kt
@@ -126,7 +126,7 @@ fun Guild.retrieveThreadChannelById(id: Long): CacheRestAction<ThreadChannel> {
                     throw InvalidChannelTypeException("Invalid channel type, expected a thread, got $channelType")
 
                 if (dataObject.getUnsignedLong("guild_id", 0) != this.idLong) {
-                    throw ParentGuildMismatchException("Thread $id is not from the same guild (expected ${this.id})")
+                    throw ParentGuildMismatchException("Thread is not from the same guild")
                 }
 
                 (jda as JDAImpl).entityBuilder.createThreadChannel(this as GuildImpl, dataObject, this.idLong, false)

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/GuildNotFoundException.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/GuildNotFoundException.kt
@@ -1,0 +1,6 @@
+package dev.freya02.botcommands.jda.ktx.retrieve
+
+/**
+ * Exception thrown when a guild was expected but not found, typically in sharded applications.
+ */
+class GuildNotFoundException internal constructor(message: String) : IllegalStateException(message)

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/InvalidChannelTypeException.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/InvalidChannelTypeException.kt
@@ -3,4 +3,4 @@ package dev.freya02.botcommands.jda.ktx.retrieve
 /**
  * Exception thrown when retrieving a channel by ID, but the type is incorrect.
  */
-class InvalidChannelTypeException(message: String) : IllegalArgumentException(message)
+class InvalidChannelTypeException internal constructor(message: String) : IllegalArgumentException(message)

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/InvalidChannelTypeException.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/InvalidChannelTypeException.kt
@@ -2,7 +2,5 @@ package dev.freya02.botcommands.jda.ktx.retrieve
 
 /**
  * Exception thrown when retrieving a channel by ID, but the type is incorrect.
- *
- * @see retrieveThreadChannelById
  */
 class InvalidChannelTypeException(message: String) : IllegalArgumentException(message)

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/JDA.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/JDA.kt
@@ -2,14 +2,23 @@ package dev.freya02.botcommands.jda.ktx.retrieve
 
 import dev.freya02.botcommands.jda.ktx.IgnoreForMatch
 import dev.freya02.botcommands.jda.ktx.coroutines.await
+import dev.freya02.botcommands.jda.ktx.deferredRestAction
 import dev.freya02.botcommands.jda.ktx.requests.runIgnoringResponseOrNull
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Entitlement
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.Webhook
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
 import net.dv8tion.jda.api.entities.sticker.StickerSnowflake
 import net.dv8tion.jda.api.entities.sticker.StickerUnion
 import net.dv8tion.jda.api.requests.ErrorResponse
+import net.dv8tion.jda.api.requests.RestAction
+import net.dv8tion.jda.api.requests.Route
+import net.dv8tion.jda.api.requests.restaction.CacheRestAction
+import net.dv8tion.jda.api.utils.MiscUtil
+import net.dv8tion.jda.internal.JDAImpl
+import net.dv8tion.jda.internal.requests.RestActionImpl
 
 /**
  * Retrieves a [User] with the provided ID.
@@ -106,4 +115,81 @@ suspend fun JDA.retrieveWebhookByIdOrNull(webhookId: Long): Webhook? {
     return runIgnoringResponseOrNull(ErrorResponse.UNKNOWN_WEBHOOK) {
         retrieveWebhookById(webhookId).await()
     }
+}
+
+/**
+ * Retrieves a thread from any guild, by ID.
+ *
+ * The cached threads are checked first, and then a request is made.
+ *
+ * The [RestAction] may throw [InvalidChannelTypeException] if a channel with the ID was found, but isn't a thread.
+ *
+ * @see JDA.retrieveThreadChannelByIdOrNull
+ */
+fun JDA.retrieveThreadChannelById(id: Long): CacheRestAction<ThreadChannel> {
+    return deferredRestAction(
+        valueSupplier = { getThreadChannelById(id) },
+        actionSupplier = {
+            RestActionImpl(this, Route.Channels.GET_CHANNEL.compile(id.toString())) { res, _ ->
+                val json = res.`object`
+                val channelType = json.getInt("type").let(ChannelType::fromId)
+                if (!channelType.isThread)
+                    throw InvalidChannelTypeException("Invalid channel type, expected a thread, got $channelType")
+
+                val guildId = json.getUnsignedLong("guild_id")
+                (this as JDAImpl).entityBuilder.createThreadChannel(null, json, guildId, false)
+            }
+        }
+    )
+}
+
+/**
+ * Retrieves a thread from any guild, by ID.
+ *
+ * The cached threads are checked first, and then a request is made.
+ *
+ * The [RestAction] may throw [InvalidChannelTypeException] if a channel with the ID was found, but isn't a thread.
+ *
+ * @see JDA.retrieveThreadChannelByIdOrNull
+ */
+fun JDA.retrieveThreadChannelById(id: String): CacheRestAction<ThreadChannel> {
+    return retrieveThreadChannelById(MiscUtil.parseSnowflake(id))
+}
+
+/**
+ * Retrieves a thread from any guild, by ID.
+ *
+ * The cached threads are checked first, and then a request is made.
+ *
+ * The returned thread may be `null` if:
+ * - It doesn't exist
+ * - The bot doesn't have access to it
+ * - The channel isn't a thread
+ *
+ * @see JDA.retrieveThreadChannelById
+ */
+suspend fun JDA.retrieveThreadChannelByIdOrNull(id: Long): ThreadChannel? {
+    return runIgnoringResponseOrNull(ErrorResponse.UNKNOWN_CHANNEL, ErrorResponse.MISSING_ACCESS) {
+        try {
+            retrieveThreadChannelById(id).await()
+        } catch (_: InvalidChannelTypeException) {
+            return null
+        }
+    }
+}
+
+/**
+ * Retrieves a thread from any guild, by ID.
+ *
+ * The cached threads are checked first, and then a request is made.
+ *
+ * The returned thread may be `null` if:
+ * - It doesn't exist
+ * - The bot doesn't have access to it
+ * - The channel isn't a thread
+ *
+ * @see JDA.retrieveThreadChannelById
+ */
+suspend fun JDA.retrieveThreadChannelByIdOrNull(id: String): ThreadChannel? {
+    return retrieveThreadChannelByIdOrNull(MiscUtil.parseSnowflake(id))
 }

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/JDA.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/JDA.kt
@@ -18,6 +18,7 @@ import net.dv8tion.jda.api.requests.Route
 import net.dv8tion.jda.api.requests.restaction.CacheRestAction
 import net.dv8tion.jda.api.utils.MiscUtil
 import net.dv8tion.jda.internal.JDAImpl
+import net.dv8tion.jda.internal.entities.GuildImpl
 import net.dv8tion.jda.internal.requests.RestActionImpl
 
 /**
@@ -123,6 +124,7 @@ suspend fun JDA.retrieveWebhookByIdOrNull(webhookId: Long): Webhook? {
  * The cached threads are checked first, and then a request is made.
  *
  * The [RestAction] may throw [InvalidChannelTypeException] if a channel with the ID was found, but isn't a thread.
+ * If the thread is not owned by the current shard, [GuildNotFoundException] is thrown.
  *
  * @see JDA.retrieveThreadChannelByIdOrNull
  */
@@ -137,7 +139,17 @@ fun JDA.retrieveThreadChannelById(id: Long): CacheRestAction<ThreadChannel> {
                     throw InvalidChannelTypeException("Invalid channel type, expected a thread, got $channelType")
 
                 val guildId = json.getUnsignedLong("guild_id")
-                (this as JDAImpl).entityBuilder.createThreadChannel(null, json, guildId, false)
+                val guild = getGuildById(guildId) ?: run {
+                    val expectedShard = (guildId shr 22) % shardInfo.shardTotal
+                    val actualShard = shardInfo.shardId
+                    if (expectedShard.toInt() == actualShard) {
+                        throw GuildNotFoundException("Thread $id was found but its guild was not found")
+                    } else {
+                        throw GuildNotFoundException("Thread $id was found but its guild was not found as it is from a different shard")
+                    }
+                }
+
+                (this as JDAImpl).entityBuilder.createThreadChannel(guild as GuildImpl, json, guildId, false)
             }
         }
     )
@@ -149,6 +161,7 @@ fun JDA.retrieveThreadChannelById(id: Long): CacheRestAction<ThreadChannel> {
  * The cached threads are checked first, and then a request is made.
  *
  * The [RestAction] may throw [InvalidChannelTypeException] if a channel with the ID was found, but isn't a thread.
+ * If the thread is not owned by the current shard, [GuildNotFoundException] is thrown.
  *
  * @see JDA.retrieveThreadChannelByIdOrNull
  */
@@ -165,6 +178,7 @@ fun JDA.retrieveThreadChannelById(id: String): CacheRestAction<ThreadChannel> {
  * - It doesn't exist
  * - The bot doesn't have access to it
  * - The channel isn't a thread
+ * - The thread isn't owned by a guild of this shard
  *
  * @see JDA.retrieveThreadChannelById
  */
@@ -187,6 +201,7 @@ suspend fun JDA.retrieveThreadChannelByIdOrNull(id: Long): ThreadChannel? {
  * - It doesn't exist
  * - The bot doesn't have access to it
  * - The channel isn't a thread
+ * - The thread isn't owned by a guild of this shard
  *
  * @see JDA.retrieveThreadChannelById
  */

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/JDA.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/JDA.kt
@@ -143,9 +143,9 @@ fun JDA.retrieveThreadChannelById(id: Long): CacheRestAction<ThreadChannel> {
                     val expectedShard = (guildId shr 22) % shardInfo.shardTotal
                     val actualShard = shardInfo.shardId
                     if (expectedShard.toInt() == actualShard) {
-                        throw GuildNotFoundException("Thread $id was found but its guild was not found")
+                        throw GuildNotFoundException("Thread was found but its guild was not found")
                     } else {
-                        throw GuildNotFoundException("Thread $id was found but its guild was not found as it is from a different shard")
+                        throw GuildNotFoundException("Thread was found but its guild was not found as it is from a different shard")
                     }
                 }
 

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/ParentGuildMismatchException.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/ParentGuildMismatchException.kt
@@ -1,0 +1,6 @@
+package dev.freya02.botcommands.jda.ktx.retrieve
+
+/**
+ * Exception thrown when retrieving a channel by ID from a guild, but their expected guild is incorrect.
+ */
+class ParentGuildMismatchException(message: String) : IllegalArgumentException(message)

--- a/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/ParentGuildMismatchException.kt
+++ b/BotCommands-jda-ktx/src/main/kotlin/dev/freya02/botcommands/jda/ktx/retrieve/ParentGuildMismatchException.kt
@@ -3,4 +3,4 @@ package dev.freya02.botcommands.jda.ktx.retrieve
 /**
  * Exception thrown when retrieving a channel by ID from a guild, but their expected guild is incorrect.
  */
-class ParentGuildMismatchException(message: String) : IllegalArgumentException(message)
+class ParentGuildMismatchException internal constructor(message: String) : IllegalArgumentException(message)


### PR DESCRIPTION
## Changes
- `Guild#retrieveThreadChannelById` now throws `ParentGuildMismatchException` if the retrieved thread isn't from the same guild
  - `OrNull` variants will return `null` in those cases

## New features
- `JDA#retrieveThreadChannelById(OrNull)` was added