### PR TITLE
Reduce reliance on `KType.isMarkedNullable`

### DIFF
--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ComponentParameterResolver.kt
@@ -49,7 +49,7 @@ interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object from this component interaction.
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], the handler is ignored,
      * but the interaction **must** be acknowledged.
      *
@@ -63,7 +63,7 @@ interface ComponentParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object from this component interaction.
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], the handler is ignored,
      * but the interaction **must** be acknowledged.
      *

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/MessageContextParameterResolver.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/MessageContextParameterResolver.kt
@@ -25,7 +25,7 @@ interface MessageContextParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object from this message context interaction.
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
      * @param option The option currently being resolved
@@ -37,7 +37,7 @@ interface MessageContextParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object from this message context interaction.
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
      * @param option The option currently being resolved

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ModalParameterResolver.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/ModalParameterResolver.kt
@@ -64,7 +64,7 @@ interface ModalParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object for this [ModalMapping].
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
      * @param option       The option currently being resolved
@@ -77,7 +77,7 @@ interface ModalParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object for this [ModalMapping].
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
      * @param option       The option currently being resolved

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/SlashParameterResolver.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/SlashParameterResolver.kt
@@ -74,7 +74,7 @@ interface SlashParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object for this [OptionMapping].
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], then the interaction is ignored,
      * and you should reply if this is a [SlashCommandInteractionEvent].
      *
@@ -91,7 +91,7 @@ interface SlashParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object for this [OptionMapping].
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], then the interaction is ignored,
      * and you should reply if this is a [SlashCommandInteractionEvent].
      *

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TextParameterResolver.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TextParameterResolver.kt
@@ -46,7 +46,7 @@ interface TextParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object from this text command.
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], then the handler goes to the next command variation.
      *
      * See the [@JDATextCommandVariation][JDATextCommandVariation] documentation for more details about text command variations.
@@ -61,7 +61,7 @@ interface TextParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object from this text command.
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], then the handler goes to the next command variation.
      *
      * See the [@JDATextCommandVariation][JDATextCommandVariation] documentation for more details about text command variations.

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TimeoutParameterResolver.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/TimeoutParameterResolver.kt
@@ -38,7 +38,7 @@ interface TimeoutParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object for this argument.
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], the handler is ignored.
      *
      * @param option The option currently being resolved
@@ -50,7 +50,7 @@ interface TimeoutParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object for this argument.
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], the handler is ignored.
      *
      * @param option The option currently being resolved

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/UserContextParameterResolver.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/api/parameters/resolvers/UserContextParameterResolver.kt
@@ -31,7 +31,7 @@ interface UserContextParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object from this user context interaction.
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
      * @param option The option currently being resolved
