### PR TITLE
Publish major-versioned docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,13 @@
-name: Deploy KDocs to Pages
+name: Check main branch KDocs
 
 on:
   push:
-    branches: ["3.X"]
+    branches:
+      - 3.X
   workflow_dispatch:
 
-# Allow one concurrent deployment
 concurrency:
-  group: "pages"
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   build-docs:
@@ -32,29 +31,3 @@ jobs:
 
       - name: Generate KDocs
         run: ./gradlew :dokkaGenerate
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with:
-          path: ./build/dokka/html
-
-  publish-docs:
-    name: Publish docs
-    runs-on: ubuntu-latest
-
-    needs: build-docs
-
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -11,6 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Checkout docs repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ github.repository }}-Docs
+          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          path: repo-docs
+
       - name: Set up JDK 25
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
@@ -28,6 +35,39 @@ jobs:
       - name: Compile and test
         run: ./gradlew build --no-configuration-cache
 
+      # Generate all docs and the root aggregate before publishing
+      # This way we can catch errors and be sure all docs will be available
+      # for both maven central and online
+      - name: Generate KDocs
+        run: ./gradlew :dokkaGenerate --no-configuration-cache
+
+      # Move the generated docs to the docs repository, in the correct version folder
+      # We do that before the release as, unlike releases, this step is repeateable
+      - name: Get project version
+        id: get-version
+        run: ./gradlew :getVersion --no-configuration-cache
+
+      - name: Move generated docs to docs repository
+        working-directory: repo-docs
+        env:
+          DOC_VERSION_NAME: ${{ steps.get-version.outputs.MAJOR_VERSION }}.X
+        run: |
+          rm -rf $DOC_VERSION_NAME
+          mkdir $DOC_VERSION_NAME
+          mv ../build/dokka/html/* $DOC_VERSION_NAME 
+
+      - name: Push docs
+        working-directory: repo-docs
+        env:
+          FULL_VERSION: ${{ steps.get-version.outputs.FULL_VERSION }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Deploy https://github.com/freya022/BotCommands/releases/tag/v$FULL_VERSION" --allow-empty
+          git push
+
+      # Do the release
       - name: Release
         run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import nl.littlerobots.vcu.plugin.resolver.VersionSelectors
+import kotlin.io.path.Path
+import kotlin.io.path.writeText
 
 plugins {
     id("repositories-conventions")
@@ -62,4 +64,20 @@ publishedProjectEnvironment {
         description = "JDA framework with everything you need for a modern bot!",
         url = "https://github.com/freya022/BotCommands",
     )
+}
+
+tasks.register<DefaultTask>("getVersion") {
+    group = "docs-publish"
+    description = "Helper for the publish workflow to get the project's version"
+
+    val version = publishedProjectEnvironment.version.get()
+    doLast {
+        val githubOutput = System.getenv("GITHUB_OUTPUT") ?: error("This task can only run in GitHub Actions")
+        Path(githubOutput).writeText(
+            """
+                MAJOR_VERSION=${version.major}
+                FULL_VERSION=$version
+            """.trimIndent()
+        )
+    }
 }


### PR DESCRIPTION
In preparation for the 4.X docs, I've adapted the CI to publish docs under major-versioned folders. They will now be published on each release.

The root page will redirect to the current stable version.

Existing links will redirect to the 3.X docs.