@@ -43,7 +43,7 @@ interface UserContextParameterResolver<T, R : Any> : IParameterResolver<T>
     /**
      * Returns a resolved object from this user context interaction.
      *
-     * If this returns `null`, and the parameter is required, i.e., not [nullable][KType.isMarkedNullable]
+     * If this returns `null`, and the parameter is required, i.e., not nullable
      * or [optional][KParameter.isOptional], then the handler will throw.
      *
      * @param option The option currently being resolved

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ServiceProvider.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/core/service/provider/ServiceProvider.kt
@@ -14,6 +14,7 @@ import io.github.freya022.botcommands.internal.core.service.canCreateWrappedServ
 import io.github.freya022.botcommands.internal.core.service.tryGetWrappedService
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.nonInstanceParameters
 import io.github.freya022.botcommands.internal.utils.ReflectionUtils.resolveBestReference
+import io.github.freya022.botcommands.internal.utils.isNullable
 import io.github.freya022.botcommands.internal.utils.throwArgument
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
@@ -274,7 +275,7 @@ internal fun KFunction<*>.checkConstructingFunction(serviceContainer: BCServiceC
     this.nonInstanceParameters.forEach {
         serviceContainer.canCreateWrappedService(it)?.let { serviceError ->
             when {
-                it.type.isMarkedNullable -> return@forEach //Ignore
+                it.isNullable -> return@forEach //Ignore
                 it.isOptional -> return@forEach //Ignore
                 else -> return ErrorType.UNAVAILABLE_PARAMETER.toError(
                     errorMessage = "Cannot get service for parameter '${it.bestName}' (${it.type.jvmErasure.simpleNestedName})",
@@ -306,7 +307,7 @@ internal fun KFunction<*>.callConstructingFunction(serviceContainer: BCServiceCo
         //Try to get a dependency, if it doesn't work and parameter isn't nullable / cannot be omitted, then return the message
         val dependencyResult = serviceContainer.tryGetWrappedService(parameter)
         args[index] = dependencyResult.service ?: when {
-            parameter.type.isMarkedNullable -> null
+            parameter.isNullable -> null
             parameter.isOptional -> return@forEachIndexed
             else -> throw ServiceException(
                 ErrorType.UNAVAILABLE_PARAMETER.toError(

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ReflectionMetadata.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ReflectionMetadata.kt
@@ -344,10 +344,7 @@ internal val KClass<*>.sourceFileOrNull: String?
     get() = this.java.sourceFileOrNull
 
 val KParameter.isNullable: Boolean
-    get() {
-        val isNullableAnnotated = ReflectionMetadata.instance.getMethodMetadata(function).nullabilities[index]
-        return isNullableAnnotated || type.isMarkedNullable
-    }
+    get() = ReflectionMetadata.instance.getMethodMetadata(function).nullabilities[index]
 
 internal val KFunction<*>.lineNumber: Int
     get() = ReflectionMetadata.instance.getMethodMetadata(this).line

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ReflectionMetadata.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ReflectionMetadata.kt
@@ -343,7 +343,7 @@ internal val KClass<*>.sourceFile: String
 internal val KClass<*>.sourceFileOrNull: String?
     get() = this.java.sourceFileOrNull
 
-internal val KParameter.isNullable: Boolean
+val KParameter.isNullable: Boolean
     get() {
         val isNullableAnnotated = ReflectionMetadata.instance.getMethodMetadata(function).nullabilities[index]
         return isNullableAnnotated || type.isMarkedNullable

--- a/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ReflectionMetadata.kt
+++ b/BotCommands-core/src/main/kotlin/io/github/freya022/botcommands/internal/utils/ReflectionMetadata.kt
@@ -343,7 +343,7 @@ internal val KClass<*>.sourceFile: String
 internal val KClass<*>.sourceFileOrNull: String?
     get() = this.java.sourceFileOrNull
 
-val KParameter.isNullable: Boolean
+internal val KParameter.isNullable: Boolean
     get() = ReflectionMetadata.instance.getMethodMetadata(function).nullabilities[index]
 
 internal val KFunction<*>.lineNumber: Int

--- a/BotCommands-typesafe-messages/core/src/main/kotlin/dev/freya02/botcommands/typesafe/messages/internal/codegen/MessageSourceGenerator.kt
+++ b/BotCommands-typesafe-messages/core/src/main/kotlin/dev/freya02/botcommands/typesafe/messages/internal/codegen/MessageSourceGenerator.kt
@@ -15,6 +15,7 @@ import io.github.freya022.botcommands.api.core.utils.getSignature
 import io.github.freya022.botcommands.api.core.utils.joinAsList
 import io.github.freya022.botcommands.api.localization.arguments.FormattableArgument
 import io.github.freya022.botcommands.internal.core.restarter.RestartClassLoaderAdapter
+import io.github.freya022.botcommands.internal.utils.isNullable
 import net.dv8tion.jda.api.interactions.DiscordLocale
 import org.slf4j.LoggerFactory
 import java.lang.classfile.ClassBuilder
@@ -140,7 +141,7 @@ internal object LocalizedContentFunctionGenerator {
                 "Optional parameters are not supported! $parameter"
             }
 
-            require(!parameter.type.isMarkedNullable, ::UnsupportedParameterException) {
+            require(!parameter.isNullable, ::UnsupportedParameterException) {
                 "Nullable parameters are not allowed! $parameter"
             }
         }
@@ -153,7 +154,7 @@ internal object LocalizedContentFunctionGenerator {
         }
 
         val preferredLocale = function.findAnnotation<PreferLocale>()?.preference ?: declaringClass.findAnnotation<PreferLocale>()?.preference
-        if (preferredLocale != null && localeParameter?.type?.isMarkedNullable == false) {
+        if (preferredLocale != null && localeParameter?.isNullable == false) {
             // If there is a preferred locale annotation, it makes no sense to also have a mandatory locale parameter
             val logger = LoggerFactory.getLogger(declaringClass.java)
             logger.warn("@${PreferLocale::class.java.simpleName} is ignored on ${function.getSignature(source = false)} because it has a non-null ${localeParameter.type.jvmErasure.simpleName} parameter")

--- a/BotCommands-typesafe-messages/core/src/main/kotlin/dev/freya02/botcommands/typesafe/messages/internal/codegen/MessageSourceGenerator.kt
+++ b/BotCommands-typesafe-messages/core/src/main/kotlin/dev/freya02/botcommands/typesafe/messages/internal/codegen/MessageSourceGenerator.kt
@@ -15,7 +15,7 @@ import io.github.freya022.botcommands.api.core.utils.getSignature
 import io.github.freya022.botcommands.api.core.utils.joinAsList
 import io.github.freya022.botcommands.api.localization.arguments.FormattableArgument
 import io.github.freya022.botcommands.internal.core.restarter.RestartClassLoaderAdapter
-import io.github.freya022.botcommands.internal.utils.isNullable
+import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.interactions.DiscordLocale
 import org.slf4j.LoggerFactory
 import java.lang.classfile.ClassBuilder
@@ -125,6 +125,8 @@ internal object MessageSourceGenerator {
 
 internal object LocalizedContentFunctionGenerator {
 
+    private val logger = KotlinLogging.logger { }
+
     internal fun create(thisClass: ClassDesc, classBuilder: ClassBuilder, declaringClass: KClass<out IMessageSource>, function: KFunction<*>) {
         require(!function.isSuspend, ::UnsupportedFunctionException) {
             "Suspend functions are not supported! ${function.getSignature(qualifiedClass = true, source = false)}"
@@ -136,12 +138,17 @@ internal object LocalizedContentFunctionGenerator {
 
         val annotation = function.findAnnotation<LocalizedContent>()
             ?: error("Function was to be implemented but annotation is absent")
+
+        val nullableIndexes = NullabilityHelper.getNullableParameterIndexes(logger, declaringClass, function)
+        // -1 to account for the instance parameter (which is always present as all functions are interface methods)
+        fun isNullable(parameter: KParameter): Boolean = parameter.index - 1 in nullableIndexes
+
         val templateParameters = getTemplateArgumentParameters(function).onEach { parameter ->
             require(parameter.isRequired, ::UnsupportedParameterException) {
                 "Optional parameters are not supported! $parameter"
             }
 
-            require(!parameter.isNullable, ::UnsupportedParameterException) {
+            require(!isNullable(parameter), ::UnsupportedParameterException) {
                 "Nullable parameters are not allowed! $parameter"
             }
         }
@@ -154,7 +161,7 @@ internal object LocalizedContentFunctionGenerator {
         }
 
         val preferredLocale = function.findAnnotation<PreferLocale>()?.preference ?: declaringClass.findAnnotation<PreferLocale>()?.preference
-        if (preferredLocale != null && localeParameter?.isNullable == false) {
+        if (preferredLocale != null && localeParameter != null && !isNullable(localeParameter)) {
             // If there is a preferred locale annotation, it makes no sense to also have a mandatory locale parameter
             val logger = LoggerFactory.getLogger(declaringClass.java)
             logger.warn("@${PreferLocale::class.java.simpleName} is ignored on ${function.getSignature(source = false)} because it has a non-null ${localeParameter.type.jvmErasure.simpleName} parameter")

--- a/BotCommands-typesafe-messages/core/src/main/kotlin/dev/freya02/botcommands/typesafe/messages/internal/utils/NullabilityHelper.kt
+++ b/BotCommands-typesafe-messages/core/src/main/kotlin/dev/freya02/botcommands/typesafe/messages/internal/utils/NullabilityHelper.kt
@@ -1,0 +1,95 @@
+package dev.freya02.botcommands.typesafe.messages.internal.utils
+
+import dev.freya02.botcommands.typesafe.messages.internal.codegen.utils.toClassDesc
+import dev.freya02.botcommands.typesafe.messages.internal.exceptions.throwInternal
+import io.github.freya022.botcommands.api.core.utils.getSignature
+import io.github.oshai.kotlinlogging.KLogger
+import java.io.InputStream
+import java.lang.classfile.*
+import java.lang.classfile.Annotation
+import java.lang.constant.MethodTypeDesc
+import kotlin.jvm.optionals.getOrNull
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.valueParameters
+import kotlin.reflect.jvm.javaMethod
+import kotlin.reflect.jvm.jvmName
+
+internal object NullabilityHelper {
+    /** Index of Java parameters, 0 is first argument, not instance parameter */
+    private typealias FormalParamIndex = Int
+
+    internal fun loadNullableParameterIndexesFromKtReflect(function: KFunction<*>): Set<FormalParamIndex> = buildSet {
+        for ((index, parameter) in function.valueParameters.withIndex()) {
+            if (parameter.annotations.any { it.annotationClass.simpleName == "Nullable" })
+                add(index)
+            else if (parameter.type.isMarkedNullable)
+                add(index)
+            else if (parameter.type.annotations.any { it.annotationClass.simpleName == "Nullable" })
+                add(index)
+        }
+    }
+
+    internal fun getNullableParameterIndexes(logger: KLogger, declaringClass: KClass<*>, function: KFunction<*>): Set<FormalParamIndex> {
+        val classModel = try {
+            val bytes = declaringClass.java.classLoader
+                .getResourceAsStream(declaringClass.java.name.replace('.', '/') + ".class")
+                ?.use(InputStream::readAllBytes)
+            if (bytes == null) {
+                logger.warn { "Binary of '${declaringClass.jvmName}' was not found" }
+                return loadNullableParameterIndexesFromKtReflect(function)
+            }
+            ClassFile.of().parse(bytes)
+        } catch (e: Exception) {
+            logger.warn(e) { "Unable to load binary of '${declaringClass.jvmName}'" }
+            return loadNullableParameterIndexesFromKtReflect(function)
+        }
+
+        val methodModel = findMethodModel(classModel, function)
+        return buildSet {
+            // Check parameter annotations
+            fun List<List<Annotation>>.collectNullables() {
+                forEachIndexed { paramIndex, annotations ->
+                    if (annotations.any { it.className().endsWith("Nullable;") }) {
+                        add(paramIndex)
+                    }
+                }
+            }
+
+            methodModel.findAttribute(Attributes.runtimeInvisibleParameterAnnotations()).getOrNull()?.parameterAnnotations()?.collectNullables()
+            methodModel.findAttribute(Attributes.runtimeVisibleParameterAnnotations()).getOrNull()?.parameterAnnotations()?.collectNullables()
+
+            // Check annotations of type parameters present in parameters
+            fun List<TypeAnnotation>.collectNullables() {
+                for (typeAnnotation in this) {
+                    val targetInfo = typeAnnotation.targetInfo() as? TypeAnnotation.FormalParameterTarget
+                        ?: continue
+                    if (typeAnnotation.annotation().className().endsWith("Nullable;")) {
+                        add(targetInfo.formalParameterIndex())
+                    }
+                }
+            }
+
+            methodModel.findAttribute(Attributes.runtimeInvisibleTypeAnnotations()).getOrNull()?.annotations()?.collectNullables()
+            methodModel.findAttribute(Attributes.runtimeVisibleTypeAnnotations()).getOrNull()?.annotations()?.collectNullables()
+        }
+    }
+
+    private fun findMethodModel(classModel: ClassModel, function: KFunction<*>): MethodModel {
+        val javaMethod = function.javaMethod!!
+        val functionsWithSameName = classModel.methods().filter { it.methodName().equalsString(javaMethod.name) }
+        return if (functionsWithSameName.isEmpty()) {
+            throwInternal("Could not locate method ${function.getSignature(qualifiedClass = true, source = false)} ")
+        } else if (functionsWithSameName.size == 1) {
+            functionsWithSameName.first()
+        } else { // Overloads
+            val expectedMethodType = MethodTypeDesc.of(
+                javaMethod.returnType.toClassDesc(),
+                javaMethod.parameterTypes.map { it.toClassDesc() },
+            )
+
+            functionsWithSameName.singleOrNull { it.methodTypeSymbol() == expectedMethodType }
+                ?: throwInternal("Could not locate method ${function.getSignature(qualifiedClass = true, source = false)}")
+        }
+    }
+}

--- a/BotCommands-typesafe-messages/core/src/test/java/dev/freya02/botcommands/typesafe/messages/utils/NullabilityHelperTestsSamples.java
+++ b/BotCommands-typesafe-messages/core/src/test/java/dev/freya02/botcommands/typesafe/messages/utils/NullabilityHelperTestsSamples.java
@@ -1,0 +1,39 @@
+package dev.freya02.botcommands.typesafe.messages.utils;
+
+import org.jspecify.annotations.Nullable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+interface TypeUseRuntimeVisible {
+    @Target(ElementType.TYPE_USE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Nullable {}
+}
+
+interface TypeUseRuntimeInvisible {
+    @Target(ElementType.TYPE_USE)
+    @Retention(RetentionPolicy.CLASS)
+    @interface Nullable {}
+}
+
+interface ParameterRuntimeVisible {
+    @Target(ElementType.PARAMETER)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Nullable {}
+}
+
+interface ParameterRuntimeInvisible {
+    @Target(ElementType.PARAMETER)
+    @Retention(RetentionPolicy.CLASS)
+    @interface Nullable {}
+}
+
+interface NullabilityHelperTestsSamples {
+    void typeUseRuntimeVisible(@TypeUseRuntimeVisible.Nullable @Nullable String bar);
+    void typeUseRuntimeInvisible(int i, @TypeUseRuntimeInvisible.Nullable String bar);
+    void parameterRuntimeVisible(@ParameterRuntimeVisible.Nullable String bar, Integer i);
+    void parameterRuntimeInvisible(int i, Integer i2, @ParameterRuntimeInvisible.Nullable String bar);
+}

--- a/BotCommands-typesafe-messages/core/src/test/kotlin/dev/freya02/botcommands/typesafe/messages/utils/NullabilityHelperTests.kt
+++ b/BotCommands-typesafe-messages/core/src/test/kotlin/dev/freya02/botcommands/typesafe/messages/utils/NullabilityHelperTests.kt
@@ -1,0 +1,71 @@
+package dev.freya02.botcommands.typesafe.messages.utils
+
+import dev.freya02.botcommands.typesafe.messages.internal.utils.NullabilityHelper
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.mockk.every
+import io.mockk.mockkObject
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+object NullabilityHelperTests {
+
+    private val logger = KotlinLogging.logger { }
+
+    @MethodSource("getNullableParameterIndexesSamples")
+    @ParameterizedTest
+    fun getNullableParameterIndexes(klass: KClass<*>, function: KFunction<*>, expectedIndexes: Set<Int>) {
+        mockkObject(NullabilityHelper) {
+            every { NullabilityHelper.loadNullableParameterIndexesFromKtReflect(any()) } answers { fail("Fallback should not be reached") }
+
+            assertEquals(expectedIndexes, NullabilityHelper.getNullableParameterIndexes(logger, klass, function))
+        }
+    }
+
+    @Test
+    fun `Finds nested classes`() {
+        mockkObject(NullabilityHelper) {
+            every { NullabilityHelper.loadNullableParameterIndexesFromKtReflect(any()) } answers { fail("Fallback should not be reached") }
+
+            NullabilityHelper.getNullableParameterIndexes(logger, Nested::class, Nested::foo)
+        }
+    }
+
+    @JvmStatic
+    fun getNullableParameterIndexesSamples(): List<Arguments> {
+        return listOf(
+            Arguments.argumentSet("Kotlin type marked nullable", NullabilityHelperTests::class, NullabilityHelperTests::typeMarkedNullable, setOf(0)),
+            Arguments.argumentSet("Type-use runtime visible", NullabilityHelperTestsSamples::class, NullabilityHelperTestsSamples::typeUseRuntimeVisible, setOf(0)),
+            Arguments.argumentSet("Type-use runtime invisible", NullabilityHelperTestsSamples::class, NullabilityHelperTestsSamples::typeUseRuntimeInvisible, setOf(1)),
+            Arguments.argumentSet("Parameter runtime invisible", NullabilityHelperTestsSamples::class, NullabilityHelperTestsSamples::parameterRuntimeInvisible, setOf(2)),
+            Arguments.argumentSet("Parameter runtime visible", NullabilityHelperTestsSamples::class, NullabilityHelperTestsSamples::parameterRuntimeVisible, setOf(0)),
+        )
+    }
+
+    @MethodSource("loadNullableParameterIndexesFromKtReflectSamples")
+    @ParameterizedTest
+    fun loadNullableParameterIndexesFromKtReflect(function: KFunction<*>, expectedIndexes: Set<Int>) {
+        assertEquals(expectedIndexes, NullabilityHelper.loadNullableParameterIndexesFromKtReflect(function))
+    }
+
+    @JvmStatic
+    fun loadNullableParameterIndexesFromKtReflectSamples(): List<Arguments> {
+        return listOf(
+            Arguments.argumentSet("Kotlin type marked nullable", NullabilityHelperTests::typeMarkedNullable, setOf(0)),
+            // TODO kotlin-reflect doesn't support reading type annotations from Java sources, revisit when the K2 impl is done
+//            Arguments.argumentSet("Type-use runtime visible", NullabilityHelperTestsSamples::typeUseRuntimeVisible, setOf(0)),
+            Arguments.argumentSet("Parameter runtime visible", NullabilityHelperTestsSamples::parameterRuntimeVisible, setOf(0)),
+        )
+    }
+
+    internal fun typeMarkedNullable(@Suppress("unused") bar: String?) {}
+
+    private interface Nested {
+        fun foo()
+    }
+}


### PR DESCRIPTION
This PR refactors most places to avoid using `KType.isMarkedNullable`, starting Kotlin 2.4, some types could return an incorrect value as the new K2 implementation doesn't try to find nullable runtime annotations. (see [KT-88503](https://youtrack.jetbrains.com/issue/KT-88503))

We now almost exclusively fetch nullabilities from the reflection metadata, meaning type-use and parameter annotations, runtime or class-retained, are taken into account.

In places where the metadata is not yet available, the class's binary is read on-demand to provide the same functionality, falling back to `kotlin-reflect` on failures. This is the case for the `BotCommands-typesafe-messages` module.